### PR TITLE
Improve Formula/Cask analytics differentiation

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -19,6 +19,8 @@ layout: base
     <td>
     {%- if page.category == "os-version" -%}
       <code>{{ item.os_version }}</code>
+    {%- elsif page.category == "cask-install" -%}
+      <code>{{ item.formula }}</code>
     {%- else -%}
       {%- assign name = item.formula | split: " " | first -%}
       {%- assign data_name = name | remove: "@" | remove: "." | remove: '+' -%}

--- a/analytics/build-error/30d/index.html
+++ b/analytics/build-error/30d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Build Error Events
+title: Homebrew Analytics Formula Build Error Events
 layout: analytics
 days: 30d
 category: build-error
-category_pretty: Build Error
+category_pretty: Formula Build Error
 ---

--- a/analytics/build-error/365d/index.html
+++ b/analytics/build-error/365d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Build Error Events
+title: Homebrew Analytics Formula Build Error Events
 layout: analytics
 days: 365d
 category: build-error
-category_pretty: Build Error
+category_pretty: Formula Build Error
 ---

--- a/analytics/build-error/90d/index.html
+++ b/analytics/build-error/90d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Build Error Events
+title: Homebrew Analytics Formula Build Error Events
 layout: analytics
 days: 90d
 category: build-error
-category_pretty: Build Error
+category_pretty: Formula Build Error
 ---

--- a/analytics/cask-install/30d/index.html
+++ b/analytics/cask-install/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Install Events
+title: Homebrew Analytics Cask Install Events
 layout: analytics
 days: 30d
 category: cask-install

--- a/analytics/cask-install/365d/index.html
+++ b/analytics/cask-install/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Install Events
+title: Homebrew Analytics Cask Install Events
 layout: analytics
 days: 365d
 category: cask-install

--- a/analytics/cask-install/90d/index.html
+++ b/analytics/cask-install/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Install Events
+title: Homebrew Analytics Cask Install Events
 layout: analytics
 days: 90d
 category: cask-install

--- a/analytics/index.html
+++ b/analytics/index.html
@@ -4,10 +4,16 @@ layout: page
 ---
 <table>
     <tr>
-        <td>Install Events</td>
+        <td>Formula Install Events</td>
         <td><a href="{{ site.baseurl }}/analytics/install/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install/365d/">365 days</a></td>
+    </tr>
+    <tr>
+        <td>Formula Install On Request Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/install-on-request/30d/">30 days</a></td>
+        <td><a href="{{ site.baseurl }}/analytics/install-on-request/90d/">90 days</a></td>
+        <td><a href="{{ site.baseurl }}/analytics/install-on-request/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Cask Install Events</td>
@@ -16,13 +22,7 @@ layout: page
         <td><a href="{{ site.baseurl }}/analytics/cask-install/365d/">365 days</a></td>
     </tr>
     <tr>
-        <td>Install On Request Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/install-on-request/30d/">30 days</a></td>
-        <td><a href="{{ site.baseurl }}/analytics/install-on-request/90d/">90 days</a></td>
-        <td><a href="{{ site.baseurl }}/analytics/install-on-request/365d/">365 days</a></td>
-    </tr>
-    <tr>
-        <td>Build Error Events</td>
+        <td>Formula Build Error Events</td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/365d/">365 days</a></td>

--- a/analytics/install-on-request/30d/index.html
+++ b/analytics/install-on-request/30d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events
 layout: analytics
 days: 30d
 category: install-on-request
-category_pretty: Install On Request
+category_pretty: Formula Install On Request
 ---

--- a/analytics/install-on-request/365d/index.html
+++ b/analytics/install-on-request/365d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events
 layout: analytics
 days: 365d
 category: install-on-request
-category_pretty: Install On Request
+category_pretty: Formula Install On Request
 ---

--- a/analytics/install-on-request/90d/index.html
+++ b/analytics/install-on-request/90d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events
 layout: analytics
 days: 90d
 category: install-on-request
-category_pretty: Install On Request
+category_pretty: Formula Install On Request
 ---

--- a/analytics/install/30d/index.html
+++ b/analytics/install/30d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Install Events
+title: Homebrew Analytics Formula Install Events
 layout: analytics
 days: 30d
 category: install
-category_pretty: Install
+category_pretty: Formula Install
 ---

--- a/analytics/install/365d/index.html
+++ b/analytics/install/365d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Install Events
+title: Homebrew Analytics Formula Install Events
 layout: analytics
 days: 365d
 category: install
-category_pretty: Install
+category_pretty: Formula Install
 ---

--- a/analytics/install/90d/index.html
+++ b/analytics/install/90d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics Install Events
+title: Homebrew Analytics Formula Install Events
 layout: analytics
 days: 90d
 category: install
-category_pretty: Install
+category_pretty: Formula Install
 ---


### PR DESCRIPTION
Make clearer which are casks and which are formulae.

Additionally, don’t link to formulae on casks page.

CC @brianmorton