### PR TITLE
Fix conflicting flags in formula-analytics calls for every combination

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,7 +88,13 @@ def generate_analytics_files(os)
       next if days != "30" && category_name == "build-error/#{core_tap_name}"
       next if os == "linux" && %w[cask-install os-version].include?(category_name)
 
-      sh "brew formula-analytics #{formula_analytics_os_arg} --days-ago=#{days} --#{category} " \
+      # The `--json` and `--all-core-formulae-json` flags are mutually
+      # exclusive, but we need to explicitly set `--json` sometimes,
+      # so only set it if we've not already set
+      # `--all-core-formulae-json`.
+      category_flags = category.include?("all-core-formulae-json") ? category : "json #{category}"
+
+      sh "brew formula-analytics #{formula_analytics_os_arg} --days-ago=#{days} --#{category_flags}" \
         "> #{analytics_data_path}/#{category_name}/#{days}d.json"
     end
   end


### PR DESCRIPTION
- This is a follow up to #244 as I missed some cases!
- We only use `--all-core-formulae-json` for `core-build-error` etc.
  categories. There are also normal `build-error` etc. categories that
  need the plain `--json` flags.
- This adds `--json` to the build-error flags if the existing category
  names don't have `--all-core-formulae-json` already specified. This
  seemed tidier than adding extra `when`s to the `case` statement for
  all the other categories.