### PR TITLE
add support for Casks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .bundle/
 _site/
 bin/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Homebrew Formulae](https://formulae.brew.sh) is an online package browser for [Homebrew](https://brew.sh).
 
-It displays all packages in [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core). It is deployed to GitHub Pages after every [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) commit by [Travis CI](https://travis-ci.org).
+It displays all packages in [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) and [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask). A GitHub Action in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/.github/main.workflow) or [homebrew-cask](https://github.com/Homebrew/homebrew-cask/blob/master/.github/main.workflow) is run on each commit, which deploys the site to GitHub Pages.
 
 ## JSON API
 
@@ -19,7 +19,7 @@ Read more in the [JSON API documentation](https://formulae.brew.sh/docs/api/).
 ## Usage
 Open https://formulae.brew.sh/ in your web browser.
 
-Instead, to run Homebrew Formulae locally run:
+To instead run Homebrew Formulae locally, run:
 ```bash
 git clone https://github.com/Homebrew/formulae.brew.sh
 cd formulae.brew.sh

--- a/_cask.html.in
+++ b/_cask.html.in
@@ -1,0 +1,5 @@
+---
+title: $TITLE
+layout: cask
+---
+{{ content }}

--- a/_data/cask/ballast.json
+++ b/_data/cask/ballast.json
@@ -1,0 +1,46 @@
+{
+  "name": [
+    "ballast"
+  ],
+  "homepage": "https://jamsinclair.nz/ballast",
+  "url": "https://github.com/jamsinclair/ballast/releases/download/v1.2.0/ballast-v1.2.0.zip",
+  "appcast": "https://github.com/jamsinclair/ballast/releases.atom",
+  "version": "1.2.0",
+  "sha256": "6976fb45da9648d4571e2cfefa6991acf53b85c4b3767887208130226c38d82c",
+  "artifacts": [
+    {
+      "quit": "nz.jamsinclair.ballast",
+      "launchctl": "nz.jamsinclair.ballast-LaunchAtLoginHelper",
+      "signal": [
+
+      ]
+    },
+    [
+      "ballast.app"
+    ],
+    {
+      "trash": [
+        "~/Library/Preferences/nz.jamsinclair.ballast.plist",
+        "~/Library/Application Scripts/nz.jamsinclair.ballast",
+        "~/Library/Application Scripts/nz.jamsinclair.ballast-LaunchAtLoginHelper",
+        "~/Library/Containers/nz.jamsinclair.ballast",
+        "~/Library/Containers/nz.jamsinclair.ballast-LaunchAtLoginHelper"
+      ],
+      "signal": [
+
+      ]
+    }
+  ],
+  "caveats": "",
+  "depends_on": {
+    "macos": [
+      [
+        ">=",
+        "10.12"
+      ]
+    ]
+  },
+  "conflicts_with": null,
+  "container": null,
+  "auto_updates": null
+}

--- a/_data/cask/ckan.json
+++ b/_data/cask/ckan.json
@@ -1,0 +1,24 @@
+{
+  "name": [
+    "Comprehensive Kerbal Archive Network client"
+  ],
+  "homepage": "https://github.com/KSP-CKAN/CKAN",
+  "url": "https://github.com/KSP-CKAN/CKAN/releases/download/v1.25.4/CKAN.dmg",
+  "appcast": "https://github.com/KSP-CKAN/CKAN/releases.atom",
+  "version": "1.25.4",
+  "sha256": "df0972cd6a9a324dffb1d4aa183b57d36547c24370df9d59b98abeadb6c68476",
+  "artifacts": [
+    [
+      "CKAN.app"
+    ]
+  ],
+  "caveats": "",
+  "depends_on": {
+    "cask": [
+      "mono-mdk"
+    ]
+  },
+  "conflicts_with": null,
+  "container": null,
+  "auto_updates": null
+}

--- a/_data/cask/firefox.json
+++ b/_data/cask/firefox.json
@@ -1,0 +1,45 @@
+{
+  "name": [
+    "Mozilla Firefox"
+  ],
+  "homepage": "https://www.mozilla.org/firefox/",
+  "url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/66.0/mac/en-US/Firefox%2066.0.dmg",
+  "appcast": "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.mozilla.org/%3Fproduct=firefox-latest-ssl%26os=osx",
+  "version": "66.0",
+  "sha256": "64e15f0e2a977ea9e1d3a14c674ebf84ee6234f896e719d6c57aeecd8785fa78",
+  "artifacts": [
+    [
+      "Firefox.app"
+    ],
+    {
+      "trash": [
+        "/Library/Logs/DiagnosticReports/firefox_*",
+        "~/Library/Application Support/Firefox",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.firefox.sfl*",
+        "~/Library/Caches/Firefox",
+        "~/Library/Caches/Mozilla/updates/Applications/Firefox",
+        "~/Library/Preferences/org.mozilla.firefox.plist"
+      ],
+      "rmdir": [
+        "~/Library/Application Support/Mozilla",
+        "~/Library/Caches/Mozilla/updates/Applications",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla"
+      ],
+      "signal": [
+
+      ]
+    }
+  ],
+  "caveats": "",
+  "depends_on": {
+  },
+  "conflicts_with": {
+    "cask": [
+      "firefox-beta",
+      "firefox-esr"
+    ]
+  },
+  "container": null,
+  "auto_updates": true
+}

--- a/_data/cask/libreoffice-language-pack.json
+++ b/_data/cask/libreoffice-language-pack.json
@@ -1,0 +1,30 @@
+{
+  "name": [
+    "LibreOffice Language Pack"
+  ],
+  "homepage": "https://www.libreoffice.org/",
+  "url": "https://download.documentfoundation.org/libreoffice/stable/6.2.1/mac/x86_64/LibreOffice_6.2.1_MacOS_x86-64_langpack_en-GB.dmg",
+  "appcast": "https://download.documentfoundation.org/libreoffice/stable/",
+  "version": "6.2.1",
+  "sha256": "47d472a983818744facfac43f72afd8d8ea9be6256e8ae8659cdcfe080ed5e09",
+  "artifacts": [
+    {
+      "delete": "/usr/local/Caskroom/libreoffice-language-pack/6.2.1/libreoffice-language-pack",
+      "signal": [
+
+      ]
+    },
+    {
+      "path": "LibreOffice Language Pack.app"
+    }
+  ],
+  "caveats": "You need to run LibreOffice at least once before installing\nlanguage pack to avoid app verification error.\n",
+  "depends_on": {
+    "cask": [
+      "libreoffice"
+    ]
+  },
+  "conflicts_with": null,
+  "container": null,
+  "auto_updates": null
+}

--- a/_data/cask/megacmd.json
+++ b/_data/cask/megacmd.json
@@ -1,0 +1,33 @@
+{
+  "name": [
+    "MEGAcmd"
+  ],
+  "homepage": "https://mega.nz/cmd",
+  "url": "https://mega.nz/MEGAcmdSetup.dmg",
+  "appcast": null,
+  "version": "latest",
+  "sha256": "no_check",
+  "artifacts": [
+    [
+      "MEGAcmd.app"
+    ],
+    [
+      "/Applications/MEGAcmd.app/Contents/MacOS/MEGAcmdLoader",
+      {
+        "target": "megacmd"
+      }
+    ],
+    {
+      "trash": "~/.megaCmd",
+      "signal": [
+
+      ]
+    }
+  ],
+  "caveats": "megacmd only works if called from /Applications, so you may need to install it with\n  brew cask install --appdir=/Applications megacmd\n",
+  "depends_on": {
+  },
+  "conflicts_with": null,
+  "container": null,
+  "auto_updates": null
+}

--- a/_data/cask/mkvtoolnix.json
+++ b/_data/cask/mkvtoolnix.json
@@ -1,0 +1,37 @@
+{
+  "name": [
+    "MKVToolNix"
+  ],
+  "homepage": "https://mkvtoolnix.download/",
+  "url": "https://mkvtoolnix.download/macos/MKVToolNix-32.0.0.dmg",
+  "appcast": "https://www.bunkus.org/blog/feed/",
+  "version": "32.0.0",
+  "sha256": "ce3c93b62df2b2b5c1f08008abeb3d739ece8314cb2b53f7fbf65f1bd55fd268",
+  "artifacts": [
+    [
+      "MKVToolNix-32.0.0.app"
+    ],
+    [
+      "/Applications/MKVToolNix-32.0.0.app/Contents/MacOS/mkvextract"
+    ],
+    [
+      "/Applications/MKVToolNix-32.0.0.app/Contents/MacOS/mkvinfo"
+    ],
+    [
+      "/Applications/MKVToolNix-32.0.0.app/Contents/MacOS/mkvmerge"
+    ],
+    [
+      "/Applications/MKVToolNix-32.0.0.app/Contents/MacOS/mkvpropedit"
+    ]
+  ],
+  "caveats": "",
+  "depends_on": {
+  },
+  "conflicts_with": {
+    "formula": [
+      "mkvtoolnix"
+    ]
+  },
+  "container": null,
+  "auto_updates": null
+}

--- a/_data/cask/wine-stable.json
+++ b/_data/cask/wine-stable.json
@@ -26,9 +26,6 @@
       "/Applications/Wine Stable.app/Contents/Resources/start/bin/appdb"
     ],
     [
-      "/Applications/Wine Stable.app/Contents/Resources/start/bin/winehelp"
-    ],
-    [
       "/Applications/Wine Stable.app/Contents/Resources/wine/bin/msiexec"
     ],
     [
@@ -69,6 +66,9 @@
     ],
     [
       "/Applications/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
+    ],
+    [
+      "/Applications/Wine Stable.app/Contents/Resources/start/bin/winehelp"
     ]
   ],
   "caveats": "wine-stable installs support for running 64 bit applications in Wine, which is considered experimental.\nIf you do not want 64 bit support, you should download and install the wine-stable package manually.\n",

--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -1,0 +1,3 @@
+<td><a href="{{ site.baseurl }}/cask/{{ include.token }}">{{ include.token }}</a></td>
+<td>{{ include.cask.name.first }}</td>
+<td>{{ include.cask.version | truncate: 25 }}</td>

--- a/_includes/casks.html
+++ b/_includes/casks.html
@@ -1,0 +1,11 @@
+{%- if include.casks.size > 0 -%}
+<p>{{ include.description }}:</p>
+<table>
+    {%- for token in include.casks -%}
+    <tr>
+        {%- assign cask = site.data.cask[token] -%}
+        {%- include cask.html token=token cask=cask -%}
+    </tr>
+    {%- endfor -%}
+</table>
+{%- endif -%}

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -20,7 +20,9 @@ layout: base
     {%- if page.category == "os-version" -%}
       <code>{{ item.os_version }}</code>
     {%- elsif page.category == "cask-install" -%}
-      <code>{{ item.cask }}</code>
+      <a href="{{ site.baseurl }}/cask/{{ item.cask }}">
+        <code>{{ item.cask }}</code>
+      </a>
     {%- else -%}
       {%- assign name = item.formula | split: " " | first -%}
       {%- assign data_name = name | remove: "@" | remove: "." | remove: '+' -%}

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -1,7 +1,7 @@
 ---
 layout: base
 ---
-{% assign json = site.data.analytics[page.category][page.days] %}
+{%- assign json = site.data.analytics[page.category][page.days] -%}
 <h2>{{ page.category_pretty }} Events</h2>
 
 <h3><a href="{{ site.baseurl }}/api/analytics/{{ page.category }}/{{ page.days}}.json"><code>/api/analytics/{{ page.category }}/{{ page.days}}.json</code> (JSON API)</a></h3>

--- a/_layouts/analytics_json.json
+++ b/_layouts/analytics_json.json
@@ -4,7 +4,7 @@
 {%- if page.homebrew-core -%}
     {%- assign json =
         site.data.analytics[page.category].homebrew-core[days] -%}
-{%- else - %}
+{%- else -%}
     {%- assign json = site.data.analytics[page.category][days] -%}
 {%- endif -%}
 {{ json | jsonify }}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -1,0 +1,53 @@
+---
+layout: default
+permalink: :title
+---
+{%- assign token = page.title -%}
+{%- assign c = site.data.cask[token] -%}
+<h2>{{ token }}</h2>
+<p>
+    Name{%- if c.name.size > 1 -%}s{%- endif -%}:
+    {% for name in c.name %}
+        <strong>{{ name }}</strong>
+        {%- unless forloop.last -%}, {% endunless %}
+    {%- endfor -%}
+</p>
+<p>
+    <a href="{{ c.homepage }}">{{ c.homepage }}</a>
+</p>
+
+<p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
+<p><a target="_blank" href="https://github.com/Homebrew/homebrew-cask/blob/master/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+
+<p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
+
+{%- include casks.html casks=c.depends_on.cask description="Depends on Casks" -%}
+{%- assign depends_on_formula = c.depends_on.formula | where_exp: "f", "site.data.formula[f]" -%}
+{%- include formulae.html formulae=depends_on_formula description="Depends on" -%}
+
+{%- if c.depends_on.size > 0 -%}
+    {%- assign requirements = "" -%}
+    {%- if c.depends_on.macos -%}
+        {%- capture requirements -%}macOS <strong>{{ c.depends_on.macos.first | join: " " }}</strong>{%- endcapture -%}
+        {%- if c.depends_on.macos.size > 1 -%}
+            {%- capture requirements -%}{{ requirements }} and <strong>{{ c.depends_on.macos[1] | join: " " }}</strong>{%- endcapture -%}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if c.depends_on.x11 -%}
+        {%- if requirements.size > 0 -%}
+            {%- assign requirements = requirements | append: ", " -%}
+        {%- endif -%}
+        {%- capture requirements -%}{{ requirements }}<strong>X11</strong>{%- endcapture -%}
+    {%- endif -%}
+    {%- if requirements.size > 0 -%}
+<p>Requires: {{ requirements }}</p>
+    {%- endif -%}
+{%- endif -%}
+
+{%- include casks.html casks=c.conflicts_with.cask description="Conflicts with Casks" -%}
+{%- assign conflicts_with_formula = c.conflicts_with.formula | where_exp: "f", "site.data.formula[f]" -%}
+{%- include formulae.html formulae=conflicts_with_formula description="Conflicts with" -%}
+
+{%- if c.caveats -%}
+<p>{{ c.caveats | xml_escape }}</p>
+{%- endif -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -2,7 +2,7 @@
 layout: default
 permalink: :title
 ---
-{%- assign full_name = page.name | remove: ".html" -%}
+{%- assign full_name = page.title -%}
 {%- assign name = full_name | remove: "@" | remove: "." | remove: '+' -%}
 {%- assign f = site.data.formula[name] -%}
 <h2>{{ f.name }}</h2>
@@ -51,7 +51,7 @@ permalink: :title
         <td>
             {%- for b in f.bottle.stable.files -%}
             {{ b[0] }}
-            {%- unless forloop.last -%}, {% endunless -%}
+            {%- unless forloop.last -%}, {% endunless %}
             {%- endfor -%}
         </td>
     </tr>
@@ -88,9 +88,9 @@ permalink: :title
 {%- if f.requirements.size > 0 -%}
 <p>
     Requires:
-    {% for r in f.requirements -%}
+    {% for r in f.requirements %}
         <strong>:{{ r.name }}</strong>
-        {%- unless forloop.last -%}, {% endunless -%}
+        {%- unless forloop.last -%}, {% endunless %}
     {%- endfor -%}
 </p>
 {%- endif -%}

--- a/api/cask.json
+++ b/api/cask.json
@@ -1,0 +1,11 @@
+---
+---
+[
+{%- assign sorted_casks = site.data.cask | sort -%}
+{% for cask in sorted_casks %}
+  {{ cask[1] | jsonify }}
+  {%- unless forloop.last -%}
+  ,
+  {%- endunless -%}
+  {% endfor %}
+]

--- a/api/cask/ballast.json
+++ b/api/cask/ballast.json
@@ -1,0 +1,4 @@
+---
+layout: cask_json
+---
+{{ content }}

--- a/api/cask/ckan.json
+++ b/api/cask/ckan.json
@@ -1,0 +1,4 @@
+---
+layout: cask_json
+---
+{{ content }}

--- a/api/cask/firefox.json
+++ b/api/cask/firefox.json
@@ -1,0 +1,4 @@
+---
+layout: cask_json
+---
+{{ content }}

--- a/api/cask/libreoffice-language-pack.json
+++ b/api/cask/libreoffice-language-pack.json
@@ -1,0 +1,4 @@
+---
+layout: cask_json
+---
+{{ content }}

--- a/api/cask/megacmd.json
+++ b/api/cask/megacmd.json
@@ -1,0 +1,4 @@
+---
+layout: cask_json
+---
+{{ content }}

--- a/api/cask/mkvtoolnix.json
+++ b/api/cask/mkvtoolnix.json
@@ -1,0 +1,4 @@
+---
+layout: cask_json
+---
+{{ content }}

--- a/api/formula.json
+++ b/api/formula.json
@@ -2,10 +2,10 @@
 ---
 [
 {%- assign sorted_formulae = site.data.formula | sort -%}
-{%- for formula in sorted_formulae %}
+{% for formula in sorted_formulae %}
   {{ formula[1] | jsonify }}
   {%- unless forloop.last -%}
   ,
   {%- endunless -%}
-  {%- endfor %}
+  {% endfor %}
 ]

--- a/cask/0xed.html
+++ b/cask/0xed.html
@@ -1,0 +1,5 @@
+---
+title: "0xed"
+layout: cask
+---
+{{ content }}

--- a/cask/ballast.html
+++ b/cask/ballast.html
@@ -1,0 +1,5 @@
+---
+title: "ballast"
+layout: cask
+---
+{{ content }}

--- a/cask/basictex.html
+++ b/cask/basictex.html
@@ -1,0 +1,5 @@
+---
+title: "basictex"
+layout: cask
+---
+{{ content }}

--- a/cask/ckan.html
+++ b/cask/ckan.html
@@ -1,0 +1,5 @@
+---
+title: "ckan"
+layout: cask
+---
+{{ content }}

--- a/cask/firefox.html
+++ b/cask/firefox.html
@@ -1,0 +1,5 @@
+---
+title: "firefox"
+layout: cask
+---
+{{ content }}

--- a/cask/fontforge.html
+++ b/cask/fontforge.html
@@ -1,0 +1,5 @@
+---
+title: "fontforge"
+layout: cask
+---
+{{ content }}

--- a/cask/libreoffice-language-pack.html
+++ b/cask/libreoffice-language-pack.html
@@ -1,0 +1,5 @@
+---
+title: "libreoffice-language-pack"
+layout: cask
+---
+{{ content }}

--- a/cask/mactex.html
+++ b/cask/mactex.html
@@ -1,0 +1,5 @@
+---
+title: "mactex"
+layout: cask
+---
+{{ content }}

--- a/cask/megacmd.html
+++ b/cask/megacmd.html
@@ -1,0 +1,5 @@
+---
+title: "megacmd"
+layout: cask
+---
+{{ content }}

--- a/cask/mkvtoolnix.html
+++ b/cask/mkvtoolnix.html
@@ -1,0 +1,5 @@
+---
+title: "mkvtoolnix"
+layout: cask
+---
+{{ content }}

--- a/cask/wine-stable.html
+++ b/cask/wine-stable.html
@@ -1,0 +1,5 @@
+---
+title: "wine-stable"
+layout: cask
+---
+{{ content }}

--- a/cask_index.html
+++ b/cask_index.html
@@ -1,0 +1,19 @@
+---
+layout: default
+permalink: /cask/
+---
+<p>This is a listing of all Casks available via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
+
+<h2><a href="{{ site.baseurl }}/api/cask.json"><code>/api/cask.json</code> (JSON API)</a></h2>
+
+<table>
+    {%- assign sorted_casks = site.data.cask | sort -%}
+    {%- for cask in sorted_casks -%}
+
+    <tr>
+        {%- assign t = cask[0] -%}
+        {%- assign c = cask[1] -%}
+        {%- include cask.html token=t cask=c -%}
+    </tr>
+    {%- endfor -%}
+</table>

--- a/docs/api.md
+++ b/docs/api.md
@@ -309,13 +309,13 @@ GET https://formulae.brew.sh/api/analytics/${CATEGORY}/${DAYS}.json
 ```
 
 #### Variables
-- `${CATEGORY}`: the category of the analytics events i.e.
+- `${CATEGORY}`: the category of the analytics events, i.e.
   - `install`: the installation of all formulae
   - `install-on-request`: the requested installation of all formulae (i.e. not as a dependency of other formulae)
   - `cask-install`: the installation of all casks
   - `build-error`: the installation failure of all formulae
-  - `os-version`: the macOS version of the machine that submitted an event
-- `${DAYS}`: the number of days of analytics events i.e.
+  - `os-version`: the macOS version of all machines that have submitted an event
+- `${DAYS}`: the number of days of analytics events, i.e.
   - `30d`: 30 days
   - `90d`: 90 days
   - `365d`: 365 days
@@ -356,11 +356,11 @@ GET https://formulae.brew.sh/api/analytics/${CATEGORY}/homebrew-core/${DAYS}.jso
 ```
 
 #### Variables
-- `${CATEGORY}`: the category of the analytics events i.e.
+- `${CATEGORY}`: the category of the analytics events, i.e.
   - `install`: the installation of all homebrew-core formulae
   - `install-on-request`: the requested installation of all homebrew-core formulae (i.e. not as a dependency of other formulae)
-  - `build-error`: the installation failure of all homebrew-core formulae. Only `${DAYS}: 30d` (30 days) is available)
-- `${DAYS}`: the number of days of analytics events i.e.
+  - `build-error`: the installation failure of all homebrew-core formulae. Only `${DAYS}: 30d` (30 days) is available.
+- `${DAYS}`: the number of days of analytics events, i.e.
   - `30d`: 30 days
   - `90d`: 90 days
   - `365d`: 365 days

--- a/formula_index.html
+++ b/formula_index.html
@@ -8,7 +8,7 @@ permalink: /formula/
 
 <table>
     {%- assign sorted_formulae = site.data.formula | sort -%}
-    {%- for formula in sorted_formulae %}
+    {%- for formula in sorted_formulae -%}
 
     <tr>
         {%- assign f = formula[1] -%}

--- a/index.html
+++ b/index.html
@@ -5,5 +5,6 @@ layout: default
 and use Homebrew see <a href="https://brew.sh">our homepage</a>.</p>
 
 <h2><a href="{{ site.baseurl }}/formula/">Browse all formulae</a></h2>
+<h2><a href="{{ site.baseurl }}/cask/">Browse all Casks</a></h2>
 <h2><a href="{{ site.baseurl }}/analytics/">Analytics data</a></h2>
 <h2><a href="{{ site.baseurl }}/docs/api/">JSON API documentation</a></h2>

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -4,7 +4,8 @@ directories = ["_data/cask", "api/cask", "cask"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
 
-Cask::Cask.each do |c|
+Tap.default_cask_tap.cask_files.each do |p|
+  c = Cask::CaskLoader::FromPathLoader.new(p).load
   json_filename = "#{c.token}.json"
   IO.write("_data/cask/#{json_filename}", "#{JSON.pretty_generate(c.to_h)}\n")
   FileUtils.cp "_api_cask.json.in", "api/cask/#{json_filename}"

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -8,4 +8,8 @@ Cask::Cask.each do |c|
   json_filename = "#{c.token}.json"
   IO.write("_data/cask/#{json_filename}", "#{JSON.pretty_generate(c.to_h)}\n")
   FileUtils.cp "_api_cask.json.in", "api/cask/#{json_filename}"
+
+  html = IO.read "_cask.html.in"
+  html.gsub!("title: $TITLE", "title: \"#{c.token}\"")
+  IO.write("cask/#{c.token}.html", html)
 end

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -9,6 +9,6 @@ Formula.each do |f|
   FileUtils.cp "_api_formula.json.in", "api/formula/#{json_filename}"
 
   html = IO.read "_formula.html.in"
-  html.gsub!("title: $TITLE", "title: #{f.name}")
+  html.gsub!("title: $TITLE", "title: \"#{f.name}\"")
   IO.write("formula/#{f.name}.html", html)
 end

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -3,7 +3,8 @@ directories = ["_data/formula", "api/formula", "formula"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
 
-Formula.each do |f|
+CoreTap.instance.formula_names.each do |n|
+  f = Formulary.factory(n)
   json_filename = "#{f.name}.json"
   IO.write("_data/formula/#{json_filename}", JSON.pretty_generate(f.to_hash))
   FileUtils.cp "_api_formula.json.in", "api/formula/#{json_filename}"


### PR DESCRIPTION
This adds the files necessary to add a listing of all Casks at `/cask/` and `/api/cask.json`, individual Cask pages at `/cask/{token}`, and the contents of `/cask/` via `generate-cask.rb`. (Another PR is still needed to add the files generated with `rake`.) Also fixes a few small issues with the text and template markup.