### PR TITLE
load skylight before newrelic_rpm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,10 @@ group :development, :test do
 end
 
 group :production do
+  gem 'skylight', '~> 1.5'
   gem 'newrelic_rpm', '~> 4.8'
   gem 'rails_12factor', '~> 0.0.2'
   gem 'rollbar', '~> 2.15'
-  gem 'skylight', '~> 1.5'
 end
 
 group :test do


### PR DESCRIPTION
Due to differences in how NewRelic and Skylight instrument middleware traces, loading Skylight _after_ NewRelic means that it will report all middleware names as `NewRelic::Agent::Instrumentation::MiddlewareProxy`:

![image](https://user-images.githubusercontent.com/2286046/37110739-945297e2-21f2-11e8-886b-96687ead682c.png)

Load Skylight first to ensure the instrumentation is applied to the actual middleware instead of the proxy:

![image](https://user-images.githubusercontent.com/2286046/37110725-858f71da-21f2-11e8-9c69-4f1df824176c.png)