### PR TITLE
Make tap configurable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,10 +15,12 @@ task :formulae, [:os,:tap] do |task, args|
 end
 
 desc "Dump cask data"
-task :cask do
+task :cask, [:tap] do |task, args|
+  args.with_defaults(:tap => "")
+
   ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1"
   ENV["HOMEBREW_NO_COLOR"] = "1"
-  sh "brew", "ruby", "script/generate-cask.rb"
+  sh "brew", "ruby", "script/generate-cask.rb", args[:tap]
 end
 
 def generate_analytics?(os)

--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ require "date"
 task default: :formula_and_analytics
 
 desc "Dump macOS formulae data"
-task :formulae, [:os] do |task, args|
-  args.with_defaults(:os => "mac")
+task :formulae, [:os,:tap] do |task, args|
+  args.with_defaults(:os => "mac", :tap => "")
 
-  ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if args.os == "mac"
+  ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if args[:os] == "mac"
   ENV["HOMEBREW_NO_COLOR"] = "1"
-  sh "brew", "ruby", "script/generate.rb", args.os
+  sh "brew", "ruby", "script/generate.rb", args[:os], args[:tap]
 end
 
 desc "Dump cask data"

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "date"
 task default: :formula_and_analytics
 
 desc "Dump macOS formulae data"
-task :formulae, [:os,:tap] do |task, args|
+task :formulae, [:os, :tap] do |task, args|
   args.with_defaults(:os => "mac", :tap => "")
 
   ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if args[:os] == "mac"

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task default: :formula_and_analytics
 
 desc "Dump macOS formulae data"
 task :formulae, [:os, :tap] do |task, args|
-  args.with_defaults(:os => "mac", :tap => "")
+  args.with_defaults(:os => "mac", :tap => "homebrew/core")
 
   ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if args[:os] == "mac"
   ENV["HOMEBREW_NO_COLOR"] = "1"
@@ -16,7 +16,7 @@ end
 
 desc "Dump cask data"
 task :cask, [:tap] do |task, args|
-  args.with_defaults(:tap => "")
+  args.with_defaults(:tap => "homebrew/cask")
 
   ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1"
   ENV["HOMEBREW_NO_COLOR"] = "1"
@@ -106,11 +106,11 @@ desc "Dump analytics data"
 task :analytics, [:os] do |task, args|
   args.with_defaults(:os => "mac")
 
-  next unless generate_analytics?(args.os)
+  next unless generate_analytics?(args[:os])
 
   setup_analytics
 
-  generate_analytics_files(args.os)
+  generate_analytics_files(args[:os])
 end
 
 desc "Dump macOS formulae and analytics data"

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,23 @@ defaults:
       search_name: Homebrew Formulae
       search_site: formulae
 
+taps:
+  core:
+    repo: core
+    name: Homebrew/core
+    fullname: Homebrew/homebrew-core
+    remote: https://github.com/Homebrew/homebrew-core
+  cask:
+    repo: cask
+    name: Homebrew/cask
+    fullname: Homebrew/homebrew-cask
+    remote: https://github.com/Homebrew/homebrew-cask
+  linux:
+    repo: core
+    name: Homebrew/core
+    fullname: Homebrew/linuxbrew-core
+    remote: https://github.com/Homebrew/linuxbrew-core
+
 logo: https://brew.sh/assets/img/homebrew-256x256.png
 
 forkme_nwo: Homebrew/formulae.brew.sh

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -18,7 +18,7 @@ permalink: :title
 </p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="https://github.com/Homebrew/homebrew-cask/blob/master/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/master/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -23,9 +23,9 @@ permalink: :title
 
 <p><a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code> (JSON API)</a></p>
 {%- if formula_path == "formula-linux" -%}
-<p><a target="_blank" href="https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/{{ f.name }}.rb">Linux formula code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.linux.remote }}/blob/master/Formula/{{ f.name }}.rb">Linux formula code</a> on GitHub</p>
 {%- else -%}
-<p><a target="_blank" href="https://github.com/Homebrew/homebrew-core/blob/master/Formula/{{ f.name }}.rb">Formula code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.core.remote }}/blob/master/Formula/{{ f.name }}.rb">Formula code</a> on GitHub</p>
 {%- endif -%}
 
 <p>Current versions:</p>

