### PR TITLE
Add Jekyll plugins to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
+gem "jekyll-feed", group: :jekyll_plugins
+gem "jekyll-remote-theme", group: :jekyll_plugins
+gem "jekyll-seo-tag", group: :jekyll_plugins
+gem "jekyll-sitemap", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,10 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-feed
+  jekyll-remote-theme
+  jekyll-seo-tag
+  jekyll-sitemap
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Makes it easier to get started with development.

I thought this should be handled by `github-pages`, but I had a few problems including a wrong version of `eventmachine`.