### PR TITLE
Rename to formulae.brew.sh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2017, Sebastian Staudt
+Copyright (c) formula.brew.sh contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-braumeister.org
+formulae.brew.sh
 ===============
 
-[![Build Status](https://secure.travis-ci.org/koraktor/braumeister.org.svg)](http://travis-ci.org/koraktor/braumeister.org)
-[![Dependency Status](https://gemnasium.com/koraktor/braumeister.org.svg)](https://gemnasium.com/koraktor/braumeister.org)
-[![Code Climate](https://codeclimate.com/github/koraktor/braumeister.org/badges/gpa.svg)](https://codeclimate.com/github/koraktor/braumeister.org)
-[![Test Coverage](https://codeclimate.com/github/koraktor/braumeister.org/badges/coverage.svg)](https://codeclimate.com/github/koraktor/braumeister.org/coverage)
+[![Build Status](https://secure.travis-ci.org/Homebrew/formulae.brew.sh.svg)](http://travis-ci.org/Homebrew/formulae.brew.sh)
+[![Dependency Status](https://gemnasium.com/Homebrew/formulae.brew.sh.svg)](https://gemnasium.com/Homebrew/formulae.brew.sh)
+[![Code Climate](https://codeclimate.com/github/Homebrew/formulae.brew.sh/badges/gpa.svg)](https://codeclimate.com/github/Homebrew/formulae.brew.sh)
+[![Test Coverage](https://codeclimate.com/github/Homebrew/formulae.brew.sh/badges/coverage.svg)](https://codeclimate.com/github/Homebrew/formulae.brew.sh/coverage)
 
 [![Gratipay](https://img.shields.io/gratipay/team/Braumeister.svg)](https://gratipay.org/Braumeister)
-[![Beerpay](https://img.shields.io/beerpay/koraktor/braumeister.org.svg)](https://beerpay.io/koraktor/braumeister.org)
+[![Beerpay](https://img.shields.io/beerpay/Homebrew/formulae.brew.sh.svg)](https://beerpay.io/Homebrew/formulae.brew.sh)
 
-braumeister.org is a Rails application that gathers package information from
+formulae.brew.sh is a Rails application that gathers package information from
 Homebrew, the macOS package manager.
 
 ## Internals
@@ -43,8 +43,8 @@ $ foreman start
 
 ## Contribute
 
-braumeister.org is an open-source project. Therefore you are free to help
-improving it. There are several ways of contributing to braumeister.org’s
+formulae.brew.sh is an open-source project. Therefore you are free to help
+improving it. There are several ways of contributing to formulae.brew.sh’s
 development:
 
  * Use it and spread the word to existing and new Homebrew users
@@ -53,7 +53,7 @@ development:
  * Create a fork on [GitHub][1] and start hacking. Extra points for using
    feature branches and GitHub’s pull requests.
 
-## About the name
+## About the internal naming
 
 “Braumeister” – [ˈbʁaʊmʌɪstəʀ] – is the German word for “master brewer” or
 “brewmaster”, the person in charge of beer production.
@@ -79,11 +79,11 @@ LICENSE file.
  * [Continuous Integration at Travis CI][5]
  * [Dependency status at Gemnasium][4]
 
-Follow braumeister.org on Twitter
+Follow formulae.brew.sh on Twitter
 [@braumeister_org](http://twitter.com/braumeister_org).
 
- [1]: https://github.com/koraktor/braumeister.org
- [2]: https://github.com/koraktor/braumeister.org/issues
+ [1]: https://github.com/Homebrew/formulae.brew.sh
+ [2]: https://github.com/Homebrew/formulae.brew.sh/issues
  [3]: https://brew.sh
- [4]: https://gemnasium.com/koraktor/braumeister.org
- [5]: https://travis-ci.org/koraktor/braumeister.org
+ [4]: https://gemnasium.com/Homebrew/formulae.brew.sh
+ [5]: https://travis-ci.org/Homebrew/formulae.brew.sh

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
   end
 
   def title
-    title = 'braumeister.org'
+    title = 'Homebrew Formulae'
     title = "#@title – #{title}" unless @title.nil?
     title
   end

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -1,7 +1,7 @@
 <div id="home" class="border-bottom">
-  <strong>braumeister.org</strong> is an online package browser for
+  <strong>formulae.brew.sh</strong> is an online package browser for
   <%= link_to 'Homebrew', 'https://brew.sh' %> – the macOS package manager.<br>
-  For more information on how to install and use Homebrew see its homepage.
+  For more information on how to install and use Homebrew see <%= link_to 'our homepage', 'https://brew.sh' %>.
 
   <%= link_to 'Browse all formulae', letter_formulae_path('a'), class: 'center' %>
 

--- a/app/views/application/status.html.erb
+++ b/app/views/application/status.html.erb
@@ -1,7 +1,7 @@
 <div id="status" class="border-bottom">
-  <strong>braumeister.org</strong> is an online package browser for
+  <strong>formulae.brew.sh</strong> is an online package browser for
   <%= link_to 'Homebrew', 'https://brew.sh' %> – the macOS package manager.<br>
-  For more information on how to install and use Homebrew see its homepage.
+  For more information on how to install and use Homebrew see <%= link_to 'our homepage', 'https://brew.sh' %>.
 
   <%= link_to 'Browse all formulae', letter_formulae_path('a'), class: 'center' %>
 

--- a/app/views/formulae/feed.atom.builder
+++ b/app/views/formulae/feed.atom.builder
@@ -3,22 +3,22 @@
 #
 # Copyright (c) 2012-2017, Sebastian Staudt
 
-atom_feed :id => "tag:braumeister.org,2012:#{all? ? 'all' : @repository.name}",
+atom_feed :id => "tag:formulae.brew.sh,2012:#{all? ? 'all' : @repository.name}",
           :schema_data => 2012,
           'xmlns:opensearch' => 'http://a9.com/-/spec/opensearch/1.1/' do |feed|
   title = 'Formula updates'
   title += " in #{@repository.name}" unless all?
 
-  feed.title title + '– braumeister.org'
+  feed.title title + '– formulae.brew.sh'
 
-  feed.link rel: 'search', href: '/opensearch.xml', title: 'braumeister.org – Search',
+  feed.link rel: 'search', href: '/opensearch.xml', title: 'formulae.brew.sh – Search',
             type: 'application/opensearchdescription+xml'
   feed.link rel: 'shortcut icon', href: 'data:image/x-icon;,',
             type: 'image/x-icon'
 
   add_entry = ->(status, formula, revision) do
     entry_options = {
-      id: "tag:braumeister.org,2012:#{formula.repository.name}/#{formula.name}-#{revision.sha}",
+      id: "tag:formulae.brew.sh,2012:#{formula.repository.name}/#{formula.name}-#{revision.sha}",
       updated:   revision.date,
       url: formula.dupe? ? polymorphic_path([formula.repository, formula]) : polymorphic_path(formula)
     }

--- a/app/views/layouts/_structured_data.html.erb
+++ b/app/views/layouts/_structured_data.html.erb
@@ -7,7 +7,7 @@
     "datePublished": "2012-01-07T01:42:05+0100",
     "image": "<%= url_to_image 'favicon.png' %>",
     "license": "https://opensource.org/licenses/BSD-3-Clause",
-    "name": "braumeister.org",
+    "name": "formulae.brew.sh",
     "operatingSystem": "any",
     "sameAs": "https://twitter.com/braumeister_org",
     "potentialAction": {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,12 @@
   <%= auto_discovery_link_tag :atom, feed_path(format: :atom) %>
   <%= csrf_meta_tag %>
 
-  <link rel="search" type="application/opensearchdescription+xml" title="braumeister.org" href="/opensearch.xml">
+  <link rel="search" type="application/opensearchdescription+xml" title="formulae.brew.sh" href="/opensearch.xml">
   <%= favicon_link_tag 'data:image/x-icon;,', type: 'image/x-icon' %>
   <%= yield :kaminari %>
 
   <meta http-equiv="content-type" content="text/html;charset=UTF-8">
-  <meta itemprop="name" content="braumeister.org">
+  <meta itemprop="name" content="formulae.brew.sh">
   <meta itemprop="description" content="An online package browser for Homebrew, the MacOS package manager.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -26,7 +26,7 @@
 </head>
 <body<% unless @repository.nil? || @repository.core? %> data-repository="<%= @repository.name %>"<% end %>>
     <div id="header">
-        <%= link_to 'Braumeister', root_path %>
+        <%= link_to 'Formulae', root_path %>
     </div>
     <div id="content" class="border-bottom">
         <% if flash[:error] %>
@@ -39,9 +39,9 @@
     </div>
     <div id="footer" class="border-top">
       <p>
-        Braumeister was created by <a href="https://plus.google.com/109586181974940228820?rel=author">
+        formulae.brew.sh was created by <a href="https://plus.google.com/109586181974940228820?rel=author">
         Sebastian Staudt</a>.
-        View source code on <a href="https://github.com/koraktor/braumeister.org"><i class="fa fa-github"></i> GitHub</a>.
+        View source code on <a href="https://github.com/Homebrew/formulae.brew.sh"><i class="fa fa-github"></i> GitHub</a>.
         Follow <a href="https://twitter.com/braumeister_org">@braumeister_org</a>
         on Twitter.
       </p>

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,6 +1,6 @@
 ---
 common: &default_settings
-  app_name: <%= ENV["NEW_RELIC_APPNAME"] || 'braumeister.org' %>
+  app_name: <%= ENV["NEW_RELIC_APPNAME"] || 'formulae.brew.sh' %>
   license_key: <%= ENV["NEW_RELIC_LICENSE_KEY"] %>
   monitor_mode: false
   ssl: true

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
   <AdultContent>false</AdultContent>
-  <Description>Search Homebrew formulae on braumeister.org</Description>
+  <Description>Search Homebrew formulae</Description>
   <InputEncoding>UTF-8</InputEncoding>
   <OutputEncoding>UTF-8</OutputEncoding>
-  <ShortName>braumeister.org</ShortName>
-  <Url type="text/html" rel="results" method="GET" template="http://braumeister.org/search/{searchTerms}" />
-  <Url type="application/opensearchdescription+xml" rel="self" method="GET" template="http://braumeister.org/opensearch.xml" />
+  <ShortName>formulae.brew.sh</ShortName>
+  <Url type="text/html" rel="results" method="GET" template="http://formulae.brew.sh/search/{searchTerms}" />
+  <Url type="application/opensearchdescription+xml" rel="self" method="GET" template="http://formulae.brew.sh/opensearch.xml" />
 </OpenSearchDescription>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow:
-Sitemap: http://braumeister.org/sitemap.xml
+Sitemap: http://formulae.brew.sh/sitemap.xml

--- a/spec/controllers/formulae_controller_spec.rb
+++ b/spec/controllers/formulae_controller_spec.rb
@@ -29,7 +29,7 @@ describe FormulaeController do
 
     it 'redirects to the correct repository if capitalization is incorrect' do
       request = mock
-      request.expects(:url).returns 'http://braumeister.org/repos/Homebrew/Homebrew-versions/browse'
+      request.expects(:url).returns 'http://formulae.brew.sh/repos/Homebrew/Homebrew-versions/browse'
       controller.expects(:request).returns request
 
       repo = mock
@@ -38,7 +38,7 @@ describe FormulaeController do
       Repository.expects(:where).with(_id: /^Homebrew\/Homebrew-versions$/i).returns criteria
       criteria.expects(:only).with(:_id, :letters, :name, :sha, :updated_at).returns [ repo ]
       controller.expects(:params).returns({ repository_id: 'Homebrew/Homebrew-versions' })
-      controller.expects(:redirect_to).with 'http://braumeister.org/repos/Homebrew/homebrew-versions/browse'
+      controller.expects(:redirect_to).with 'http://formulae.brew.sh/repos/Homebrew/homebrew-versions/browse'
 
       controller.send :select_repository
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,12 +35,12 @@ describe ApplicationHelper do
 
   describe '#title' do
     it 'provides a default title' do
-      expect(helper.title).to eq('braumeister.org')
+      expect(helper.title).to eq('Homebrew Formulae')
     end
 
     it 'provides customized titles' do
       assign :title, 'Custom Title'
-      expect(helper.title).to eq('Custom Title – braumeister.org')
+      expect(helper.title).to eq('Custom Title – Homebrew Formulae')
     end
   end
 


### PR DESCRIPTION
Rename this project to make it an official part of Homebrew itself.

As part of this we will:

- [x] Invite @koraktor to the Homebrew organisation
- [x] Move this repository to the Homebrew organisation (and preserve @koraktor's admin rights)
- [x] Rename this repository to `Homebrew/formulae.brew.sh`
- [x] Setup DNS for formulae.brew.sh to point to this Heroku application
- [ ] Merge this PR
- [x] Rename Heroku pipeline to `formulae-brew-sh`
- [x] Add collaborators to Heroku apps
- [x] <del>Create a Heroku team for Homebrew and transfer / rename the applications</del>
- [x] Create a Rollbar team for Homebrew and transfer / rename the project