--- a/cask_index.html
+++ b/cask_index.html
@@ -2,7 +2,7 @@
 layout: default
 permalink: /cask/
 ---
-<p>This is a listing of all casks available via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
+<p>This is a listing of all casks available from the <a href="{{ site.taps.cask.remote }}">{{ site.taps.cask.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
 
 <h2><a href="{{ site.baseurl }}/api/cask.json"><code>/api/cask.json</code> (JSON API)</a></h2>
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,8 +4,8 @@ layout: page
 permalink: /docs/api/
 ---
 ## Formulae
-### List formulae metadata for all homebrew-core formulae
-List the `brew info --json=v1` output for all current Homebrew/homebrew-core formulae.
+### List formulae metadata for all {{ site.taps.core.repo }} formulae
+List the `brew info --json=v1` output for all current {{ site.taps.core.fullname }} formulae.
 
 ```
 GET https://formulae.brew.sh/api/formula.json
@@ -98,8 +98,8 @@ GET https://formulae.brew.sh/api/formula.json
 ]
 ```
 
-### Get formula metadata for a homebrew-core formula
-Get the `brew info --json=v1` output for a single, current Homebrew/homebrew-core formula with an extra `analytics` key with analytics data.
+### Get formula metadata for a {{ site.taps.core.repo }} formula
+Get the `brew info --json=v1` output for a single, current {{ site.taps.core.fullname }} formula with an extra `analytics` key with analytics data.
 
 ```
 GET https://formulae.brew.sh/api/formula/${FORMULA}.json
@@ -348,8 +348,8 @@ GET https://formulae.brew.sh/api/analytics/${CATEGORY}/${DAYS}.json
 }
 ```
 
-### List analytics events for all homebrew-core formulae
-List all the Homebrew/homebrew-core formulae's analytics events for a specified category and number of days (grouped by formula name).
+### List analytics events for all {{ site.taps.core.repo }} formulae
+List all the {{ site.taps.core.fullname }} formulae's analytics events for a specified category and number of days (grouped by formula name).
 
 ```
 GET https://formulae.brew.sh/api/analytics/${CATEGORY}/homebrew-core/${DAYS}.json
@@ -357,9 +357,9 @@ GET https://formulae.brew.sh/api/analytics/${CATEGORY}/homebrew-core/${DAYS}.jso
 
 #### Variables
 - `${CATEGORY}`: the category of the analytics events, i.e.
-  - `install`: the installation of all homebrew-core formulae
-  - `install-on-request`: the requested installation of all homebrew-core formulae (i.e. not as a dependency of other formulae)
-  - `build-error`: the installation failure of all homebrew-core formulae. Only `${DAYS}: 30d` (30 days) is available.
+  - `install`: the installation of all {{ site.taps.core.repo }} formulae
+  - `install-on-request`: the requested installation of all {{ site.taps.core.repo }} formulae (i.e. not as a dependency of other formulae)
+  - `build-error`: the installation failure of all {{ site.taps.core.repo }} formulae. Only `${DAYS}: 30d` (30 days) is available.
 - `${DAYS}`: the number of days of analytics events, i.e.
   - `30d`: 30 days
   - `90d`: 90 days

--- a/formula_index.html
+++ b/formula_index.html
@@ -2,7 +2,7 @@
 layout: default
 permalink: /formula/
 ---
-<p>This is a listing of all packages available via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
+<p>This is a listing of all packages available from the <a href="{{ site.taps.core.remote }}">{{ site.taps.core.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
 
 <h2><a href="{{ site.baseurl }}/api/formula.json"><code>/api/formula.json</code> (JSON API)</a></h2>
 

--- a/formula_linux_index.html
+++ b/formula_linux_index.html
@@ -2,7 +2,7 @@
 layout: default
 permalink: /formula-linux/
 ---
-<p>This is a listing of all packages available via the <a href="https://brew.sh">Homebrew</a> package manager for Linux.</p>
+<p>This is a listing of all packages available from the <a href="{{ site.taps.linux.remote }}">{{ site.taps.linux.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for Linux.</p>
 
 <h2><a href="{{ site.baseurl }}/api/formula-linux.json"><code>/api/formula-linux.json</code> (JSON API)</a></h2>
 

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -2,8 +2,7 @@
 require "cask/cask"
 
 tap_name = ARGV.first
-tap = Tap.new(tap_name.split("/")) if tap_name
-tap ||= Tap.default_cask_tap
+tap = Tap.fetch(tap_name)
 
 directories = ["_data/cask", "api/cask", "cask"]
 FileUtils.rm_rf directories

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -1,5 +1,9 @@
 #!/usr/bin/env brew ruby
 require "cask/cask"
+
+tap_name = (ARGV.first || "").split("/")
+tap = tap_name.empty? ? Tap.default_cask_tap : Tap.new(*tap_name)
+
 directories = ["_data/cask", "api/cask", "cask"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
@@ -7,7 +11,7 @@ FileUtils.mkdir_p directories
 json_template = IO.read "_api_cask.json.in"
 html_template = IO.read "_cask.html.in"
 
-Tap.default_cask_tap.cask_files.each do |p|
+tap.cask_files.each do |p|
   c = Cask::CaskLoader::FromPathLoader.new(p).load
   IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env brew ruby
 require "cask/cask"
 
-tap_name = (ARGV.first || "").split("/")
-tap = tap_name.empty? ? Tap.default_cask_tap : Tap.new(*tap_name)
+tap_name = ARGV.first
+tap = Tap.new(tap_name.split("/")) if tap_name
+tap ||= Tap.default_cask_tap
 
 directories = ["_data/cask", "api/cask", "cask"]
 FileUtils.rm_rf directories

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env brew ruby
 os = ARGV.first
+tap_name = (ARGV.second || "").split("/")
 
 formula_dir = os == "mac" ? "formula" : "formula-linux"
+tap = tap_name.empty? ? CoreTap.instance : Tap.new(*tap_name)
 
 directories = ["_data/#{formula_dir}", "api/#{formula_dir}", "#{formula_dir}"]
 FileUtils.rm_rf directories
@@ -10,7 +12,7 @@ FileUtils.mkdir_p directories
 json_template = IO.read "_api_formula.json.in"
 html_template = IO.read "_formula.html.in"
 
-CoreTap.instance.formula_names.each do |n|
+tap.formula_names.each do |n|
   f = Formulary.factory(n)
   IO.write("_data/#{formula_dir}/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_hash)}\n")
   IO.write("api/#{formula_dir}/#{f.name}.json", json_template)

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -1,9 +1,10 @@
 #!/usr/bin/env brew ruby
 os = ARGV.first
-tap_name = (ARGV.second || "").split("/")
+tap_name = ARGV.second
+tap = Tap.new(tap_name.split("/")) if tap_name
+tap ||= CoreTap.instance
 
 formula_dir = os == "mac" ? "formula" : "formula-linux"
-tap = tap_name.empty? ? CoreTap.instance : Tap.new(*tap_name)
 
 directories = ["_data/#{formula_dir}", "api/#{formula_dir}", "#{formula_dir}"]
 FileUtils.rm_rf directories

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -1,10 +1,9 @@
 #!/usr/bin/env brew ruby
 os = ARGV.first
 tap_name = ARGV.second
-tap = Tap.new(tap_name.split("/")) if tap_name
-tap ||= CoreTap.instance
 
 formula_dir = os == "mac" ? "formula" : "formula-linux"
+tap = Tap.fetch(tap_name)
 
 directories = ["_data/#{formula_dir}", "api/#{formula_dir}", "#{formula_dir}"]
 FileUtils.rm_rf directories


### PR DESCRIPTION
This PR is an attempt to make the tap configurable, such that forks may build the website for their own 3rd party taps.

This PR is comprised of two primary changes:

- Rakefile and generator scripts:
`script/generate.rb` and `script/generate-cask.rb` are modified to accept a tap argument of the form "owner/repo". If the argument is omitted or empty, they default to their present values (CoreTap and default_cask_tap, respectively). To pair with this change, the corresponding Rakefile tasks are also modified to accept a tap argument and to pass it along to the scripts.

- Tap info in Jekyll configuration
The second main change in this PR, is the addition of tap information to the Jekyll configuration. These configuration options are then used in the cask and formula templates when constructing URLs for the formulae. Again, the configuration is pre-set to the homebrew-core and cask values.

With both of these changes in place, it becomes easier for the site to be built for 3rd party taps, but still defaults to the primary core/cask taps.