### PR TITLE
Update nvm's github organization

### DIFF
--- a/_data/formula-linux/nvm.json
+++ b/_data/formula-linux/nvm.json
@@ -9,7 +9,7 @@
 
   ],
   "desc": "Manage multiple Node.js versions",
-  "homepage": "https://github.com/creationix/nvm",
+  "homepage": "https://github.com/nvm-sh/nvm",
   "versions": {
     "stable": "0.35.2",
     "devel": null,

--- a/_data/formula/nvm.json
+++ b/_data/formula/nvm.json
@@ -9,7 +9,7 @@
 
   ],
   "desc": "Manage multiple Node.js versions",
-  "homepage": "https://github.com/creationix/nvm",
+  "homepage": "https://github.com/nvm-sh/nvm",
   "versions": {
     "stable": "0.35.2",
     "devel": null,


### PR DESCRIPTION
The `nvm` repository on Github moved from `creationix` to `nvm-sh`.

## Verify

* Visit `https://github.com/creationix/nvm`
* Redirects to `https://github.com/nvm-sh/nvm `

As such, updating the formulas.