### PR TITLE
CI: Switch Actions 'version' parameter for 'ruby-version'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        version: '>=2.3'
+        ruby-version: '>=2.3'
 
     - name: Install RubyGems
       run: |


### PR DESCRIPTION
- The Actions UI showed a deprecation warning for `version`:
  Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use ruby-version instead