### PR TITLE
Improve styling for search error message

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -127,6 +127,7 @@ div#content {
   }
 
   div.error {
+    padding-top: 2em;
     font-weight: bold;
     text-align:  center;
   }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/923242/37551968-1e187af2-29a3-11e8-8451-85419d102e81.png)

After:

![image](https://user-images.githubusercontent.com/923242/37551969-24865d5a-29a3-11e8-9c1e-024491049800.png)
