### PR TITLE
Reformat and display caveats within table

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -49,5 +49,13 @@ permalink: :title
 {%- include formulae.html formulae=conflicts_with_formula description="Conflicts with" -%}
 
 {%- if c.caveats -%}
-<p>{{ c.caveats | xml_escape }}</p>
+{%- capture soft_indent %}
+  {% endcapture -%}
+{%- capture hard_indent %}
+&nbsp;&nbsp;&nbsp;&nbsp;{% endcapture -%}
+<table class="full-width">
+    <tr>
+        <td>{{ c.caveats | xml_escape | replace: soft_indent, hard_indent | newline_to_br }}</td>
+    </tr>
+</table>
 {%- endif -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -102,6 +102,18 @@ permalink: :title
 </p>
 {%- endif -%}
 
+{%- if f.caveats -%}
+{%- capture soft_indent %}
+  {% endcapture -%}
+{%- capture hard_indent %}
+&nbsp;&nbsp;&nbsp;&nbsp;{% endcapture -%}
+<table class="full-width">
+    <tr>
+        <td>{{ f.caveats | xml_escape | replace: soft_indent, hard_indent | newline_to_br }}</td>
+    </tr>
+</table>
+{%- endif -%}
+
 {%- if site.data.analytics.install.homebrew-core["30d"].formulae[full_name].size > 0 -%}
 <p>Analytics:</p>
 <table>


### PR DESCRIPTION
This places caveats for both formulae and casks within a table, giving it them slightly more distinctive background. It also attempts to more closely replicate how they appear on the command line. (The `capture` trick works around Liquid's inability to match newlines against `\n` in strings.)
