### PR TITLE
Add more CI checks for HTML/JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   # trigger vendored ruby installation
   - brew help
   - bundle install
+  - export HOMEBREW_NO_ANALYTICS=1
 
 script:
-  - export HOMEBREW_NO_ANALYTICS=1
-  - rake jekyll
+  - bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "github-pages", group: :jekyll_plugins
+
+group :test do
+  gem "jsonlint"
+  gem "html-proofer"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
+    colorize (0.8.1)
     commonmarker (0.17.9)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
@@ -83,6 +84,15 @@ GEM
     html-pipeline (2.8.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.9.1)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.8.1)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -192,6 +202,9 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
+    jsonlint (0.2.0)
+      oj (~> 2)
+      trollop (~> 2)
     kramdown (1.16.2)
     liquid (4.0.0)
     listen (3.1.5)
@@ -210,6 +223,8 @@ GEM
       mini_portile2 (~> 2.3.0)
     octokit (4.9.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    oj (2.18.5)
+    parallel (1.12.1)
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -234,17 +249,21 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
+    trollop (2.1.2)
     typhoeus (1.3.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.3)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  html-proofer
+  jsonlint
   rake
 
 BUNDLED WITH

--- a/_includes/formula.html
+++ b/_includes/formula.html
@@ -1,4 +1,4 @@
 <td><a href="{{ site.baseurl }}/formula/{{ include.formula.name }}">{{ include.formula.name }}</a></td>
 <td>✅</td>
 <td>{{ include.formula.versions.stable }}</td>
-<td>{{ include.formula.desc }}</td>
+<td>{{ include.formula.desc | xml_escape }}</td>

--- a/_includes/formulae.html
+++ b/_includes/formulae.html
@@ -2,7 +2,7 @@
 <p>{{ include.description }}:</p>
 <table>
     {%- for f in include.formulae -%}
-    {%- assign formula_name = f | remove: "@" | remove: "." -%}
+    {%- assign formula_name = f | remove: "@" | remove: "." | remove: '+' -%}
     <tr>
         {%- assign formula = site.data.formula[formula_name] -%}
         {%- include formula.html formula=formula -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -3,7 +3,7 @@ layout: default
 permalink: :title
 ---
 {%- assign full_name = page.name | remove: ".html" -%}
-{%- assign name = full_name | remove: "@" | remove: "." -%}
+{%- assign name = full_name | remove: "@" | remove: "." | remove: '+' -%}
 {%- assign f = site.data.formula[name] -%}
 <h2>{{ f.name }}</h2>
 {%- if f.aliases.size > 0 -%}
@@ -15,7 +15,7 @@ permalink: :title
 {%- if f.oldname -%}
 <p>Formerly known as: <strong>{{ f.oldname }}</strong></p>
 {%- endif -%}
-<p>{{ f.desc }}</p>
+<p>{{ f.desc | xml_escape }}</p>
 <p>
     <a href="{{ f.homepage }}">{{ f.homepage }}</a>
 </p>

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -1,5 +1,6 @@
 ---
 ---
-{%- assign name = page.name | remove: ".json" | remove: "@" | remove: "." -%}
+{%- assign name = page.name | remove: ".json" | remove: "@" |
+                              remove: "." | remove: '+' -%}
 {%- assign formula = site.data.formula[name] -%}
 {{ formula | jsonify }}


### PR DESCRIPTION
Run `html-proofer` and `jsonlint` on CI runs and fix the errors that cropped up from `html-proofer` locally.