### PR TITLE
Use the formula_path variable to get the OS-scoped formula name

### DIFF
--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -5,7 +5,7 @@ permalink: :title
 {%- assign full_name = page.title -%}
 {%- assign formula_path = page.dir | remove: "/" -%}
 {%- assign name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-{%- assign f = site.data.formula[name] -%}
+{%- assign f = site.data[formula_path][name] -%}
 <h2>{{ f.name }}</h2>
 {%- if f.aliases.size > 0 -%}
 <p>


### PR DESCRIPTION
- This was hardcoded to the macOS formula data directory by mistake, causing everything to work fine _except_ Linux-only formulae which obviously aren't present in the macOS data files.
- The analytics part of this file was using the `formula_path` variable correctly, which meant that the data appeared fine, but the Linux-only formulae just didn't have names or anything that relied on a lookup based on name.

Before, `/formula-linux/adoptopenjdk`:

![image](https://user-images.githubusercontent.com/355033/67227141-834c4f00-f42e-11e9-9b2d-668da3fb90ca.png)

After:

![image](https://user-images.githubusercontent.com/355033/67227505-446ac900-f42f-11e9-98d2-44e0baa79bcc.png)

