### PR TITLE
main_import: handle missing OFFICIAL_TAPS.

### DIFF
--- a/lib/main_import.rb
+++ b/lib/main_import.rb
@@ -40,6 +40,8 @@ module MainImport
 
   def official_taps
     brew_taps.const_get :OFFICIAL_TAPS
+  rescue NameError
+    [].freeze
   end
 
   def update_deprecated_taps


### PR DESCRIPTION
This variable will be removed shortly: https://github.com/Homebrew/brew/pull/4007