### PR TITLE
GitHub Actions: don't build master.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,5 @@
 name: GitHub Actions CI
-on:
-  push:
-    branches: master
-  pull_request: []
+on: pull_request
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
These seem to be mainly failing and we're pushing almost entirely automatically so don't need to run CI.