### PR TITLE
Use double quotes

### DIFF
--- a/_data/formula/zsh-completions.json
+++ b/_data/formula/zsh-completions.json
@@ -46,7 +46,7 @@
   "conflicts_with": [
 
   ],
-  "caveats": "To activate these completions, add the following to your .zshrc:\n\n  fpath=($(brew --prefix)/share/zsh-completions $fpath)\n\nYou may also need to force rebuild `zcompdump`:\n\n  rm -f ~/.zcompdump; compinit\n\nAdditionally, if you receive \"zsh compinit: insecure directories\" warnings when attempting\nto load these completions, you may need to run this:\n\n  chmod go-w '$(brew --prefix)/share'\n",
+  "caveats": "To activate these completions, add the following to your .zshrc:\n\n  fpath=($(brew --prefix)/share/zsh-completions $fpath)\n\nYou may also need to force rebuild `zcompdump`:\n\n  rm -f ~/.zcompdump; compinit\n\nAdditionally, if you receive \"zsh compinit: insecure directories\" warnings when attempting\nto load these completions, you may need to run this:\n\n  chmod go-w "$(brew --prefix)/share"\n",
   "installed": [
 
   ],


### PR DESCRIPTION
We cannot use command substitution in expressions wrapped into single quotes; expression will output as is;
So, we expect that execution of the following command:
`'$(brew --prefix)/share'`
should be:
 '/usr/local/share' (as example)
, but we get:
'$(brew --prefix)/share'