### PR TITLE
formula_index: restore from formula/index.html.

### DIFF
--- a/formula_index.html
+++ b/formula_index.html
@@ -1,0 +1,18 @@
+---
+layout: default
+permalink: /formula/
+---
+<p>This is a listing of all packages available via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
+
+<h2><a href="{{ site.baseurl }}/api/formula.json"><code>/api/formula.json</code> (JSON API)</a></h2>
+
+<table>
+    {%- assign sorted_formulae = site.data.formula | sort -%}
+    {%- for formula in sorted_formulae %}
+
+    <tr>
+        {%- assign f = formula[1] -%}
+        {%- include formula.html formula=f -%}
+    </tr>
+    {%- endfor -%}
+</table>


### PR DESCRIPTION
It's easier to put this in the root both to find it and to mean that `formula` can be deleted and recreated by `script/generate`.

Fixes #72.