### PR TITLE
Fix configure script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,7 +5,7 @@ cd "$(dirname "$0")/.."
 
 if [ "$(uname -s)" = "Darwin" ]; then
   brew bundle check &>/dev/null || brew bundle
-  /usr/local/opt/mongodb@3.2/bin/mongo braumeister db/mongodb_setup.js --quiet
+  /usr/local/opt/mongodb@3.4/bin/mongo braumeister db/mongodb_setup.js --quiet
 fi
 
 rbenv version-name &>/dev/null || {


### PR DESCRIPTION
[This commit](https://github.com/Homebrew/formulae.brew.sh/commit/6cde3a1a4e249fca09dac5a334532d450e316445) changes the version from 3.2 to 3.4.

This change causes the following error on a fresh(ish) machine:

```
➜ ./script/bootstrap
./script/bootstrap: line 8: /usr/local/opt/mongodb@3.2/bin/mongo: No such file or directory
```

The [line in question is here](https://github.com/Homebrew/formulae.brew.sh/blob/cd6152a55a0462057d14a572bb3ad115e6205c2d/script/bootstrap#L8) (snippet below):

```
  /usr/local/opt/mongodb@3.2/bin/mongo braumeister db/mongodb_setup.js --quiet
```
