### PR TITLE
Rake updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To instead run Homebrew Formulae locally, run:
 git clone https://github.com/Homebrew/formulae.brew.sh
 cd formulae.brew.sh
 bundle install
-bundle exec jekyll serve
+bundle exec rake serve
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To instead run Homebrew Formulae locally, run:
 git clone https://github.com/Homebrew/formulae.brew.sh
 cd formulae.brew.sh
 bundle install
-bundle exec rake serve
+bundle exec jekyll serve
 ```
 
 ## License

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "rake"
 require "rake/clean"
+require 'jekyll'
 require "json"
 require "date"
 
@@ -7,7 +8,7 @@ task default: :formula_and_analytics
 
 desc "Dump macOS formulae data"
 task :formulae, [:os, :tap] do |task, args|
-  args.with_defaults(:os => "mac", :tap => "homebrew/core")
+  args.with_defaults(:os => "mac", :tap => Jekyll.configuration.dig("taps", "core", "name"))
 
   ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if args[:os] == "mac"
   ENV["HOMEBREW_NO_COLOR"] = "1"
@@ -16,7 +17,7 @@ end
 
 desc "Dump cask data"
 task :cask, [:tap] do |task, args|
-  args.with_defaults(:tap => "homebrew/cask")
+  args.with_defaults(:tap => Jekyll.configuration.dig("taps", "cask", "name"))
 
   ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1"
   ENV["HOMEBREW_NO_COLOR"] = "1"

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,8 @@ task :formulae, [:os, :tap] do |task, args|
   ENV["HOMEBREW_NO_COLOR"] = "1"
   sh "brew", "ruby", "script/generate.rb", args[:os], args[:tap]
 end
+CLOBBER.include FileList[%w[_data/formula api/formula formula
+                         _data/formula-linux api/formula-linux formula-linux]]
 
 desc "Dump cask data"
 task :cask, [:tap] do |task, args|
@@ -23,6 +25,7 @@ task :cask, [:tap] do |task, args|
   ENV["HOMEBREW_NO_COLOR"] = "1"
   sh "brew", "ruby", "script/generate-cask.rb", args[:tap]
 end
+CLOBBER.include FileList[%w[_data/cask api/cask cask]]
 
 def generate_analytics?(os)
   return false if ENV["HOMEBREW_NO_ANALYTICS"]
@@ -113,6 +116,7 @@ task :analytics, [:os] do |task, args|
 
   generate_analytics_files(args[:os])
 end
+CLOBBER.include FileList[%w[_data/analytics _data/analytics-linux]]
 
 desc "Dump macOS formulae and analytics data"
 task formula_and_analytics: %i[formulae analytics]

--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,12 @@ end
 
 desc "Build the site"
 task build: [:formula_and_analytics, :cask, :linux_formula_and_analytics] do
-  sh "bundle", "exec", "jekyll", "build"
+  Jekyll::Commands::Build.process({})
+end
+
+desc "Serve the site (jekyll serve)"
+task :serve do
+  Jekyll::Commands::Serve.process({})
 end
 
 desc "Run html proofer to validate the HTML output."

--- a/Rakefile
+++ b/Rakefile
@@ -133,7 +133,7 @@ task build: [:formula_and_analytics, :cask, :linux_formula_and_analytics] do
 end
 CLEAN.include FileList["_site"]
 
-desc "Serve the site (jekyll serve)"
+desc "Serve the site"
 task :serve do
   Jekyll::Commands::Serve.process({})
 end

--- a/Rakefile
+++ b/Rakefile
@@ -131,6 +131,7 @@ desc "Build the site"
 task build: [:formula_and_analytics, :cask, :linux_formula_and_analytics] do
   Jekyll::Commands::Build.process({})
 end
+CLEAN.include FileList["_site"]
 
 desc "Serve the site (jekyll serve)"
 task :serve do
@@ -158,7 +159,7 @@ end
 desc "Run JSON Lint to validate the JSON output."
 task jsonlint: :build do
   require "jsonlint"
-  files_to_check = Rake::FileList.new(["./_site/**/*.json"])
+  files_to_check = FileList["_site/**/*.json"]
   puts "Running JSON Lint on #{files_to_check.flatten.length} files..."
 
   linter = JsonLint::Linter.new
@@ -173,5 +174,3 @@ task jsonlint: :build do
 end
 
 task test: %i[html_proofer jsonlint]
-
-CLEAN.include FileList["_site"]


### PR DESCRIPTION
The primary purpose of this PR is to update the Rakefile such that the data generation tasks pull their default tap names from the jekyll configuration. The benefit of this is reducing the number of places where this information is duplicated (thereby simplifying the configuration changes necessary for tap-forks).

Additionally, this PR configures the rake CLOBBER listing such that the `rake clobber` task is capable of clearing out not only jekyll's generated site, but also the generated formula/cask/analytics data files. Rake differentiates clean and clobber where clobber is a more extensive or "thorough" cleaning. I think this makes a very good differentiating between cleaning the jekyll site (which is not committed) and clobbering the homebrew data (which _is_ committed). Clobber is a much less rarely used task, after all.

Accordingly, I have added the clean/clobber modifications next to the corresponding rake tasks which generate the respective files and directories. I believe this pattern ensures that the clean/clobber lists will be maintained over time as the rake tasks themselves are maintained; ensuring they stay in sync.

Lastly, this adds a `serve` rake task to correspond to the jekyll-serve command. I find it useful to treat rake as the *primary* source for tasks. `serve` was the only "primary" command that was still left to be run outside of rake.