### PR TITLE
CI cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: GitHub Actions CI
-on: pull_request
+on:
+  push:
+    branches: master
+  pull_request: []
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -24,11 +27,11 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: '>=2.3'
+        ruby-version: '2.6'
 
     - name: Install RubyGems
       run: |
-        gem install bundler
+        gem install bundler -v "~>1"
         bundle install --jobs 4 --retry 3
 
     - name: Generate site

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,4 +267,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.0.1
+   1.17.2

--- a/Rakefile
+++ b/Rakefile
@@ -132,7 +132,7 @@ task html_proofer: :build do
     "./_site",
     parallel: { in_threads: 4 },
     favicon: true,
-    http_status_ignore: [0],
+    http_status_ignore: [0, 302, 303, 429, 521],
     assume_extension: true,
     check_external_hash: true,
     check_favicon: true,


### PR DESCRIPTION
- Use Ruby 2.6
- Use Bundler 1.x (as comes with Ruby 2.6)
- Ignore more "not an error" HTTP status codes