### PR TITLE
The `--json` and `--all-core-formulae-json` flags are exclusive

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,7 +88,7 @@ def generate_analytics_files(os)
       next if days != "30" && category_name == "build-error/#{core_tap_name}"
       next if os == "linux" && %w[cask-install os-version].include?(category_name)
 
-      sh "brew formula-analytics #{formula_analytics_os_arg} --days-ago=#{days} --json --#{category} " \
+      sh "brew formula-analytics #{formula_analytics_os_arg} --days-ago=#{days} --#{category} " \
         "> #{analytics_data_path}/#{category_name}/#{days}d.json"
     end
   end


### PR DESCRIPTION
- In https://github.com/Homebrew/homebrew-formula-analytics/pull/129, `brew formula-analytics` switched to use `CLI::Parser`. While doing so, `--json` and `--all-core-formulae-json` were set to be [conflicting](https://github.com/Homebrew/homebrew-formula-analytics/blob/master/cmd/formula-analytics.rb#L34).
- This caused an issue where the GitHub Action to generate the data for these formulae.brew.sh pages [couldn't run](https://github.com/Homebrew/homebrew-core/issues/49840) because it was using both of the arguments.
- Instead, make this only use `--all-core-formulae-json` as it's the more specific one.

Fixes https://github.com/Homebrew/homebrew-core/issues/49840.