### PR TITLE
optimize file generation scripts

### DIFF
--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -1,16 +1,15 @@
 #!/usr/bin/env brew ruby
-require 'cask/cask'
+require "cask/cask"
 directories = ["_data/cask", "api/cask", "cask"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
 
+json_template = IO.read "_api_cask.json.in"
+html_template = IO.read "_cask.html.in"
+
 Tap.default_cask_tap.cask_files.each do |p|
   c = Cask::CaskLoader::FromPathLoader.new(p).load
-  json_filename = "#{c.token}.json"
-  IO.write("_data/cask/#{json_filename}", "#{JSON.pretty_generate(c.to_h)}\n")
-  FileUtils.cp "_api_cask.json.in", "api/cask/#{json_filename}"
-
-  html = IO.read "_cask.html.in"
-  html.gsub!("title: $TITLE", "title: \"#{c.token}\"")
-  IO.write("cask/#{c.token}.html", html)
+  IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
+  IO.write("api/cask/#{c.token}.json", json_template)
+  IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))
 end

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -3,13 +3,12 @@ directories = ["_data/formula", "api/formula", "formula"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
 
+json_template = IO.read "_api_formula.json.in"
+html_template = IO.read "_formula.html.in"
+
 CoreTap.instance.formula_names.each do |n|
   f = Formulary.factory(n)
-  json_filename = "#{f.name}.json"
-  IO.write("_data/formula/#{json_filename.gsub('+', '_')}", JSON.pretty_generate(f.to_hash))
-  FileUtils.cp "_api_formula.json.in", "api/formula/#{json_filename}"
-
-  html = IO.read "_formula.html.in"
-  html.gsub!("title: $TITLE", "title: \"#{f.name}\"")
-  IO.write("formula/#{f.name}.html", html)
+  IO.write("_data/formula/#{f.name.tr("+", "_")}.json", JSON.pretty_generate(f.to_hash))
+  IO.write("api/formula/#{f.name}.json", json_template)
+  IO.write("formula/#{f.name}.html", html_template.gsub("title: $TITLE", "title: \"#{f.name}\""))
 end

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -8,7 +8,7 @@ html_template = IO.read "_formula.html.in"
 
 CoreTap.instance.formula_names.each do |n|
   f = Formulary.factory(n)
-  IO.write("_data/formula/#{f.name.tr("+", "_")}.json", JSON.pretty_generate(f.to_hash))
+  IO.write("_data/formula/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_hash)}\n")
   IO.write("api/formula/#{f.name}.json", json_template)
   IO.write("formula/#{f.name}.html", html_template.gsub("title: $TITLE", "title: \"#{f.name}\""))
 end


### PR DESCRIPTION
Refactored both to increase readability and reduce disk access by reading each template only once. Also appends a line break to the formula data files, as is done for casks.

Runtime for `generate.rb` before & after: 
```
$ time rake formulae
brew ruby script/generate.rb

real	0m57.903s
user	0m25.730s
sys	0m30.266s
```
```
$ time rake formulae
brew ruby script/generate.rb

real	0m51.447s
user	0m23.568s
sys	0m26.660s
```

And for `generate-cask.rb`:
```
$ time rake cask
brew ruby script/generate-cask.rb

real	0m7.693s
user	0m3.500s
sys	0m3.226s
```
```
$ time rake cask
brew ruby script/generate-cask.rb

real	0m5.923s
user	0m3.172s
sys	0m2.655s
```