### PR TITLE
Really fix dependency list path for Linux formulae

### DIFF
--- a/_includes/formulae.html
+++ b/_includes/formulae.html
@@ -1,11 +1,12 @@
 {%- if include.formulae.size > 0 -%}
 <p>{{ include.description }}:</p>
+{%- assign formula_path = include.formula_path %}
 <table>
     {%- for f in include.formulae -%}
     {%- assign formula_name = f | remove: "@" | remove: "." | replace: "+", "_" -%}
     <tr>
         {%- assign formula = site.data[formula_path][formula_name] -%}
-        {%- include formula.html formula=formula -%}
+        {%- include formula.html formula_path=formula_path formula=formula -%}
     </tr>
     {%- endfor -%}
 </table>


### PR DESCRIPTION
- #195 was almost there but not quite!
- We need to use `formula_path` in two places: once to get the correct formula data, and once to specify the path for the formula.html includes - otherwise, as was happening here, it defaults to `formula`.