### PR TITLE
Automatically hide deprecated taps

### DIFF
--- a/lib/main_import.rb
+++ b/lib/main_import.rb
@@ -25,14 +25,33 @@ module MainImport
     end
   end
 
-  def official_taps
+  def brew_taps
     official_taps_path = "#{path}/Library/Homebrew/official_taps.rb"
     official_taps_rb = File.read official_taps_path
 
-    homebrew = Module.new
-    homebrew.module_eval official_taps_rb, official_taps_path
+    brew = Module.new
+    brew.module_eval official_taps_rb, official_taps_path
+    brew
+  end
 
-    homebrew.const_get :OFFICIAL_TAPS
+  def deprecated_official_taps
+    brew_taps.const_get :DEPRECATED_OFFICIAL_TAPS
+  end
+
+  def official_taps
+    brew_taps.const_get :OFFICIAL_TAPS
+  end
+
+  def update_deprecated_taps
+    deprecated_official_taps.each do |tap|
+      tap_name = "Homebrew/homebrew-#{tap}"
+
+      repo = Repository.find tap_name
+      unless repo.nil? || repo.outdated?
+        repo.outdated = true
+        repo.save
+      end
+    end
   end
 
   def update_status

--- a/lib/tasks/braumeister.rake
+++ b/lib/tasks/braumeister.rake
@@ -78,6 +78,7 @@ namespace :braumeister do
     rollbar_rescued do
       repo = Repository.main.extend MainImport
       repo.update_status
+      repo.update_deprecated_taps
       repo.create_missing_taps
     end
   end

--- a/spec/lib/main_import_spec.rb
+++ b/spec/lib/main_import_spec.rb
@@ -40,6 +40,19 @@ describe MainImport do
 
   end
 
+  describe '#deprecated_official_taps' do
+
+    it 'should return DEPRECATED_OFFICIAL_TAPS from brew' do
+      repo.expects(:path).returns '/repo'
+      file_contents = 'DEPRECATED_OFFICIAL_TAPS = %w{apache php}'
+      File.expects(:read).with('/repo/Library/Homebrew/official_taps.rb').
+              returns file_contents
+
+      expect(repo.deprecated_official_taps).to eq(%w{apache php})
+    end
+
+  end
+
   describe '#official_taps' do
 
     it 'should return OFFICIAL_TAPS from brew' do
@@ -49,6 +62,24 @@ describe MainImport do
               returns file_contents
 
       expect(repo.official_taps).to eq(%w{apache php})
+    end
+
+  end
+
+  describe '#update_deprecated_taps' do
+
+    it 'should mark deprecated taps' do
+      apache = Repository.new
+      php = Repository.new
+
+      repo.expects(:deprecated_official_taps).returns %w{apache php}
+      Repository.expects(:find).with('Homebrew/homebrew-apache').returns apache
+      Repository.expects(:find).with('Homebrew/homebrew-php').returns php
+
+      repo.update_deprecated_taps
+
+      expect(apache).to be_outdated
+      expect(php).to be_outdated
     end
 
   end
@@ -64,7 +95,7 @@ describe MainImport do
       end
     end
 
-    it 'should saving if the commit ID did change' do
+    it 'should save if the commit ID did change' do
       repo.sha = '01234567'
       repo.expects(:save!)
 


### PR DESCRIPTION
This would simply set the `outdated` flag for any tap repository that is found in brew’s `DEPRECATED_OFFICIAL_TAPS`.

Any suggestions, @MikeMcQuaid @colindean?

See #58 and #60.