### PR TITLE
Update TomEE Webprofile version to latest (7.1.1)

### DIFF
--- a/_data/formula/tomee-webprofile.json
+++ b/_data/formula/tomee-webprofile.json
@@ -8,10 +8,10 @@
   "versioned_formulae": [
 
   ],
-  "desc": "All-Apache Java EE 6 Web Profile stack",
+  "desc": "All-Apache Java EE 7 Web Profile stack",
   "homepage": "https://tomee.apache.org/",
   "versions": {
-    "stable": "7.1.0",
+    "stable": "7.1.1",
     "devel": null,
     "head": null,
     "bottle": false


### PR DESCRIPTION
This PR updates the version of the TomEE Webprofile to the latest. The version currently referenced is not available anymore.