### PR TITLE
Update headline to "the missing online..."

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<p><a href="{{ site.baseurl }}/">Homebrew Formulae</a> is an online package browser for <a href="https://brew.sh">Homebrew</a> – the macOS package manager. For more information on how to install
+<p><a href="{{ site.baseurl }}/">Homebrew Formulae</a> is the missing online package browser for <a href="https://brew.sh">Homebrew</a> – the macOS package manager. For more information on how to install
 and use Homebrew see <a href="https://brew.sh">our homepage</a>.</p>
 
 <h2><a href="{{ site.baseurl }}/formula/">Browse all formulae</a></h2>


### PR DESCRIPTION
This PR changes the headline from "Homebrew Formulae is an online package browser for Homebrew" to "Homebrew Formulae is the missing online package browser for Homebrew", to match Homebrew's famous headline (https://brew.sh).