### PR TITLE
Generate initial homebrew/cask analytics

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -13,7 +13,6 @@ jobs:
     env:
       CI: 1
       HOMEBREW_COLOR: 1
-      HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - name: Check out repository
@@ -29,6 +28,7 @@ jobs:
         env:
           ANALYTICS_JSON_KEY: ${{ secrets.ANALYTICS_JSON_KEY }}
           LINUX_ANALYTICS_JSON_KEY: ${{ secrets.LINUX_ANALYTICS_JSON_KEY }}
+          HOMEBREW_NO_ANALYTICS: 1
         run: |
           if which brew &>/dev/null; then
             HOMEBREW_REPOSITORY="$(brew --repository)"

--- a/_data/analytics/cask-install/homebrew-cask/30d.json
+++ b/_data/analytics/cask-install/homebrew-cask/30d.json
@@ -1,0 +1,33279 @@
+{
+  "category": "cask_install",
+  "total_items": 5545,
+  "start_date": "2020-04-06",
+  "end_date": "2020-05-06",
+  "total_count": 8452113,
+  "formulae": {
+    "0-ad": [
+      {
+        "cask": "0-ad",
+        "count": "39"
+      }
+    ],
+    "010-editor": [
+      {
+        "cask": "010-editor",
+        "count": "41"
+      }
+    ],
+    "0xed": [
+      {
+        "cask": "0xed",
+        "count": "76"
+      }
+    ],
+    "115browser": [
+      {
+        "cask": "115browser",
+        "count": "32"
+      }
+    ],
+    "1clipboard": [
+      {
+        "cask": "1clipboard",
+        "count": "46"
+      }
+    ],
+    "1password": [
+      {
+        "cask": "1password",
+        "count": "1,986"
+      }
+    ],
+    "1password-beta": [
+      {
+        "cask": "1password-beta",
+        "count": "30"
+      }
+    ],
+    "1password-cli": [
+      {
+        "cask": "1password-cli",
+        "count": "606"
+      }
+    ],
+    "1password6": [
+      {
+        "cask": "1password6",
+        "count": "39"
+      }
+    ],
+    "2fatotray": [
+      {
+        "cask": "2fatotray",
+        "count": "3"
+      }
+    ],
+    "32-bitcheck": [
+      {
+        "cask": "32-bitcheck",
+        "count": "1"
+      }
+    ],
+    "360safe": [
+      {
+        "cask": "360safe",
+        "count": "12"
+      }
+    ],
+    "3cxphone": [
+      {
+        "cask": "3cxphone",
+        "count": "19"
+      }
+    ],
+    "3dconnexion": [
+      {
+        "cask": "3dconnexion",
+        "count": "7"
+      }
+    ],
+    "3dgenceslicer": [
+      {
+        "cask": "3dgenceslicer",
+        "count": "2"
+      }
+    ],
+    "4k-slideshow-maker": [
+      {
+        "cask": "4k-slideshow-maker",
+        "count": "6"
+      }
+    ],
+    "4k-stogram": [
+      {
+        "cask": "4k-stogram",
+        "count": "11"
+      }
+    ],
+    "4k-video-downloader": [
+      {
+        "cask": "4k-video-downloader",
+        "count": "159"
+      }
+    ],
+    "4k-video-to-mp3": [
+      {
+        "cask": "4k-video-to-mp3",
+        "count": "7"
+      }
+    ],
+    "4k-youtube-to-mp3": [
+      {
+        "cask": "4k-youtube-to-mp3",
+        "count": "48"
+      }
+    ],
+    "4peaks": [
+      {
+        "cask": "4peaks",
+        "count": "4"
+      }
+    ],
+    "5kplayer": [
+      {
+        "cask": "5kplayer",
+        "count": "50"
+      }
+    ],
+    "8bitdo-firmware-updater": [
+      {
+        "cask": "8bitdo-firmware-updater",
+        "count": "13"
+      }
+    ],
+    "a-better-finder-attributes": [
+      {
+        "cask": "a-better-finder-attributes",
+        "count": "26"
+      }
+    ],
+    "a-better-finder-rename": [
+      {
+        "cask": "a-better-finder-rename",
+        "count": "103"
+      }
+    ],
+    "a-slower-speed-of-light": [
+      {
+        "cask": "a-slower-speed-of-light",
+        "count": "5"
+      }
+    ],
+    "ableton-live": [
+      {
+        "cask": "ableton-live",
+        "count": "20"
+      }
+    ],
+    "ableton-live-intro": [
+      {
+        "cask": "ableton-live-intro",
+        "count": "4"
+      }
+    ],
+    "ableton-live-lite": [
+      {
+        "cask": "ableton-live-lite",
+        "count": "21"
+      }
+    ],
+    "ableton-live-standard": [
+      {
+        "cask": "ableton-live-standard",
+        "count": "1"
+      }
+    ],
+    "ableton-live-suite": [
+      {
+        "cask": "ableton-live-suite",
+        "count": "52"
+      }
+    ],
+    "ableton-live-suite9": [
+      {
+        "cask": "ableton-live-suite9",
+        "count": "4"
+      }
+    ],
+    "abricotine": [
+      {
+        "cask": "abricotine",
+        "count": "15"
+      }
+    ],
+    "abscissa": [
+      {
+        "cask": "abscissa",
+        "count": "10"
+      }
+    ],
+    "abstract": [
+      {
+        "cask": "abstract",
+        "count": "78"
+      }
+    ],
+    "accessmenubarapps": [
+      {
+        "cask": "accessmenubarapps",
+        "count": "17"
+      }
+    ],
+    "accurics-cli": [
+      {
+        "cask": "accurics-cli",
+        "count": "3"
+      }
+    ],
+    "ace-link": [
+      {
+        "cask": "ace-link",
+        "count": "26"
+      }
+    ],
+    "acorn": [
+      {
+        "cask": "acorn",
+        "count": "19"
+      }
+    ],
+    "acousticbrainz-gui": [
+      {
+        "cask": "acousticbrainz-gui",
+        "count": "4"
+      }
+    ],
+    "acquia-dev": [
+      {
+        "cask": "acquia-dev",
+        "count": "2"
+      }
+    ],
+    "acronis-true-image": [
+      {
+        "cask": "acronis-true-image",
+        "count": "9"
+      }
+    ],
+    "acs-acr39u-smartcard-driver": [
+      {
+        "cask": "acs-acr39u-smartcard-driver",
+        "count": "1"
+      }
+    ],
+    "acslogo": [
+      {
+        "cask": "acslogo",
+        "count": "1"
+      }
+    ],
+    "activedock": [
+      {
+        "cask": "activedock",
+        "count": "13"
+      }
+    ],
+    "activitywatch": [
+      {
+        "cask": "activitywatch",
+        "count": "33"
+      }
+    ],
+    "actual-odbc-pack": [
+      {
+        "cask": "actual-odbc-pack",
+        "count": "11"
+      }
+    ],
+    "adafruit-arduino": [
+      {
+        "cask": "adafruit-arduino",
+        "count": "6"
+      }
+    ],
+    "adapter": [
+      {
+        "cask": "adapter",
+        "count": "28"
+      }
+    ],
+    "adguard": [
+      {
+        "cask": "adguard",
+        "count": "171"
+      }
+    ],
+    "adguard-nightly": [
+      {
+        "cask": "adguard-nightly",
+        "count": "17"
+      }
+    ],
+    "adium": [
+      {
+        "cask": "adium",
+        "count": "121"
+      }
+    ],
+    "adobe-acrobat-pro": [
+      {
+        "cask": "adobe-acrobat-pro",
+        "count": "140"
+      }
+    ],
+    "adobe-acrobat-reader": [
+      {
+        "cask": "adobe-acrobat-reader",
+        "count": "1,499"
+      }
+    ],
+    "adobe-air": [
+      {
+        "cask": "adobe-air",
+        "count": "83"
+      }
+    ],
+    "adobe-air-sdk": [
+      {
+        "cask": "adobe-air-sdk",
+        "count": "6"
+      }
+    ],
+    "adobe-connect": [
+      {
+        "cask": "adobe-connect",
+        "count": "60"
+      }
+    ],
+    "adobe-creative-cloud": [
+      {
+        "cask": "adobe-creative-cloud",
+        "count": "1,151"
+      }
+    ],
+    "adobe-creative-cloud-cleaner-tool": [
+      {
+        "cask": "adobe-creative-cloud-cleaner-tool",
+        "count": "56"
+      }
+    ],
+    "adobe-digital-editions": [
+      {
+        "cask": "adobe-digital-editions",
+        "count": "119"
+      }
+    ],
+    "adobe-dng-converter": [
+      {
+        "cask": "adobe-dng-converter",
+        "count": "22"
+      }
+    ],
+    "adobe-lens-profile-creator": [
+      {
+        "cask": "adobe-lens-profile-creator",
+        "count": "3"
+      }
+    ],
+    "adoptopenjdk": [
+      {
+        "cask": "adoptopenjdk",
+        "count": "5,581"
+      }
+    ],
+    "adoptopenjdk10": [
+      {
+        "cask": "adoptopenjdk10",
+        "count": "407"
+      }
+    ],
+    "adoptopenjdk11": [
+      {
+        "cask": "adoptopenjdk11",
+        "count": "6,164"
+      }
+    ],
+    "adoptopenjdk11-jre": [
+      {
+        "cask": "adoptopenjdk11-jre",
+        "count": "98"
+      }
+    ],
+    "adoptopenjdk11-openj9": [
+      {
+        "cask": "adoptopenjdk11-openj9",
+        "count": "129"
+      }
+    ],
+    "adoptopenjdk11-openj9-jre": [
+      {
+        "cask": "adoptopenjdk11-openj9-jre",
+        "count": "11"
+      }
+    ],
+    "adoptopenjdk11-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk11-openj9-jre-large",
+        "count": "1"
+      }
+    ],
+    "adoptopenjdk11-openj9-large": [
+      {
+        "cask": "adoptopenjdk11-openj9-large",
+        "count": "11"
+      }
+    ],
+    "adoptopenjdk12": [
+      {
+        "cask": "adoptopenjdk12",
+        "count": "818"
+      }
+    ],
+    "adoptopenjdk12-jre": [
+      {
+        "cask": "adoptopenjdk12-jre",
+        "count": "12"
+      }
+    ],
+    "adoptopenjdk12-openj9": [
+      {
+        "cask": "adoptopenjdk12-openj9",
+        "count": "18"
+      }
+    ],
+    "adoptopenjdk12-openj9-jre": [
+      {
+        "cask": "adoptopenjdk12-openj9-jre",
+        "count": "1"
+      }
+    ],
+    "adoptopenjdk12-openj9-large": [
+      {
+        "cask": "adoptopenjdk12-openj9-large",
+        "count": "2"
+      }
+    ],
+    "adoptopenjdk13": [
+      {
+        "cask": "adoptopenjdk13",
+        "count": "1,416"
+      }
+    ],
+    "adoptopenjdk13-jre": [
+      {
+        "cask": "adoptopenjdk13-jre",
+        "count": "165"
+      }
+    ],
+    "adoptopenjdk13-openj9": [
+      {
+        "cask": "adoptopenjdk13-openj9",
+        "count": "33"
+      }
+    ],
+    "adoptopenjdk13-openj9-jre": [
+      {
+        "cask": "adoptopenjdk13-openj9-jre",
+        "count": "8"
+      }
+    ],
+    "adoptopenjdk14": [
+      {
+        "cask": "adoptopenjdk14",
+        "count": "2,045"
+      }
+    ],
+    "adoptopenjdk14-jre": [
+      {
+        "cask": "adoptopenjdk14-jre",
+        "count": "75"
+      }
+    ],
+    "adoptopenjdk14-openj9": [
+      {
+        "cask": "adoptopenjdk14-openj9",
+        "count": "104"
+      }
+    ],
+    "adoptopenjdk14-openj9-jre": [
+      {
+        "cask": "adoptopenjdk14-openj9-jre",
+        "count": "26"
+      }
+    ],
+    "adoptopenjdk14-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk14-openj9-jre-large",
+        "count": "6"
+      }
+    ],
+    "adoptopenjdk14-openj9-large": [
+      {
+        "cask": "adoptopenjdk14-openj9-large",
+        "count": "8"
+      }
+    ],
+    "adoptopenjdk8": [
+      {
+        "cask": "adoptopenjdk8",
+        "count": "33,985"
+      }
+    ],
+    "adoptopenjdk8-jre": [
+      {
+        "cask": "adoptopenjdk8-jre",
+        "count": "315"
+      }
+    ],
+    "adoptopenjdk8-openj9": [
+      {
+        "cask": "adoptopenjdk8-openj9",
+        "count": "208"
+      }
+    ],
+    "adoptopenjdk8-openj9-jre": [
+      {
+        "cask": "adoptopenjdk8-openj9-jre",
+        "count": "22"
+      }
+    ],
+    "adoptopenjdk8-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk8-openj9-jre-large",
+        "count": "2"
+      }
+    ],
+    "adoptopenjdk8-openj9-large": [
+      {
+        "cask": "adoptopenjdk8-openj9-large",
+        "count": "15"
+      }
+    ],
+    "adoptopenjdk9": [
+      {
+        "cask": "adoptopenjdk9",
+        "count": "477"
+      }
+    ],
+    "advancedrestclient": [
+      {
+        "cask": "advancedrestclient",
+        "count": "38"
+      }
+    ],
+    "adventure": [
+      {
+        "cask": "adventure",
+        "count": "16"
+      }
+    ],
+    "adware-removal-tool": [
+      {
+        "cask": "adware-removal-tool",
+        "count": "10"
+      }
+    ],
+    "aegisub": [
+      {
+        "cask": "aegisub",
+        "count": "78"
+      }
+    ],
+    "aerial": [
+      {
+        "cask": "aerial",
+        "count": "636"
+      }
+    ],
+    "aether": [
+      {
+        "cask": "aether",
+        "count": "3"
+      }
+    ],
+    "aexol-remote-mouse": [
+      {
+        "cask": "aexol-remote-mouse",
+        "count": "7"
+      }
+    ],
+    "affinity-designer-beta": [
+      {
+        "cask": "affinity-designer-beta",
+        "count": "19"
+      }
+    ],
+    "affinity-photo-beta": [
+      {
+        "cask": "affinity-photo-beta",
+        "count": "15"
+      }
+    ],
+    "after-dark-classic": [
+      {
+        "cask": "after-dark-classic",
+        "count": "7"
+      }
+    ],
+    "agenda": [
+      {
+        "cask": "agenda",
+        "count": "64"
+      }
+    ],
+    "agfeo-dashboard": [
+      {
+        "cask": "agfeo-dashboard",
+        "count": "1"
+      }
+    ],
+    "aimersoft-video-converter-ultimate": [
+      {
+        "cask": "aimersoft-video-converter-ultimate",
+        "count": "3"
+      }
+    ],
+    "air-connect": [
+      {
+        "cask": "air-connect",
+        "count": "9"
+      }
+    ],
+    "air-video-server-hd": [
+      {
+        "cask": "air-video-server-hd",
+        "count": "13"
+      }
+    ],
+    "aircall": [
+      {
+        "cask": "aircall",
+        "count": "5"
+      }
+    ],
+    "airdisplay": [
+      {
+        "cask": "airdisplay",
+        "count": "13"
+      }
+    ],
+    "airdroid": [
+      {
+        "cask": "airdroid",
+        "count": "56"
+      }
+    ],
+    "airflow": [
+      {
+        "cask": "airflow",
+        "count": "70"
+      }
+    ],
+    "airfoil": [
+      {
+        "cask": "airfoil",
+        "count": "45"
+      }
+    ],
+    "airmedia": [
+      {
+        "cask": "airmedia",
+        "count": "15"
+      }
+    ],
+    "airparrot": [
+      {
+        "cask": "airparrot",
+        "count": "22"
+      }
+    ],
+    "airpass": [
+      {
+        "cask": "airpass",
+        "count": "9"
+      }
+    ],
+    "airqmon": [
+      {
+        "cask": "airqmon",
+        "count": "6"
+      }
+    ],
+    "airserver": [
+      {
+        "cask": "airserver",
+        "count": "131"
+      }
+    ],
+    "airtable": [
+      {
+        "cask": "airtable",
+        "count": "58"
+      }
+    ],
+    "airtame": [
+      {
+        "cask": "airtame",
+        "count": "18"
+      }
+    ],
+    "airtest-ide": [
+      {
+        "cask": "airtest-ide",
+        "count": "1"
+      }
+    ],
+    "airtool": [
+      {
+        "cask": "airtool",
+        "count": "19"
+      }
+    ],
+    "airtrash": [
+      {
+        "cask": "airtrash",
+        "count": "1"
+      }
+    ],
+    "airunlock": [
+      {
+        "cask": "airunlock",
+        "count": "3"
+      }
+    ],
+    "airy": [
+      {
+        "cask": "airy",
+        "count": "25"
+      }
+    ],
+    "aja-system-test": [
+      {
+        "cask": "aja-system-test",
+        "count": "15"
+      }
+    ],
+    "akai-professional-lpd8-editor": [
+      {
+        "cask": "akai-professional-lpd8-editor",
+        "count": "1"
+      }
+    ],
+    "alacritty": [
+      {
+        "cask": "alacritty",
+        "count": "3,640"
+      }
+    ],
+    "aladin": [
+      {
+        "cask": "aladin",
+        "count": "4"
+      }
+    ],
+    "alchemy": [
+      {
+        "cask": "alchemy",
+        "count": "6"
+      }
+    ],
+    "alephone": [
+      {
+        "cask": "alephone",
+        "count": "2"
+      }
+    ],
+    "alfaview": [
+      {
+        "cask": "alfaview",
+        "count": "10"
+      }
+    ],
+    "alfred": [
+      {
+        "cask": "alfred",
+        "count": "3,158"
+      }
+    ],
+    "alfred-snippetslab": [
+      {
+        "cask": "alfred-snippetslab",
+        "count": "1"
+      }
+    ],
+    "alfred-sound-bank": [
+      {
+        "cask": "alfred-sound-bank",
+        "count": "1"
+      }
+    ],
+    "alfred-things": [
+      {
+        "cask": "alfred-things",
+        "count": "1"
+      }
+    ],
+    "alfred2": [
+      {
+        "cask": "alfred2",
+        "count": "8"
+      }
+    ],
+    "alfred3": [
+      {
+        "cask": "alfred3",
+        "count": "45"
+      }
+    ],
+    "algodoo": [
+      {
+        "cask": "algodoo",
+        "count": "12"
+      }
+    ],
+    "alifix": [
+      {
+        "cask": "alifix",
+        "count": "1"
+      }
+    ],
+    "alimail": [
+      {
+        "cask": "alimail",
+        "count": "1"
+      }
+    ],
+    "alinof-timer": [
+      {
+        "cask": "alinof-timer",
+        "count": "17"
+      }
+    ],
+    "aliwangwang": [
+      {
+        "cask": "aliwangwang",
+        "count": "105"
+      }
+    ],
+    "aliworkbench": [
+      {
+        "cask": "aliworkbench",
+        "count": "6"
+      }
+    ],
+    "all-in-one-messenger": [
+      {
+        "cask": "all-in-one-messenger",
+        "count": "36"
+      }
+    ],
+    "alloy": [
+      {
+        "cask": "alloy",
+        "count": "10"
+      }
+    ],
+    "alt-c": [
+      {
+        "cask": "alt-c",
+        "count": "9"
+      }
+    ],
+    "alt-tab": [
+      {
+        "cask": "alt-tab",
+        "count": "800"
+      }
+    ],
+    "altair-graphql-client": [
+      {
+        "cask": "altair-graphql-client",
+        "count": "276"
+      }
+    ],
+    "altdeploy": [
+      {
+        "cask": "altdeploy",
+        "count": "17"
+      }
+    ],
+    "alternote": [
+      {
+        "cask": "alternote",
+        "count": "3"
+      }
+    ],
+    "altserver": [
+      {
+        "cask": "altserver",
+        "count": "71"
+      }
+    ],
+    "alva": [
+      {
+        "cask": "alva",
+        "count": "9"
+      }
+    ],
+    "amadeus-pro": [
+      {
+        "cask": "amadeus-pro",
+        "count": "11"
+      }
+    ],
+    "amadine": [
+      {
+        "cask": "amadine",
+        "count": "4"
+      }
+    ],
+    "amazon-chime": [
+      {
+        "cask": "amazon-chime",
+        "count": "140"
+      }
+    ],
+    "amazon-music": [
+      {
+        "cask": "amazon-music",
+        "count": "229"
+      }
+    ],
+    "amazon-photos": [
+      {
+        "cask": "amazon-photos",
+        "count": "40"
+      }
+    ],
+    "amazon-workdocs": [
+      {
+        "cask": "amazon-workdocs",
+        "count": "11"
+      }
+    ],
+    "amazon-workspaces": [
+      {
+        "cask": "amazon-workspaces",
+        "count": "162"
+      }
+    ],
+    "amethyst": [
+      {
+        "cask": "amethyst",
+        "count": "1,418"
+      }
+    ],
+    "amitv87-pip": [
+      {
+        "cask": "amitv87-pip",
+        "count": "52"
+      }
+    ],
+    "amm": [
+      {
+        "cask": "amm",
+        "count": "3"
+      }
+    ],
+    "ammonite": [
+      {
+        "cask": "ammonite",
+        "count": "32"
+      }
+    ],
+    "amorphousdiskmark": [
+      {
+        "cask": "amorphousdiskmark",
+        "count": "20"
+      }
+    ],
+    "amphetamine-enhancer": [
+      {
+        "cask": "amphetamine-enhancer",
+        "count": "2"
+      }
+    ],
+    "ampps": [
+      {
+        "cask": "ampps",
+        "count": "13"
+      }
+    ],
+    "anaconda": [
+      {
+        "cask": "anaconda",
+        "count": "3,545"
+      }
+    ],
+    "anaconda2": [
+      {
+        "cask": "anaconda2",
+        "count": "12"
+      }
+    ],
+    "ananas-analytics-desktop-edition": [
+      {
+        "cask": "ananas-analytics-desktop-edition",
+        "count": "3"
+      }
+    ],
+    "android-file-transfer": [
+      {
+        "cask": "android-file-transfer",
+        "count": "1,062"
+      }
+    ],
+    "android-messages": [
+      {
+        "cask": "android-messages",
+        "count": "72"
+      }
+    ],
+    "android-ndk": [
+      {
+        "cask": "android-ndk",
+        "count": "598"
+      }
+    ],
+    "android-ndk-16b": [
+      {
+        "cask": "android-ndk-16b",
+        "count": "4"
+      }
+    ],
+    "android-ndk-19b": [
+      {
+        "cask": "android-ndk-19b",
+        "count": "1"
+      }
+    ],
+    "android-ndk-for-unity@2018.4.5f1": [
+      {
+        "cask": "android-ndk-for-unity@2018.4.5f1",
+        "count": "2"
+      }
+    ],
+    "android-ndk14": [
+      {
+        "cask": "android-ndk14",
+        "count": "1"
+      }
+    ],
+    "android-platform-tools": [
+      {
+        "cask": "android-platform-tools",
+        "count": "14,790"
+      }
+    ],
+    "android-sdk": [
+      {
+        "cask": "android-sdk",
+        "count": "5,011"
+      }
+    ],
+    "android-studio": [
+      {
+        "cask": "android-studio",
+        "count": "2,463"
+      }
+    ],
+    "android-studio-preview": [
+      {
+        "cask": "android-studio-preview",
+        "count": "65"
+      }
+    ],
+    "androidtool": [
+      {
+        "cask": "androidtool",
+        "count": "155"
+      }
+    ],
+    "angband": [
+      {
+        "cask": "angband",
+        "count": "8"
+      }
+    ],
+    "angry-ip-scanner": [
+      {
+        "cask": "angry-ip-scanner",
+        "count": "222"
+      }
+    ],
+    "anka-build": [
+      {
+        "cask": "anka-build",
+        "count": "1"
+      }
+    ],
+    "anka-flow": [
+      {
+        "cask": "anka-flow",
+        "count": "90"
+      }
+    ],
+    "anki": [
+      {
+        "cask": "anki",
+        "count": "635"
+      }
+    ],
+    "ankiapp-anki": [
+      {
+        "cask": "ankiapp-anki",
+        "count": "17"
+      }
+    ],
+    "anne-pro": [
+      {
+        "cask": "anne-pro",
+        "count": "2"
+      }
+    ],
+    "anonym": [
+      {
+        "cask": "anonym",
+        "count": "8"
+      }
+    ],
+    "anonymousvpn": [
+      {
+        "cask": "anonymousvpn",
+        "count": "8"
+      }
+    ],
+    "another-redis-desktop-manager": [
+      {
+        "cask": "another-redis-desktop-manager",
+        "count": "963"
+      }
+    ],
+    "ansible-dk": [
+      {
+        "cask": "ansible-dk",
+        "count": "9"
+      }
+    ],
+    "ansiterm2": [
+      {
+        "cask": "ansiterm2",
+        "count": "1"
+      }
+    ],
+    "antconc": [
+      {
+        "cask": "antconc",
+        "count": "5"
+      }
+    ],
+    "antsword-loader": [
+      {
+        "cask": "antsword-loader",
+        "count": "2"
+      }
+    ],
+    "anvil": [
+      {
+        "cask": "anvil",
+        "count": "10"
+      }
+    ],
+    "anybar": [
+      {
+        "cask": "anybar",
+        "count": "50"
+      }
+    ],
+    "anydesk": [
+      {
+        "cask": "anydesk",
+        "count": "531"
+      }
+    ],
+    "anydo": [
+      {
+        "cask": "anydo",
+        "count": "26"
+      }
+    ],
+    "anylist": [
+      {
+        "cask": "anylist",
+        "count": "16"
+      }
+    ],
+    "anytrans": [
+      {
+        "cask": "anytrans",
+        "count": "9"
+      }
+    ],
+    "anytrans-for-android": [
+      {
+        "cask": "anytrans-for-android",
+        "count": "7"
+      }
+    ],
+    "anzeigenchef": [
+      {
+        "cask": "anzeigenchef",
+        "count": "2"
+      }
+    ],
+    "ao": [
+      {
+        "cask": "ao",
+        "count": "17"
+      }
+    ],
+    "apache-couchdb": [
+      {
+        "cask": "apache-couchdb",
+        "count": "28"
+      }
+    ],
+    "apache-directory-studio": [
+      {
+        "cask": "apache-directory-studio",
+        "count": "322"
+      }
+    ],
+    "apfelstrudel": [
+      {
+        "cask": "apfelstrudel",
+        "count": "1"
+      }
+    ],
+    "apk-icon-editor": [
+      {
+        "cask": "apk-icon-editor",
+        "count": "3"
+      }
+    ],
+    "app-cleaner": [
+      {
+        "cask": "app-cleaner",
+        "count": "281"
+      }
+    ],
+    "app-tamer": [
+      {
+        "cask": "app-tamer",
+        "count": "13"
+      }
+    ],
+    "appcleaner": [
+      {
+        "cask": "appcleaner",
+        "count": "2,195"
+      }
+    ],
+    "appcode": [
+      {
+        "cask": "appcode",
+        "count": "120"
+      }
+    ],
+    "appcode-eap": [
+      {
+        "cask": "appcode-eap",
+        "count": "1"
+      }
+    ],
+    "appdelete": [
+      {
+        "cask": "appdelete",
+        "count": "24"
+      }
+    ],
+    "appearin": [
+      {
+        "cask": "appearin",
+        "count": "1"
+      }
+    ],
+    "appgate-sdp-client": [
+      {
+        "cask": "appgate-sdp-client",
+        "count": "26"
+      }
+    ],
+    "appgrid": [
+      {
+        "cask": "appgrid",
+        "count": "6"
+      }
+    ],
+    "appium": [
+      {
+        "cask": "appium",
+        "count": "99"
+      }
+    ],
+    "apple-events": [
+      {
+        "cask": "apple-events",
+        "count": "9"
+      }
+    ],
+    "apple-hewlett-packard-printer-drivers": [
+      {
+        "cask": "apple-hewlett-packard-printer-drivers",
+        "count": "29"
+      }
+    ],
+    "apple-juice": [
+      {
+        "cask": "apple-juice",
+        "count": "46"
+      }
+    ],
+    "applejuice-core": [
+      {
+        "cask": "applejuice-core",
+        "count": "5"
+      }
+    ],
+    "applejuice-gui": [
+      {
+        "cask": "applejuice-gui",
+        "count": "2"
+      }
+    ],
+    "applepi-baker": [
+      {
+        "cask": "applepi-baker",
+        "count": "68"
+      }
+    ],
+    "apppolice": [
+      {
+        "cask": "apppolice",
+        "count": "28"
+      }
+    ],
+    "appshelf": [
+      {
+        "cask": "appshelf",
+        "count": "2"
+      }
+    ],
+    "appstore-quickview": [
+      {
+        "cask": "appstore-quickview",
+        "count": "1"
+      }
+    ],
+    "appstudio": [
+      {
+        "cask": "appstudio",
+        "count": "2"
+      }
+    ],
+    "apptivate": [
+      {
+        "cask": "apptivate",
+        "count": "13"
+      }
+    ],
+    "apptrap": [
+      {
+        "cask": "apptrap",
+        "count": "25"
+      }
+    ],
+    "appzapper": [
+      {
+        "cask": "appzapper",
+        "count": "70"
+      }
+    ],
+    "aptanastudio": [
+      {
+        "cask": "aptanastudio",
+        "count": "24"
+      }
+    ],
+    "aptible": [
+      {
+        "cask": "aptible",
+        "count": "146"
+      }
+    ],
+    "aqua-data-studio": [
+      {
+        "cask": "aqua-data-studio",
+        "count": "24"
+      }
+    ],
+    "aquamacs": [
+      {
+        "cask": "aquamacs",
+        "count": "83"
+      }
+    ],
+    "aquaskk": [
+      {
+        "cask": "aquaskk",
+        "count": "29"
+      }
+    ],
+    "aquaterm": [
+      {
+        "cask": "aquaterm",
+        "count": "395"
+      }
+    ],
+    "araxis-merge": [
+      {
+        "cask": "araxis-merge",
+        "count": "35"
+      }
+    ],
+    "archichect": [
+      {
+        "cask": "archichect",
+        "count": "1"
+      }
+    ],
+    "archipelago": [
+      {
+        "cask": "archipelago",
+        "count": "2"
+      }
+    ],
+    "archiver": [
+      {
+        "cask": "archiver",
+        "count": "38"
+      }
+    ],
+    "arduino": [
+      {
+        "cask": "arduino",
+        "count": "649"
+      }
+    ],
+    "arduino-nightly": [
+      {
+        "cask": "arduino-nightly",
+        "count": "2"
+      }
+    ],
+    "argos3-webviz": [
+      {
+        "cask": "argos3-webviz",
+        "count": "5"
+      }
+    ],
+    "argouml": [
+      {
+        "cask": "argouml",
+        "count": "5"
+      }
+    ],
+    "aria-maestosa": [
+      {
+        "cask": "aria-maestosa",
+        "count": "6"
+      }
+    ],
+    "aria2d": [
+      {
+        "cask": "aria2d",
+        "count": "35"
+      }
+    ],
+    "aria2gui": [
+      {
+        "cask": "aria2gui",
+        "count": "233"
+      }
+    ],
+    "ariang": [
+      {
+        "cask": "ariang",
+        "count": "32"
+      }
+    ],
+    "ark-desktop-wallet": [
+      {
+        "cask": "ark-desktop-wallet",
+        "count": "1"
+      }
+    ],
+    "armitage": [
+      {
+        "cask": "armitage",
+        "count": "66"
+      }
+    ],
+    "armory": [
+      {
+        "cask": "armory",
+        "count": "6"
+      }
+    ],
+    "arq": [
+      {
+        "cask": "arq",
+        "count": "140"
+      }
+    ],
+    "arq-cloud-backup": [
+      {
+        "cask": "arq-cloud-backup",
+        "count": "8"
+      }
+    ],
+    "arq5": [
+      {
+        "cask": "arq5",
+        "count": "10"
+      }
+    ],
+    "arrayfire": [
+      {
+        "cask": "arrayfire",
+        "count": "13"
+      }
+    ],
+    "arrsync": [
+      {
+        "cask": "arrsync",
+        "count": "13"
+      }
+    ],
+    "art-directors-toolkit": [
+      {
+        "cask": "art-directors-toolkit",
+        "count": "1"
+      }
+    ],
+    "artisan": [
+      {
+        "cask": "artisan",
+        "count": "7"
+      }
+    ],
+    "artpip": [
+      {
+        "cask": "artpip",
+        "count": "9"
+      }
+    ],
+    "asc-timetables": [
+      {
+        "cask": "asc-timetables",
+        "count": "1"
+      }
+    ],
+    "ascension": [
+      {
+        "cask": "ascension",
+        "count": "7"
+      }
+    ],
+    "asciidocfx": [
+      {
+        "cask": "asciidocfx",
+        "count": "53"
+      }
+    ],
+    "asix-ax88179": [
+      {
+        "cask": "asix-ax88179",
+        "count": "9"
+      }
+    ],
+    "aspera-connect": [
+      {
+        "cask": "aspera-connect",
+        "count": "15"
+      }
+    ],
+    "asset-catalog-tinkerer": [
+      {
+        "cask": "asset-catalog-tinkerer",
+        "count": "87"
+      }
+    ],
+    "astah-professional": [
+      {
+        "cask": "astah-professional",
+        "count": "13"
+      }
+    ],
+    "astro-command-center": [
+      {
+        "cask": "astro-command-center",
+        "count": "5"
+      }
+    ],
+    "astropad": [
+      {
+        "cask": "astropad",
+        "count": "11"
+      }
+    ],
+    "astropad-studio": [
+      {
+        "cask": "astropad-studio",
+        "count": "2"
+      }
+    ],
+    "atext": [
+      {
+        "cask": "atext",
+        "count": "42"
+      }
+    ],
+    "atlantis": [
+      {
+        "cask": "atlantis",
+        "count": "4"
+      }
+    ],
+    "atlassian-companion": [
+      {
+        "cask": "atlassian-companion",
+        "count": "2"
+      }
+    ],
+    "atlauncher": [
+      {
+        "cask": "atlauncher",
+        "count": "11"
+      }
+    ],
+    "atok": [
+      {
+        "cask": "atok",
+        "count": "15"
+      }
+    ],
+    "atom": [
+      {
+        "cask": "atom",
+        "count": "4,586"
+      }
+    ],
+    "atom-beta": [
+      {
+        "cask": "atom-beta",
+        "count": "19"
+      }
+    ],
+    "atom-nightly": [
+      {
+        "cask": "atom-nightly",
+        "count": "8"
+      }
+    ],
+    "au-lab": [
+      {
+        "cask": "au-lab",
+        "count": "63"
+      }
+    ],
+    "audacity": [
+      {
+        "cask": "audacity",
+        "count": "10"
+      }
+    ],
+    "audio-hijack": [
+      {
+        "cask": "audio-hijack",
+        "count": "169"
+      }
+    ],
+    "audiobook-builder": [
+      {
+        "cask": "audiobook-builder",
+        "count": "12"
+      }
+    ],
+    "audiobookbinder": [
+      {
+        "cask": "audiobookbinder",
+        "count": "18"
+      }
+    ],
+    "audioscrobbler": [
+      {
+        "cask": "audioscrobbler",
+        "count": "1"
+      }
+    ],
+    "audioslicer": [
+      {
+        "cask": "audioslicer",
+        "count": "7"
+      }
+    ],
+    "audirvana": [
+      {
+        "cask": "audirvana",
+        "count": "23"
+      }
+    ],
+    "augur": [
+      {
+        "cask": "augur",
+        "count": "3"
+      }
+    ],
+    "aurora": [
+      {
+        "cask": "aurora",
+        "count": "5"
+      }
+    ],
+    "aurora-hdr": [
+      {
+        "cask": "aurora-hdr",
+        "count": "3"
+      }
+    ],
+    "auryo": [
+      {
+        "cask": "auryo",
+        "count": "4"
+      }
+    ],
+    "authy": [
+      {
+        "cask": "authy",
+        "count": "810"
+      }
+    ],
+    "autodesk-fusion360": [
+      {
+        "cask": "autodesk-fusion360",
+        "count": "148"
+      }
+    ],
+    "autodmg": [
+      {
+        "cask": "autodmg",
+        "count": "17"
+      }
+    ],
+    "autofirma": [
+      {
+        "cask": "autofirma",
+        "count": "13"
+      }
+    ],
+    "automute": [
+      {
+        "cask": "automute",
+        "count": "6"
+      }
+    ],
+    "autopkgr": [
+      {
+        "cask": "autopkgr",
+        "count": "7"
+      }
+    ],
+    "autovolume": [
+      {
+        "cask": "autovolume",
+        "count": "1"
+      }
+    ],
+    "autumn": [
+      {
+        "cask": "autumn",
+        "count": "1"
+      }
+    ],
+    "avast-secureline-vpn": [
+      {
+        "cask": "avast-secureline-vpn",
+        "count": "2"
+      }
+    ],
+    "avast-security": [
+      {
+        "cask": "avast-security",
+        "count": "93"
+      }
+    ],
+    "aveee_slack": [
+      {
+        "cask": "aveee_slack",
+        "count": "1"
+      }
+    ],
+    "avg-antivirus": [
+      {
+        "cask": "avg-antivirus",
+        "count": "56"
+      }
+    ],
+    "aviatrix-vpn-client": [
+      {
+        "cask": "aviatrix-vpn-client",
+        "count": "24"
+      }
+    ],
+    "avibrazil-rdm": [
+      {
+        "cask": "avibrazil-rdm",
+        "count": "195"
+      }
+    ],
+    "avidcodecsle": [
+      {
+        "cask": "avidcodecsle",
+        "count": "5"
+      }
+    ],
+    "avidemux": [
+      {
+        "cask": "avidemux",
+        "count": "251"
+      }
+    ],
+    "avira-antivirus": [
+      {
+        "cask": "avira-antivirus",
+        "count": "76"
+      }
+    ],
+    "avitools": [
+      {
+        "cask": "avitools",
+        "count": "4"
+      }
+    ],
+    "avocode": [
+      {
+        "cask": "avocode",
+        "count": "17"
+      }
+    ],
+    "avogadro": [
+      {
+        "cask": "avogadro",
+        "count": "23"
+      }
+    ],
+    "awa": [
+      {
+        "cask": "awa",
+        "count": "2"
+      }
+    ],
+    "aware": [
+      {
+        "cask": "aware",
+        "count": "16"
+      }
+    ],
+    "awareness": [
+      {
+        "cask": "awareness",
+        "count": "17"
+      }
+    ],
+    "awips-python": [
+      {
+        "cask": "awips-python",
+        "count": "4"
+      }
+    ],
+    "aws-vault": [
+      {
+        "cask": "aws-vault",
+        "count": "1,577"
+      }
+    ],
+    "awsaml": [
+      {
+        "cask": "awsaml",
+        "count": "13"
+      }
+    ],
+    "axe-electrum": [
+      {
+        "cask": "axe-electrum",
+        "count": "1"
+      }
+    ],
+    "axure-rp": [
+      {
+        "cask": "axure-rp",
+        "count": "90"
+      }
+    ],
+    "azure-data-studio": [
+      {
+        "cask": "azure-data-studio",
+        "count": "287"
+      }
+    ],
+    "back-in-time": [
+      {
+        "cask": "back-in-time",
+        "count": "9"
+      }
+    ],
+    "backblaze": [
+      {
+        "cask": "backblaze",
+        "count": "187"
+      }
+    ],
+    "backblaze-downloader": [
+      {
+        "cask": "backblaze-downloader",
+        "count": "14"
+      }
+    ],
+    "background-music": [
+      {
+        "cask": "background-music",
+        "count": "3,235"
+      }
+    ],
+    "background-music-pre": [
+      {
+        "cask": "background-music-pre",
+        "count": "44"
+      }
+    ],
+    "backlog": [
+      {
+        "cask": "backlog",
+        "count": "3"
+      }
+    ],
+    "backuploupe": [
+      {
+        "cask": "backuploupe",
+        "count": "19"
+      }
+    ],
+    "badlion-client": [
+      {
+        "cask": "badlion-client",
+        "count": "5"
+      }
+    ],
+    "baiducloud": [
+      {
+        "cask": "baiducloud",
+        "count": "44"
+      }
+    ],
+    "baiduhi": [
+      {
+        "cask": "baiduhi",
+        "count": "2"
+      }
+    ],
+    "baiduinput": [
+      {
+        "cask": "baiduinput",
+        "count": "44"
+      }
+    ],
+    "baidunetdisk": [
+      {
+        "cask": "baidunetdisk",
+        "count": "526"
+      }
+    ],
+    "baidunetdisk2.2.2": [
+      {
+        "cask": "baidunetdisk2.2.2",
+        "count": "1"
+      }
+    ],
+    "bailiff": [
+      {
+        "cask": "bailiff",
+        "count": "1"
+      }
+    ],
+    "balance-lock": [
+      {
+        "cask": "balance-lock",
+        "count": "12"
+      }
+    ],
+    "balenaetcher": [
+      {
+        "cask": "balenaetcher",
+        "count": "2,949"
+      }
+    ],
+    "ballast": [
+      {
+        "cask": "ballast",
+        "count": "36"
+      }
+    ],
+    "balsamiq-mockups": [
+      {
+        "cask": "balsamiq-mockups",
+        "count": "1"
+      }
+    ],
+    "balsamiq-wireframes": [
+      {
+        "cask": "balsamiq-wireframes",
+        "count": "65"
+      }
+    ],
+    "bandage": [
+      {
+        "cask": "bandage",
+        "count": "2"
+      }
+    ],
+    "bankid": [
+      {
+        "cask": "bankid",
+        "count": "7"
+      }
+    ],
+    "banking-4": [
+      {
+        "cask": "banking-4",
+        "count": "8"
+      }
+    ],
+    "banktivity": [
+      {
+        "cask": "banktivity",
+        "count": "17"
+      }
+    ],
+    "banshee": [
+      {
+        "cask": "banshee",
+        "count": "12"
+      }
+    ],
+    "baretorrent": [
+      {
+        "cask": "baretorrent",
+        "count": "15"
+      }
+    ],
+    "baritone": [
+      {
+        "cask": "baritone",
+        "count": "4"
+      }
+    ],
+    "barklyjava8": [
+      {
+        "cask": "barklyjava8",
+        "count": "9"
+      }
+    ],
+    "barrier": [
+      {
+        "cask": "barrier",
+        "count": "428"
+      }
+    ],
+    "bartender": [
+      {
+        "cask": "bartender",
+        "count": "672"
+      }
+    ],
+    "barxtemp": [
+      {
+        "cask": "barxtemp",
+        "count": "4"
+      }
+    ],
+    "base": [
+      {
+        "cask": "base",
+        "count": "12"
+      }
+    ],
+    "basecamp": [
+      {
+        "cask": "basecamp",
+        "count": "49"
+      }
+    ],
+    "basictex": [
+      {
+        "cask": "basictex",
+        "count": "2,300"
+      }
+    ],
+    "basler-pylon": [
+      {
+        "cask": "basler-pylon",
+        "count": "1"
+      }
+    ],
+    "batchmod": [
+      {
+        "cask": "batchmod",
+        "count": "17"
+      }
+    ],
+    "bathyscaphe": [
+      {
+        "cask": "bathyscaphe",
+        "count": "25"
+      }
+    ],
+    "battery-guardian": [
+      {
+        "cask": "battery-guardian",
+        "count": "10"
+      }
+    ],
+    "battery-report": [
+      {
+        "cask": "battery-report",
+        "count": "7"
+      }
+    ],
+    "battle-net": [
+      {
+        "cask": "battle-net",
+        "count": "297"
+      }
+    ],
+    "battlescribe": [
+      {
+        "cask": "battlescribe",
+        "count": "5"
+      }
+    ],
+    "baudline": [
+      {
+        "cask": "baudline",
+        "count": "4"
+      }
+    ],
+    "bbc-iplayer-downloads": [
+      {
+        "cask": "bbc-iplayer-downloads",
+        "count": "16"
+      }
+    ],
+    "bbedit": [
+      {
+        "cask": "bbedit",
+        "count": "280"
+      }
+    ],
+    "bdash": [
+      {
+        "cask": "bdash",
+        "count": "1"
+      }
+    ],
+    "beacon-scanner": [
+      {
+        "cask": "beacon-scanner",
+        "count": "6"
+      }
+    ],
+    "beagleim": [
+      {
+        "cask": "beagleim",
+        "count": "24"
+      }
+    ],
+    "beagleim-beta": [
+      {
+        "cask": "beagleim-beta",
+        "count": "2"
+      }
+    ],
+    "beaker-browser": [
+      {
+        "cask": "beaker-browser",
+        "count": "18"
+      }
+    ],
+    "beamer": [
+      {
+        "cask": "beamer",
+        "count": "42"
+      }
+    ],
+    "bean": [
+      {
+        "cask": "bean",
+        "count": "3"
+      }
+    ],
+    "beardedspice": [
+      {
+        "cask": "beardedspice",
+        "count": "186"
+      }
+    ],
+    "bearychat": [
+      {
+        "cask": "bearychat",
+        "count": "1"
+      }
+    ],
+    "beatport-pro": [
+      {
+        "cask": "beatport-pro",
+        "count": "5"
+      }
+    ],
+    "beatunes": [
+      {
+        "cask": "beatunes",
+        "count": "7"
+      }
+    ],
+    "beautune": [
+      {
+        "cask": "beautune",
+        "count": "1"
+      }
+    ],
+    "bee": [
+      {
+        "cask": "bee",
+        "count": "7"
+      }
+    ],
+    "beekeeper-studio": [
+      {
+        "cask": "beekeeper-studio",
+        "count": "2"
+      }
+    ],
+    "beersmith": [
+      {
+        "cask": "beersmith",
+        "count": "5"
+      }
+    ],
+    "beoplay-software-update": [
+      {
+        "cask": "beoplay-software-update",
+        "count": "2"
+      }
+    ],
+    "bestres": [
+      {
+        "cask": "bestres",
+        "count": "8"
+      }
+    ],
+    "betaflight-configurator": [
+      {
+        "cask": "betaflight-configurator",
+        "count": "16"
+      }
+    ],
+    "better-window-manager": [
+      {
+        "cask": "better-window-manager",
+        "count": "11"
+      }
+    ],
+    "bettertouchtool": [
+      {
+        "cask": "bettertouchtool",
+        "count": "895"
+      }
+    ],
+    "betterzip": [
+      {
+        "cask": "betterzip",
+        "count": "416"
+      }
+    ],
+    "between": [
+      {
+        "cask": "between",
+        "count": "2"
+      }
+    ],
+    "betwixt": [
+      {
+        "cask": "betwixt",
+        "count": "4"
+      }
+    ],
+    "beyond-compare": [
+      {
+        "cask": "beyond-compare",
+        "count": "353"
+      }
+    ],
+    "bfxr": [
+      {
+        "cask": "bfxr",
+        "count": "10"
+      }
+    ],
+    "bibdesk": [
+      {
+        "cask": "bibdesk",
+        "count": "202"
+      }
+    ],
+    "big-mean-folder-machine": [
+      {
+        "cask": "big-mean-folder-machine",
+        "count": "4"
+      }
+    ],
+    "bilibili": [
+      {
+        "cask": "bilibili",
+        "count": "62"
+      }
+    ],
+    "bilimini": [
+      {
+        "cask": "bilimini",
+        "count": "5"
+      }
+    ],
+    "binary-ninja": [
+      {
+        "cask": "binary-ninja",
+        "count": "10"
+      }
+    ],
+    "bino": [
+      {
+        "cask": "bino",
+        "count": "6"
+      }
+    ],
+    "birdfont": [
+      {
+        "cask": "birdfont",
+        "count": "17"
+      }
+    ],
+    "biscuit": [
+      {
+        "cask": "biscuit",
+        "count": "32"
+      }
+    ],
+    "bisq": [
+      {
+        "cask": "bisq",
+        "count": "20"
+      }
+    ],
+    "bit-slicer": [
+      {
+        "cask": "bit-slicer",
+        "count": "13"
+      }
+    ],
+    "bitbar": [
+      {
+        "cask": "bitbar",
+        "count": "650"
+      }
+    ],
+    "bitcoin-core": [
+      {
+        "cask": "bitcoin-core",
+        "count": "42"
+      }
+    ],
+    "bitmessage": [
+      {
+        "cask": "bitmessage",
+        "count": "3"
+      }
+    ],
+    "bitrix24": [
+      {
+        "cask": "bitrix24",
+        "count": "12"
+      }
+    ],
+    "bitwarden": [
+      {
+        "cask": "bitwarden",
+        "count": "629"
+      }
+    ],
+    "bitwig-studio": [
+      {
+        "cask": "bitwig-studio",
+        "count": "6"
+      }
+    ],
+    "blackhole": [
+      {
+        "cask": "blackhole",
+        "count": "2,031"
+      }
+    ],
+    "blackvue-viewer": [
+      {
+        "cask": "blackvue-viewer",
+        "count": "3"
+      }
+    ],
+    "blank-screensaver": [
+      {
+        "cask": "blank-screensaver",
+        "count": "6"
+      }
+    ],
+    "blender": [
+      {
+        "cask": "blender",
+        "count": "909"
+      }
+    ],
+    "blheli-configurator": [
+      {
+        "cask": "blheli-configurator",
+        "count": "6"
+      }
+    ],
+    "blink1control": [
+      {
+        "cask": "blink1control",
+        "count": "6"
+      }
+    ],
+    "blisk": [
+      {
+        "cask": "blisk",
+        "count": "38"
+      }
+    ],
+    "blitz": [
+      {
+        "cask": "blitz",
+        "count": "11"
+      }
+    ],
+    "blobby-volley2": [
+      {
+        "cask": "blobby-volley2",
+        "count": "14"
+      }
+    ],
+    "blockblock": [
+      {
+        "cask": "blockblock",
+        "count": "111"
+      }
+    ],
+    "blocks-code": [
+      {
+        "cask": "blocks-code",
+        "count": "1"
+      }
+    ],
+    "blockstack": [
+      {
+        "cask": "blockstack",
+        "count": "3"
+      }
+    ],
+    "blocs": [
+      {
+        "cask": "blocs",
+        "count": "3"
+      }
+    ],
+    "bloodhound": [
+      {
+        "cask": "bloodhound",
+        "count": "16"
+      }
+    ],
+    "bloomrpc": [
+      {
+        "cask": "bloomrpc",
+        "count": "1,105"
+      }
+    ],
+    "blu-ray-player": [
+      {
+        "cask": "blu-ray-player",
+        "count": "5"
+      }
+    ],
+    "blu-ray-player-pro": [
+      {
+        "cask": "blu-ray-player-pro",
+        "count": "12"
+      }
+    ],
+    "blue-jeans": [
+      {
+        "cask": "blue-jeans",
+        "count": "637"
+      }
+    ],
+    "blue-jeans-browser-plugin": [
+      {
+        "cask": "blue-jeans-browser-plugin",
+        "count": "10"
+      }
+    ],
+    "bluefish": [
+      {
+        "cask": "bluefish",
+        "count": "17"
+      }
+    ],
+    "bluegriffon": [
+      {
+        "cask": "bluegriffon",
+        "count": "7"
+      }
+    ],
+    "blueharvest": [
+      {
+        "cask": "blueharvest",
+        "count": "12"
+      }
+    ],
+    "bluej": [
+      {
+        "cask": "bluej",
+        "count": "22"
+      }
+    ],
+    "bluesense": [
+      {
+        "cask": "bluesense",
+        "count": "1"
+      }
+    ],
+    "bluestacks": [
+      {
+        "cask": "bluestacks",
+        "count": "262"
+      }
+    ],
+    "bmw-vagrant": [
+      {
+        "cask": "bmw-vagrant",
+        "count": "1"
+      }
+    ],
+    "bob": [
+      {
+        "cask": "bob",
+        "count": "410"
+      }
+    ],
+    "boinc": [
+      {
+        "cask": "boinc",
+        "count": "108"
+      }
+    ],
+    "bolts": [
+      {
+        "cask": "bolts",
+        "count": "1"
+      }
+    ],
+    "bonjeff": [
+      {
+        "cask": "bonjeff",
+        "count": "4"
+      }
+    ],
+    "bonjour-browser": [
+      {
+        "cask": "bonjour-browser",
+        "count": "11"
+      }
+    ],
+    "bookends": [
+      {
+        "cask": "bookends",
+        "count": "25"
+      }
+    ],
+    "bookmacster": [
+      {
+        "cask": "bookmacster",
+        "count": "11"
+      }
+    ],
+    "boom": [
+      {
+        "cask": "boom",
+        "count": "19"
+      }
+    ],
+    "boom-3d": [
+      {
+        "cask": "boom-3d",
+        "count": "60"
+      }
+    ],
+    "boonzi": [
+      {
+        "cask": "boonzi",
+        "count": "3"
+      }
+    ],
+    "boostnote": [
+      {
+        "cask": "boostnote",
+        "count": "318"
+      }
+    ],
+    "bootchamp": [
+      {
+        "cask": "bootchamp",
+        "count": "7"
+      }
+    ],
+    "bootstrap-studio": [
+      {
+        "cask": "bootstrap-studio",
+        "count": "23"
+      }
+    ],
+    "bootxchanger": [
+      {
+        "cask": "bootxchanger",
+        "count": "3"
+      }
+    ],
+    "borgbackup": [
+      {
+        "cask": "borgbackup",
+        "count": "215"
+      }
+    ],
+    "bose-soundtouch": [
+      {
+        "cask": "bose-soundtouch",
+        "count": "2"
+      }
+    ],
+    "bose-updater": [
+      {
+        "cask": "bose-updater",
+        "count": "13"
+      }
+    ],
+    "bossa": [
+      {
+        "cask": "bossa",
+        "count": "12"
+      }
+    ],
+    "bot-framework-emulator": [
+      {
+        "cask": "bot-framework-emulator",
+        "count": "20"
+      }
+    ],
+    "bowtie": [
+      {
+        "cask": "bowtie",
+        "count": "10"
+      }
+    ],
+    "box-drive": [
+      {
+        "cask": "box-drive",
+        "count": "83"
+      }
+    ],
+    "box-edit": [
+      {
+        "cask": "box-edit",
+        "count": "9"
+      }
+    ],
+    "box-sync": [
+      {
+        "cask": "box-sync",
+        "count": "63"
+      }
+    ],
+    "boxcryptor": [
+      {
+        "cask": "boxcryptor",
+        "count": "33"
+      }
+    ],
+    "boxer": [
+      {
+        "cask": "boxer",
+        "count": "10"
+      }
+    ],
+    "boxofsnoo-fairmount": [
+      {
+        "cask": "boxofsnoo-fairmount",
+        "count": "1"
+      }
+    ],
+    "boxy-suite": [
+      {
+        "cask": "boxy-suite",
+        "count": "7"
+      }
+    ],
+    "brackets": [
+      {
+        "cask": "brackets",
+        "count": "424"
+      }
+    ],
+    "brain-workshop": [
+      {
+        "cask": "brain-workshop",
+        "count": "7"
+      }
+    ],
+    "brainfm": [
+      {
+        "cask": "brainfm",
+        "count": "4"
+      }
+    ],
+    "brave-browser": [
+      {
+        "cask": "brave-browser",
+        "count": "2,349"
+      }
+    ],
+    "brave-browser-beta": [
+      {
+        "cask": "brave-browser-beta",
+        "count": "114"
+      }
+    ],
+    "brave-browser-dev": [
+      {
+        "cask": "brave-browser-dev",
+        "count": "32"
+      }
+    ],
+    "brave-browser-nightly": [
+      {
+        "cask": "brave-browser-nightly",
+        "count": "10"
+      }
+    ],
+    "breakaway": [
+      {
+        "cask": "breakaway",
+        "count": "1"
+      }
+    ],
+    "breaktimer": [
+      {
+        "cask": "breaktimer",
+        "count": "16"
+      }
+    ],
+    "brewservicesmenubar": [
+      {
+        "cask": "brewservicesmenubar",
+        "count": "41"
+      }
+    ],
+    "brewtarget": [
+      {
+        "cask": "brewtarget",
+        "count": "3"
+      }
+    ],
+    "bria": [
+      {
+        "cask": "bria",
+        "count": "13"
+      }
+    ],
+    "bricklink-studio": [
+      {
+        "cask": "bricklink-studio",
+        "count": "12"
+      }
+    ],
+    "bricksmith": [
+      {
+        "cask": "bricksmith",
+        "count": "8"
+      }
+    ],
+    "brightness": [
+      {
+        "cask": "brightness",
+        "count": "18"
+      }
+    ],
+    "brightness-sync": [
+      {
+        "cask": "brightness-sync",
+        "count": "13"
+      }
+    ],
+    "brisk": [
+      {
+        "cask": "brisk",
+        "count": "3"
+      }
+    ],
+    "brisync": [
+      {
+        "cask": "brisync",
+        "count": "12"
+      }
+    ],
+    "brl-cad-mged": [
+      {
+        "cask": "brl-cad-mged",
+        "count": "5"
+      }
+    ],
+    "brogue": [
+      {
+        "cask": "brogue",
+        "count": "13"
+      }
+    ],
+    "brook": [
+      {
+        "cask": "brook",
+        "count": "27"
+      }
+    ],
+    "brooklyn": [
+      {
+        "cask": "brooklyn",
+        "count": "327"
+      }
+    ],
+    "brother-p-touch-update-software": [
+      {
+        "cask": "brother-p-touch-update-software",
+        "count": "2"
+      }
+    ],
+    "browserosaurus": [
+      {
+        "cask": "browserosaurus",
+        "count": "57"
+      }
+    ],
+    "browserstacklocal": [
+      {
+        "cask": "browserstacklocal",
+        "count": "39"
+      }
+    ],
+    "btcpayserver-vault": [
+      {
+        "cask": "btcpayserver-vault",
+        "count": "1"
+      }
+    ],
+    "buildsettingextractor": [
+      {
+        "cask": "buildsettingextractor",
+        "count": "4"
+      }
+    ],
+    "bunch": [
+      {
+        "cask": "bunch",
+        "count": "10"
+      }
+    ],
+    "bunqcommunity-bunq": [
+      {
+        "cask": "bunqcommunity-bunq",
+        "count": "15"
+      }
+    ],
+    "burn": [
+      {
+        "cask": "burn",
+        "count": "92"
+      }
+    ],
+    "burp-suite": [
+      {
+        "cask": "burp-suite",
+        "count": "155"
+      }
+    ],
+    "busycal": [
+      {
+        "cask": "busycal",
+        "count": "16"
+      }
+    ],
+    "busycontacts": [
+      {
+        "cask": "busycontacts",
+        "count": "6"
+      }
+    ],
+    "butler": [
+      {
+        "cask": "butler",
+        "count": "17"
+      }
+    ],
+    "butt": [
+      {
+        "cask": "butt",
+        "count": "11"
+      }
+    ],
+    "butter": [
+      {
+        "cask": "butter",
+        "count": "2"
+      }
+    ],
+    "buttercup": [
+      {
+        "cask": "buttercup",
+        "count": "63"
+      }
+    ],
+    "bwana": [
+      {
+        "cask": "bwana",
+        "count": "1"
+      }
+    ],
+    "bzflag": [
+      {
+        "cask": "bzflag",
+        "count": "29"
+      }
+    ],
+    "c0re100-qbittorrent": [
+      {
+        "cask": "c0re100-qbittorrent",
+        "count": "71"
+      }
+    ],
+    "cabal": [
+      {
+        "cask": "cabal",
+        "count": "73"
+      }
+    ],
+    "cacher": [
+      {
+        "cask": "cacher",
+        "count": "33"
+      }
+    ],
+    "caffeine": [
+      {
+        "cask": "caffeine",
+        "count": "1,107"
+      }
+    ],
+    "cajviewer": [
+      {
+        "cask": "cajviewer",
+        "count": "20"
+      }
+    ],
+    "cakebrew": [
+      {
+        "cask": "cakebrew",
+        "count": "903"
+      }
+    ],
+    "calcservice": [
+      {
+        "cask": "calcservice",
+        "count": "3"
+      }
+    ],
+    "caldigit-docking-utility": [
+      {
+        "cask": "caldigit-docking-utility",
+        "count": "2"
+      }
+    ],
+    "caldigit-thunderbolt-charging": [
+      {
+        "cask": "caldigit-thunderbolt-charging",
+        "count": "5"
+      }
+    ],
+    "calendar-366": [
+      {
+        "cask": "calendar-366",
+        "count": "4"
+      }
+    ],
+    "calibre": [
+      {
+        "cask": "calibre",
+        "count": "2,515"
+      }
+    ],
+    "camed": [
+      {
+        "cask": "camed",
+        "count": "2"
+      }
+    ],
+    "camera-live": [
+      {
+        "cask": "camera-live",
+        "count": "57"
+      }
+    ],
+    "camerabag-photo": [
+      {
+        "cask": "camerabag-photo",
+        "count": "2"
+      }
+    ],
+    "camtasia": [
+      {
+        "cask": "camtasia",
+        "count": "32"
+      }
+    ],
+    "camtwiststudio": [
+      {
+        "cask": "camtwiststudio",
+        "count": "1"
+      }
+    ],
+    "camunda-modeler": [
+      {
+        "cask": "camunda-modeler",
+        "count": "78"
+      }
+    ],
+    "canary": [
+      {
+        "cask": "canary",
+        "count": "33"
+      }
+    ],
+    "candybar": [
+      {
+        "cask": "candybar",
+        "count": "3"
+      }
+    ],
+    "canon-eos-utility": [
+      {
+        "cask": "canon-eos-utility",
+        "count": "23"
+      }
+    ],
+    "canon-ijscanner1": [
+      {
+        "cask": "canon-ijscanner1",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner13f": [
+      {
+        "cask": "canon-ijscanner13f",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner14f": [
+      {
+        "cask": "canon-ijscanner14f",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner3": [
+      {
+        "cask": "canon-ijscanner3",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner6": [
+      {
+        "cask": "canon-ijscanner6",
+        "count": "1"
+      }
+    ],
+    "canon-lide-90": [
+      {
+        "cask": "canon-lide-90",
+        "count": "4"
+      }
+    ],
+    "cantata": [
+      {
+        "cask": "cantata",
+        "count": "31"
+      }
+    ],
+    "caprine": [
+      {
+        "cask": "caprine",
+        "count": "198"
+      }
+    ],
+    "captain": [
+      {
+        "cask": "captain",
+        "count": "12"
+      }
+    ],
+    "captin": [
+      {
+        "cask": "captin",
+        "count": "24"
+      }
+    ],
+    "caption": [
+      {
+        "cask": "caption",
+        "count": "17"
+      }
+    ],
+    "capto": [
+      {
+        "cask": "capto",
+        "count": "18"
+      }
+    ],
+    "capture-one": [
+      {
+        "cask": "capture-one",
+        "count": "12"
+      }
+    ],
+    "carbon-copy-cloner": [
+      {
+        "cask": "carbon-copy-cloner",
+        "count": "175"
+      }
+    ],
+    "cardhop": [
+      {
+        "cask": "cardhop",
+        "count": "14"
+      }
+    ],
+    "caret": [
+      {
+        "cask": "caret",
+        "count": "13"
+      }
+    ],
+    "cask": [
+      {
+        "cask": "cask",
+        "count": "3"
+      }
+    ],
+    "catalina-cache-cleaner": [
+      {
+        "cask": "catalina-cache-cleaner",
+        "count": "11"
+      }
+    ],
+    "catch": [
+      {
+        "cask": "catch",
+        "count": "14"
+      }
+    ],
+    "catlight": [
+      {
+        "cask": "catlight",
+        "count": "5"
+      }
+    ],
+    "cave-story": [
+      {
+        "cask": "cave-story",
+        "count": "2"
+      }
+    ],
+    "cbz-manager": [
+      {
+        "cask": "cbz-manager",
+        "count": "10"
+      }
+    ],
+    "ccleaner": [
+      {
+        "cask": "ccleaner",
+        "count": "335"
+      }
+    ],
+    "ccmenu": [
+      {
+        "cask": "ccmenu",
+        "count": "26"
+      }
+    ],
+    "cctalk": [
+      {
+        "cask": "cctalk",
+        "count": "6"
+      }
+    ],
+    "cd-to": [
+      {
+        "cask": "cd-to",
+        "count": "40"
+      }
+    ],
+    "cellery": [
+      {
+        "cask": "cellery",
+        "count": "1"
+      }
+    ],
+    "cellprofiler": [
+      {
+        "cask": "cellprofiler",
+        "count": "2"
+      }
+    ],
+    "cemu": [
+      {
+        "cask": "cemu",
+        "count": "8"
+      }
+    ],
+    "cerebro": [
+      {
+        "cask": "cerebro",
+        "count": "29"
+      }
+    ],
+    "cevelop": [
+      {
+        "cask": "cevelop",
+        "count": "11"
+      }
+    ],
+    "chai": [
+      {
+        "cask": "chai",
+        "count": "8"
+      }
+    ],
+    "chalk": [
+      {
+        "cask": "chalk",
+        "count": "28"
+      }
+    ],
+    "chameleon-ssd-optimizer": [
+      {
+        "cask": "chameleon-ssd-optimizer",
+        "count": "17"
+      }
+    ],
+    "charger-information": [
+      {
+        "cask": "charger-information",
+        "count": "1"
+      }
+    ],
+    "charles": [
+      {
+        "cask": "charles",
+        "count": "637"
+      }
+    ],
+    "charles-beta": [
+      {
+        "cask": "charles-beta",
+        "count": "1"
+      }
+    ],
+    "charles3": [
+      {
+        "cask": "charles3",
+        "count": "2"
+      }
+    ],
+    "charlessoft-timetracker": [
+      {
+        "cask": "charlessoft-timetracker",
+        "count": "5"
+      }
+    ],
+    "chatmate-for-facebook": [
+      {
+        "cask": "chatmate-for-facebook",
+        "count": "6"
+      }
+    ],
+    "chatmate-for-whatsapp": [
+      {
+        "cask": "chatmate-for-whatsapp",
+        "count": "26"
+      }
+    ],
+    "chatology": [
+      {
+        "cask": "chatology",
+        "count": "5"
+      }
+    ],
+    "chatty": [
+      {
+        "cask": "chatty",
+        "count": "4"
+      }
+    ],
+    "chatwork": [
+      {
+        "cask": "chatwork",
+        "count": "33"
+      }
+    ],
+    "cheatsheet": [
+      {
+        "cask": "cheatsheet",
+        "count": "910"
+      }
+    ],
+    "checkpoint": [
+      {
+        "cask": "checkpoint",
+        "count": "1"
+      }
+    ],
+    "checkra1n": [
+      {
+        "cask": "checkra1n",
+        "count": "149"
+      }
+    ],
+    "cheetah3d": [
+      {
+        "cask": "cheetah3d",
+        "count": "3"
+      }
+    ],
+    "chef-infra-client": [
+      {
+        "cask": "chef-infra-client",
+        "count": "18"
+      }
+    ],
+    "chef-workstation": [
+      {
+        "cask": "chef-workstation",
+        "count": "286"
+      }
+    ],
+    "chefdk": [
+      {
+        "cask": "chefdk",
+        "count": "232"
+      }
+    ],
+    "chemdoodle": [
+      {
+        "cask": "chemdoodle",
+        "count": "2"
+      }
+    ],
+    "chessx": [
+      {
+        "cask": "chessx",
+        "count": "18"
+      }
+    ],
+    "chiaki": [
+      {
+        "cask": "chiaki",
+        "count": "5"
+      }
+    ],
+    "chicken": [
+      {
+        "cask": "chicken",
+        "count": "22"
+      }
+    ],
+    "chirp-daily": [
+      {
+        "cask": "chirp-daily",
+        "count": "13"
+      }
+    ],
+    "chocolat": [
+      {
+        "cask": "chocolat",
+        "count": "7"
+      }
+    ],
+    "choosy": [
+      {
+        "cask": "choosy",
+        "count": "90"
+      }
+    ],
+    "chrome-devtools": [
+      {
+        "cask": "chrome-devtools",
+        "count": "41"
+      }
+    ],
+    "chrome-remote-desktop-host": [
+      {
+        "cask": "chrome-remote-desktop-host",
+        "count": "91"
+      }
+    ],
+    "chromedriver": [
+      {
+        "cask": "chromedriver",
+        "count": "11,159"
+      }
+    ],
+    "chromedriver-beta": [
+      {
+        "cask": "chromedriver-beta",
+        "count": "42"
+      }
+    ],
+    "chromedriver80": [
+      {
+        "cask": "chromedriver80",
+        "count": "1"
+      }
+    ],
+    "chromium": [
+      {
+        "cask": "chromium",
+        "count": "2,265"
+      }
+    ],
+    "chromium-portia": [
+      {
+        "cask": "chromium-portia",
+        "count": "3"
+      }
+    ],
+    "chronicle": [
+      {
+        "cask": "chronicle",
+        "count": "1"
+      }
+    ],
+    "chronoagent": [
+      {
+        "cask": "chronoagent",
+        "count": "2"
+      }
+    ],
+    "chronos": [
+      {
+        "cask": "chronos",
+        "count": "6"
+      }
+    ],
+    "chronosync": [
+      {
+        "cask": "chronosync",
+        "count": "11"
+      }
+    ],
+    "chronycontrol": [
+      {
+        "cask": "chronycontrol",
+        "count": "5"
+      }
+    ],
+    "chrysalis": [
+      {
+        "cask": "chrysalis",
+        "count": "14"
+      }
+    ],
+    "cinch": [
+      {
+        "cask": "cinch",
+        "count": "13"
+      }
+    ],
+    "cinder": [
+      {
+        "cask": "cinder",
+        "count": "6"
+      }
+    ],
+    "cinebench": [
+      {
+        "cask": "cinebench",
+        "count": "87"
+      }
+    ],
+    "cineplay": [
+      {
+        "cask": "cineplay",
+        "count": "1"
+      }
+    ],
+    "cirrus": [
+      {
+        "cask": "cirrus",
+        "count": "2"
+      }
+    ],
+    "cisco-proximity": [
+      {
+        "cask": "cisco-proximity",
+        "count": "439"
+      }
+    ],
+    "cisdem-data-recovery": [
+      {
+        "cask": "cisdem-data-recovery",
+        "count": "7"
+      }
+    ],
+    "cisdem-document-reader": [
+      {
+        "cask": "cisdem-document-reader",
+        "count": "7"
+      }
+    ],
+    "cisdem-pdf-converter-ocr": [
+      {
+        "cask": "cisdem-pdf-converter-ocr",
+        "count": "6"
+      }
+    ],
+    "cisdem-pdfmanagerultimate": [
+      {
+        "cask": "cisdem-pdfmanagerultimate",
+        "count": "10"
+      }
+    ],
+    "cisdem-pdftoolkit": [
+      {
+        "cask": "cisdem-pdftoolkit",
+        "count": "3"
+      }
+    ],
+    "citra": [
+      {
+        "cask": "citra",
+        "count": "38"
+      }
+    ],
+    "citrix-workspace": [
+      {
+        "cask": "citrix-workspace",
+        "count": "1"
+      }
+    ],
+    "cityofzion-neon": [
+      {
+        "cask": "cityofzion-neon",
+        "count": "11"
+      }
+    ],
+    "ck550-macos": [
+      {
+        "cask": "ck550-macos",
+        "count": "2"
+      }
+    ],
+    "ckan": [
+      {
+        "cask": "ckan",
+        "count": "9"
+      }
+    ],
+    "ckb-next": [
+      {
+        "cask": "ckb-next",
+        "count": "14"
+      }
+    ],
+    "clamxav": [
+      {
+        "cask": "clamxav",
+        "count": "47"
+      }
+    ],
+    "clashx": [
+      {
+        "cask": "clashx",
+        "count": "465"
+      }
+    ],
+    "clashxr": [
+      {
+        "cask": "clashxr",
+        "count": "1"
+      }
+    ],
+    "classroom-assistant": [
+      {
+        "cask": "classroom-assistant",
+        "count": "4"
+      }
+    ],
+    "clean-me": [
+      {
+        "cask": "clean-me",
+        "count": "204"
+      }
+    ],
+    "cleanapp": [
+      {
+        "cask": "cleanapp",
+        "count": "5"
+      }
+    ],
+    "cleanmymac": [
+      {
+        "cask": "cleanmymac",
+        "count": "970"
+      }
+    ],
+    "cleanmymac3": [
+      {
+        "cask": "cleanmymac3",
+        "count": "20"
+      }
+    ],
+    "cleanshot": [
+      {
+        "cask": "cleanshot",
+        "count": "24"
+      }
+    ],
+    "cleartext": [
+      {
+        "cask": "cleartext",
+        "count": "5"
+      }
+    ],
+    "clementine": [
+      {
+        "cask": "clementine",
+        "count": "107"
+      }
+    ],
+    "clickcharts": [
+      {
+        "cask": "clickcharts",
+        "count": "1"
+      }
+    ],
+    "clickup": [
+      {
+        "cask": "clickup",
+        "count": "35"
+      }
+    ],
+    "clion": [
+      {
+        "cask": "clion",
+        "count": "447"
+      }
+    ],
+    "clip-studio-paint": [
+      {
+        "cask": "clip-studio-paint",
+        "count": "17"
+      }
+    ],
+    "clipgrab": [
+      {
+        "cask": "clipgrab",
+        "count": "58"
+      }
+    ],
+    "clipy": [
+      {
+        "cask": "clipy",
+        "count": "583"
+      }
+    ],
+    "cliqz": [
+      {
+        "cask": "cliqz",
+        "count": "4"
+      }
+    ],
+    "clix": [
+      {
+        "cask": "clix",
+        "count": "1"
+      }
+    ],
+    "cljstyle": [
+      {
+        "cask": "cljstyle",
+        "count": "13"
+      }
+    ],
+    "clock": [
+      {
+        "cask": "clock",
+        "count": "5"
+      }
+    ],
+    "clock-bar": [
+      {
+        "cask": "clock-bar",
+        "count": "75"
+      }
+    ],
+    "clockify": [
+      {
+        "cask": "clockify",
+        "count": "64"
+      }
+    ],
+    "clocksaver": [
+      {
+        "cask": "clocksaver",
+        "count": "90"
+      }
+    ],
+    "clone-hero": [
+      {
+        "cask": "clone-hero",
+        "count": "6"
+      }
+    ],
+    "clonk": [
+      {
+        "cask": "clonk",
+        "count": "5"
+      }
+    ],
+    "cloud-pbx": [
+      {
+        "cask": "cloud-pbx",
+        "count": "1"
+      }
+    ],
+    "cloudapp": [
+      {
+        "cask": "cloudapp",
+        "count": "89"
+      }
+    ],
+    "cloudcompare": [
+      {
+        "cask": "cloudcompare",
+        "count": "12"
+      }
+    ],
+    "cloudmounter": [
+      {
+        "cask": "cloudmounter",
+        "count": "21"
+      }
+    ],
+    "cloudtv": [
+      {
+        "cask": "cloudtv",
+        "count": "3"
+      }
+    ],
+    "cloudup": [
+      {
+        "cask": "cloudup",
+        "count": "1"
+      }
+    ],
+    "cloudytabs": [
+      {
+        "cask": "cloudytabs",
+        "count": "21"
+      }
+    ],
+    "clover-configurator": [
+      {
+        "cask": "clover-configurator",
+        "count": "196"
+      }
+    ],
+    "cluster": [
+      {
+        "cask": "cluster",
+        "count": "1"
+      }
+    ],
+    "cmake": [
+      {
+        "cask": "cmake",
+        "count": "635"
+      }
+    ],
+    "cmd-eikana": [
+      {
+        "cask": "cmd-eikana",
+        "count": "40"
+      }
+    ],
+    "cmdtap": [
+      {
+        "cask": "cmdtap",
+        "count": "1"
+      }
+    ],
+    "cn-wps": [
+      {
+        "cask": "cn-wps",
+        "count": "4"
+      }
+    ],
+    "cncjs": [
+      {
+        "cask": "cncjs",
+        "count": "5"
+      }
+    ],
+    "cncnet": [
+      {
+        "cask": "cncnet",
+        "count": "10"
+      }
+    ],
+    "coccinellida": [
+      {
+        "cask": "coccinellida",
+        "count": "4"
+      }
+    ],
+    "coccoc": [
+      {
+        "cask": "coccoc",
+        "count": "4"
+      }
+    ],
+    "cockatrice": [
+      {
+        "cask": "cockatrice",
+        "count": "19"
+      }
+    ],
+    "cocktail": [
+      {
+        "cask": "cocktail",
+        "count": "28"
+      }
+    ],
+    "cocoapods": [
+      {
+        "cask": "cocoapods",
+        "count": "86"
+      }
+    ],
+    "cocoarestclient": [
+      {
+        "cask": "cocoarestclient",
+        "count": "31"
+      }
+    ],
+    "cocoaspell": [
+      {
+        "cask": "cocoaspell",
+        "count": "74"
+      }
+    ],
+    "coconutbattery": [
+      {
+        "cask": "coconutbattery",
+        "count": "723"
+      }
+    ],
+    "cocoscreator": [
+      {
+        "cask": "cocoscreator",
+        "count": "43"
+      }
+    ],
+    "coda": [
+      {
+        "cask": "coda",
+        "count": "43"
+      }
+    ],
+    "code-notes": [
+      {
+        "cask": "code-notes",
+        "count": "7"
+      }
+    ],
+    "code42-crashplan": [
+      {
+        "cask": "code42-crashplan",
+        "count": "36"
+      }
+    ],
+    "codeexpander": [
+      {
+        "cask": "codeexpander",
+        "count": "1"
+      }
+    ],
+    "codekit": [
+      {
+        "cask": "codekit",
+        "count": "55"
+      }
+    ],
+    "codelite": [
+      {
+        "cask": "codelite",
+        "count": "46"
+      }
+    ],
+    "coderunner": [
+      {
+        "cask": "coderunner",
+        "count": "91"
+      }
+    ],
+    "cold-turkey-blocker": [
+      {
+        "cask": "cold-turkey-blocker",
+        "count": "18"
+      }
+    ],
+    "color-oracle": [
+      {
+        "cask": "color-oracle",
+        "count": "9"
+      }
+    ],
+    "colormunki-photo": [
+      {
+        "cask": "colormunki-photo",
+        "count": "1"
+      }
+    ],
+    "colorpicker-developer": [
+      {
+        "cask": "colorpicker-developer",
+        "count": "32"
+      }
+    ],
+    "colorpicker-materialdesign": [
+      {
+        "cask": "colorpicker-materialdesign",
+        "count": "8"
+      }
+    ],
+    "colorpicker-propicker": [
+      {
+        "cask": "colorpicker-propicker",
+        "count": "17"
+      }
+    ],
+    "colorpicker-skalacolor": [
+      {
+        "cask": "colorpicker-skalacolor",
+        "count": "20"
+      }
+    ],
+    "colorsnapper": [
+      {
+        "cask": "colorsnapper",
+        "count": "16"
+      }
+    ],
+    "colour-contrast-analyser": [
+      {
+        "cask": "colour-contrast-analyser",
+        "count": "8"
+      }
+    ],
+    "combine-pdfs": [
+      {
+        "cask": "combine-pdfs",
+        "count": "10"
+      }
+    ],
+    "comictagger": [
+      {
+        "cask": "comictagger",
+        "count": "11"
+      }
+    ],
+    "command-tab-plus": [
+      {
+        "cask": "command-tab-plus",
+        "count": "9"
+      }
+    ],
+    "commander-one": [
+      {
+        "cask": "commander-one",
+        "count": "159"
+      }
+    ],
+    "commandpost": [
+      {
+        "cask": "commandpost",
+        "count": "1"
+      }
+    ],
+    "commandq": [
+      {
+        "cask": "commandq",
+        "count": "1"
+      }
+    ],
+    "comparemerge": [
+      {
+        "cask": "comparemerge",
+        "count": "22"
+      }
+    ],
+    "composercat": [
+      {
+        "cask": "composercat",
+        "count": "2"
+      }
+    ],
+    "compositor": [
+      {
+        "cask": "compositor",
+        "count": "9"
+      }
+    ],
+    "conferences": [
+      {
+        "cask": "conferences",
+        "count": "2"
+      }
+    ],
+    "confluent-hub-client": [
+      {
+        "cask": "confluent-hub-client",
+        "count": "195"
+      }
+    ],
+    "connectiq": [
+      {
+        "cask": "connectiq",
+        "count": "8"
+      }
+    ],
+    "connectmenow": [
+      {
+        "cask": "connectmenow",
+        "count": "5"
+      }
+    ],
+    "consolation3": [
+      {
+        "cask": "consolation3",
+        "count": "1"
+      }
+    ],
+    "console": [
+      {
+        "cask": "console",
+        "count": "5"
+      }
+    ],
+    "contexts": [
+      {
+        "cask": "contexts",
+        "count": "109"
+      }
+    ],
+    "continuity-activation-tool": [
+      {
+        "cask": "continuity-activation-tool",
+        "count": "2"
+      }
+    ],
+    "contraste": [
+      {
+        "cask": "contraste",
+        "count": "3"
+      }
+    ],
+    "controllermate": [
+      {
+        "cask": "controllermate",
+        "count": "11"
+      }
+    ],
+    "controlplane": [
+      {
+        "cask": "controlplane",
+        "count": "27"
+      }
+    ],
+    "cookie": [
+      {
+        "cask": "cookie",
+        "count": "9"
+      }
+    ],
+    "cool-retro-term": [
+      {
+        "cask": "cool-retro-term",
+        "count": "397"
+      }
+    ],
+    "coolterm": [
+      {
+        "cask": "coolterm",
+        "count": "59"
+      }
+    ],
+    "copyclip": [
+      {
+        "cask": "copyclip",
+        "count": "99"
+      }
+    ],
+    "copyq": [
+      {
+        "cask": "copyq",
+        "count": "269"
+      }
+    ],
+    "coqide": [
+      {
+        "cask": "coqide",
+        "count": "70"
+      }
+    ],
+    "cord": [
+      {
+        "cask": "cord",
+        "count": "56"
+      }
+    ],
+    "corelocationcli": [
+      {
+        "cask": "corelocationcli",
+        "count": "38"
+      }
+    ],
+    "cornercal": [
+      {
+        "cask": "cornercal",
+        "count": "7"
+      }
+    ],
+    "cornerstone": [
+      {
+        "cask": "cornerstone",
+        "count": "16"
+      }
+    ],
+    "corona-tracker": [
+      {
+        "cask": "corona-tracker",
+        "count": "288"
+      }
+    ],
+    "coronasdk": [
+      {
+        "cask": "coronasdk",
+        "count": "6"
+      }
+    ],
+    "corretto": [
+      {
+        "cask": "corretto",
+        "count": "395"
+      }
+    ],
+    "corretto8": [
+      {
+        "cask": "corretto8",
+        "count": "349"
+      }
+    ],
+    "corsair-icue": [
+      {
+        "cask": "corsair-icue",
+        "count": "25"
+      }
+    ],
+    "coteditor": [
+      {
+        "cask": "coteditor",
+        "count": "213"
+      }
+    ],
+    "couchbase-server-community": [
+      {
+        "cask": "couchbase-server-community",
+        "count": "15"
+      }
+    ],
+    "couchbase-server-enterprise": [
+      {
+        "cask": "couchbase-server-enterprise",
+        "count": "1"
+      }
+    ],
+    "couchpotato": [
+      {
+        "cask": "couchpotato",
+        "count": "14"
+      }
+    ],
+    "couleurs": [
+      {
+        "cask": "couleurs",
+        "count": "11"
+      }
+    ],
+    "coverload": [
+      {
+        "cask": "coverload",
+        "count": "3"
+      }
+    ],
+    "cozy-drive": [
+      {
+        "cask": "cozy-drive",
+        "count": "5"
+      }
+    ],
+    "cpuinfo": [
+      {
+        "cask": "cpuinfo",
+        "count": "43"
+      }
+    ],
+    "cr": [
+      {
+        "cask": "cr",
+        "count": "4"
+      }
+    ],
+    "craftmanager": [
+      {
+        "cask": "craftmanager",
+        "count": "11"
+      }
+    ],
+    "create-recovery-partition-installer": [
+      {
+        "cask": "create-recovery-partition-installer",
+        "count": "9"
+      }
+    ],
+    "createuserpkg": [
+      {
+        "cask": "createuserpkg",
+        "count": "3"
+      }
+    ],
+    "creepy": [
+      {
+        "cask": "creepy",
+        "count": "5"
+      }
+    ],
+    "cricut-design-space": [
+      {
+        "cask": "cricut-design-space",
+        "count": "5"
+      }
+    ],
+    "criptext": [
+      {
+        "cask": "criptext",
+        "count": "1"
+      }
+    ],
+    "cronnix": [
+      {
+        "cask": "cronnix",
+        "count": "29"
+      }
+    ],
+    "crossover": [
+      {
+        "cask": "crossover",
+        "count": "117"
+      }
+    ],
+    "crosspack-avr": [
+      {
+        "cask": "crosspack-avr",
+        "count": "72"
+      }
+    ],
+    "crunch": [
+      {
+        "cask": "crunch",
+        "count": "23"
+      }
+    ],
+    "crushftp": [
+      {
+        "cask": "crushftp",
+        "count": "14"
+      }
+    ],
+    "crypt": [
+      {
+        "cask": "crypt",
+        "count": "28"
+      }
+    ],
+    "crypter": [
+      {
+        "cask": "crypter",
+        "count": "7"
+      }
+    ],
+    "cryptomator": [
+      {
+        "cask": "cryptomator",
+        "count": "342"
+      }
+    ],
+    "cryptr": [
+      {
+        "cask": "cryptr",
+        "count": "28"
+      }
+    ],
+    "crystalmaker": [
+      {
+        "cask": "crystalmaker",
+        "count": "4"
+      }
+    ],
+    "crystax-ndk": [
+      {
+        "cask": "crystax-ndk",
+        "count": "1"
+      }
+    ],
+    "cscreen": [
+      {
+        "cask": "cscreen",
+        "count": "629"
+      }
+    ],
+    "cube": [
+      {
+        "cask": "cube",
+        "count": "1"
+      }
+    ],
+    "cubicsdr": [
+      {
+        "cask": "cubicsdr",
+        "count": "72"
+      }
+    ],
+    "cuda-z": [
+      {
+        "cask": "cuda-z",
+        "count": "64"
+      }
+    ],
+    "cumulus": [
+      {
+        "cask": "cumulus",
+        "count": "2"
+      }
+    ],
+    "cura-lulzbot": [
+      {
+        "cask": "cura-lulzbot",
+        "count": "11"
+      }
+    ],
+    "curecon-qt": [
+      {
+        "cask": "curecon-qt",
+        "count": "1"
+      }
+    ],
+    "curio": [
+      {
+        "cask": "curio",
+        "count": "2"
+      }
+    ],
+    "cursorcerer": [
+      {
+        "cask": "cursorcerer",
+        "count": "10"
+      }
+    ],
+    "cursorsense": [
+      {
+        "cask": "cursorsense",
+        "count": "11"
+      }
+    ],
+    "cutbox": [
+      {
+        "cask": "cutbox",
+        "count": "2"
+      }
+    ],
+    "cuteclips": [
+      {
+        "cask": "cuteclips",
+        "count": "1"
+      }
+    ],
+    "cutesdr": [
+      {
+        "cask": "cutesdr",
+        "count": "5"
+      }
+    ],
+    "cutter": [
+      {
+        "cask": "cutter",
+        "count": "161"
+      }
+    ],
+    "cyberduck": [
+      {
+        "cask": "cyberduck",
+        "count": "2,178"
+      }
+    ],
+    "cyberghost-vpn": [
+      {
+        "cask": "cyberghost-vpn",
+        "count": "15"
+      }
+    ],
+    "cycling74-max": [
+      {
+        "cask": "cycling74-max",
+        "count": "6"
+      }
+    ],
+    "cytoscape": [
+      {
+        "cask": "cytoscape",
+        "count": "22"
+      }
+    ],
+    "daedalus": [
+      {
+        "cask": "daedalus",
+        "count": "2"
+      }
+    ],
+    "daemon-tools": [
+      {
+        "cask": "daemon-tools",
+        "count": "21"
+      }
+    ],
+    "daily-english-listening": [
+      {
+        "cask": "daily-english-listening",
+        "count": "1"
+      }
+    ],
+    "daisydisk": [
+      {
+        "cask": "daisydisk",
+        "count": "330"
+      }
+    ],
+    "dangerzone": [
+      {
+        "cask": "dangerzone",
+        "count": "3"
+      }
+    ],
+    "darktable": [
+      {
+        "cask": "darktable",
+        "count": "431"
+      }
+    ],
+    "darktable-dev": [
+      {
+        "cask": "darktable-dev",
+        "count": "2"
+      }
+    ],
+    "darwindumper": [
+      {
+        "cask": "darwindumper",
+        "count": "3"
+      }
+    ],
+    "dash": [
+      {
+        "cask": "dash",
+        "count": "1,281"
+      }
+    ],
+    "dash-dash": [
+      {
+        "cask": "dash-dash",
+        "count": "1"
+      }
+    ],
+    "dash2": [
+      {
+        "cask": "dash2",
+        "count": "2"
+      }
+    ],
+    "dash3": [
+      {
+        "cask": "dash3",
+        "count": "7"
+      }
+    ],
+    "dash4": [
+      {
+        "cask": "dash4",
+        "count": "30"
+      }
+    ],
+    "dashcam-viewer": [
+      {
+        "cask": "dashcam-viewer",
+        "count": "4"
+      }
+    ],
+    "dashlane": [
+      {
+        "cask": "dashlane",
+        "count": "159"
+      }
+    ],
+    "dat": [
+      {
+        "cask": "dat",
+        "count": "6"
+      }
+    ],
+    "data-integration": [
+      {
+        "cask": "data-integration",
+        "count": "41"
+      }
+    ],
+    "data-rescue": [
+      {
+        "cask": "data-rescue",
+        "count": "7"
+      }
+    ],
+    "data-science-studio": [
+      {
+        "cask": "data-science-studio",
+        "count": "21"
+      }
+    ],
+    "datadog-agent": [
+      {
+        "cask": "datadog-agent",
+        "count": "147"
+      }
+    ],
+    "datagraph": [
+      {
+        "cask": "datagraph",
+        "count": "34"
+      }
+    ],
+    "datagrip": [
+      {
+        "cask": "datagrip",
+        "count": "677"
+      }
+    ],
+    "dataloader": [
+      {
+        "cask": "dataloader",
+        "count": "11"
+      }
+    ],
+    "datovka": [
+      {
+        "cask": "datovka",
+        "count": "8"
+      }
+    ],
+    "datweatherdoe": [
+      {
+        "cask": "datweatherdoe",
+        "count": "27"
+      }
+    ],
+    "davmail": [
+      {
+        "cask": "davmail",
+        "count": "15"
+      }
+    ],
+    "dawnlabs-alchemy": [
+      {
+        "cask": "dawnlabs-alchemy",
+        "count": "1"
+      }
+    ],
+    "day-o": [
+      {
+        "cask": "day-o",
+        "count": "92"
+      }
+    ],
+    "db-browser-for-sqlite": [
+      {
+        "cask": "db-browser-for-sqlite",
+        "count": "3,089"
+      }
+    ],
+    "dbeaver-community": [
+      {
+        "cask": "dbeaver-community",
+        "count": "3,887"
+      }
+    ],
+    "dbeaver-enterprise": [
+      {
+        "cask": "dbeaver-enterprise",
+        "count": "41"
+      }
+    ],
+    "dbglass": [
+      {
+        "cask": "dbglass",
+        "count": "18"
+      }
+    ],
+    "dbkoda": [
+      {
+        "cask": "dbkoda",
+        "count": "11"
+      }
+    ],
+    "dbngin": [
+      {
+        "cask": "dbngin",
+        "count": "82"
+      }
+    ],
+    "dbschema": [
+      {
+        "cask": "dbschema",
+        "count": "16"
+      }
+    ],
+    "dbvisualizer": [
+      {
+        "cask": "dbvisualizer",
+        "count": "197"
+      }
+    ],
+    "dcommander": [
+      {
+        "cask": "dcommander",
+        "count": "11"
+      }
+    ],
+    "dcp-o-matic": [
+      {
+        "cask": "dcp-o-matic",
+        "count": "3"
+      }
+    ],
+    "dcp-o-matic-batch-converter": [
+      {
+        "cask": "dcp-o-matic-batch-converter",
+        "count": "2"
+      }
+    ],
+    "dcp-o-matic-encode-server": [
+      {
+        "cask": "dcp-o-matic-encode-server",
+        "count": "1"
+      }
+    ],
+    "dcp-o-matic-kdm-creator": [
+      {
+        "cask": "dcp-o-matic-kdm-creator",
+        "count": "2"
+      }
+    ],
+    "dcp-o-matic-player": [
+      {
+        "cask": "dcp-o-matic-player",
+        "count": "2"
+      }
+    ],
+    "dcv-viewer": [
+      {
+        "cask": "dcv-viewer",
+        "count": "1"
+      }
+    ],
+    "dd-utility": [
+      {
+        "cask": "dd-utility",
+        "count": "16"
+      }
+    ],
+    "deadbeef-devel": [
+      {
+        "cask": "deadbeef-devel",
+        "count": "12"
+      }
+    ],
+    "deadbolt": [
+      {
+        "cask": "deadbolt",
+        "count": "11"
+      }
+    ],
+    "deathtodsstore": [
+      {
+        "cask": "deathtodsstore",
+        "count": "4"
+      }
+    ],
+    "debookee": [
+      {
+        "cask": "debookee",
+        "count": "10"
+      }
+    ],
+    "deckset": [
+      {
+        "cask": "deckset",
+        "count": "53"
+      }
+    ],
+    "deco": [
+      {
+        "cask": "deco",
+        "count": "7"
+      }
+    ],
+    "decrediton": [
+      {
+        "cask": "decrediton",
+        "count": "3"
+      }
+    ],
+    "deeper": [
+      {
+        "cask": "deeper",
+        "count": "25"
+      }
+    ],
+    "deepgit": [
+      {
+        "cask": "deepgit",
+        "count": "10"
+      }
+    ],
+    "deepl": [
+      {
+        "cask": "deepl",
+        "count": "550"
+      }
+    ],
+    "deezer": [
+      {
+        "cask": "deezer",
+        "count": "151"
+      }
+    ],
+    "default-folder-x": [
+      {
+        "cask": "default-folder-x",
+        "count": "36"
+      }
+    ],
+    "deflemask": [
+      {
+        "cask": "deflemask",
+        "count": "1"
+      }
+    ],
+    "dejalu": [
+      {
+        "cask": "dejalu",
+        "count": "4"
+      }
+    ],
+    "delayedlauncher": [
+      {
+        "cask": "delayedlauncher",
+        "count": "1"
+      }
+    ],
+    "delighted": [
+      {
+        "cask": "delighted",
+        "count": "2"
+      }
+    ],
+    "delta": [
+      {
+        "cask": "delta",
+        "count": "4"
+      }
+    ],
+    "deltawalker": [
+      {
+        "cask": "deltawalker",
+        "count": "20"
+      }
+    ],
+    "deluge": [
+      {
+        "cask": "deluge",
+        "count": "285"
+      }
+    ],
+    "dendroscope": [
+      {
+        "cask": "dendroscope",
+        "count": "2"
+      }
+    ],
+    "denemo": [
+      {
+        "cask": "denemo",
+        "count": "5"
+      }
+    ],
+    "denpo": [
+      {
+        "cask": "denpo",
+        "count": "1"
+      }
+    ],
+    "denpo-cask": [
+      {
+        "cask": "denpo-cask",
+        "count": "1"
+      }
+    ],
+    "deploystudio": [
+      {
+        "cask": "deploystudio",
+        "count": "1"
+      }
+    ],
+    "desktoputility": [
+      {
+        "cask": "desktoputility",
+        "count": "6"
+      }
+    ],
+    "desmume": [
+      {
+        "cask": "desmume",
+        "count": "19"
+      }
+    ],
+    "detectx-swift": [
+      {
+        "cask": "detectx-swift",
+        "count": "10"
+      }
+    ],
+    "detexify": [
+      {
+        "cask": "detexify",
+        "count": "21"
+      }
+    ],
+    "detox-instruments": [
+      {
+        "cask": "detox-instruments",
+        "count": "57"
+      }
+    ],
+    "devdocs": [
+      {
+        "cask": "devdocs",
+        "count": "104"
+      }
+    ],
+    "devdocs-macos": [
+      {
+        "cask": "devdocs-macos",
+        "count": "16"
+      }
+    ],
+    "developerexcuses": [
+      {
+        "cask": "developerexcuses",
+        "count": "2"
+      }
+    ],
+    "devhub": [
+      {
+        "cask": "devhub",
+        "count": "12"
+      }
+    ],
+    "devolo-cockpit": [
+      {
+        "cask": "devolo-cockpit",
+        "count": "16"
+      }
+    ],
+    "devonagent": [
+      {
+        "cask": "devonagent",
+        "count": "13"
+      }
+    ],
+    "devonthink": [
+      {
+        "cask": "devonthink",
+        "count": "76"
+      }
+    ],
+    "devonthink-pro": [
+      {
+        "cask": "devonthink-pro",
+        "count": "2"
+      }
+    ],
+    "dexed": [
+      {
+        "cask": "dexed",
+        "count": "10"
+      }
+    ],
+    "dhs": [
+      {
+        "cask": "dhs",
+        "count": "17"
+      }
+    ],
+    "dia": [
+      {
+        "cask": "dia",
+        "count": "218"
+      }
+    ],
+    "dialpad": [
+      {
+        "cask": "dialpad",
+        "count": "10"
+      }
+    ],
+    "diashapes": [
+      {
+        "cask": "diashapes",
+        "count": "12"
+      }
+    ],
+    "dictater": [
+      {
+        "cask": "dictater",
+        "count": "2"
+      }
+    ],
+    "dictcc-en-de-dictionary-plugin": [
+      {
+        "cask": "dictcc-en-de-dictionary-plugin",
+        "count": "5"
+      }
+    ],
+    "dictionaries": [
+      {
+        "cask": "dictionaries",
+        "count": "22"
+      }
+    ],
+    "dictunifier": [
+      {
+        "cask": "dictunifier",
+        "count": "30"
+      }
+    ],
+    "difffork": [
+      {
+        "cask": "difffork",
+        "count": "4"
+      }
+    ],
+    "diffmerge": [
+      {
+        "cask": "diffmerge",
+        "count": "491"
+      }
+    ],
+    "digikam": [
+      {
+        "cask": "digikam",
+        "count": "83"
+      }
+    ],
+    "dingtalk": [
+      {
+        "cask": "dingtalk",
+        "count": "230"
+      }
+    ],
+    "disablemonitor": [
+      {
+        "cask": "disablemonitor",
+        "count": "24"
+      }
+    ],
+    "discord": [
+      {
+        "cask": "discord",
+        "count": "4,993"
+      }
+    ],
+    "discord-canary": [
+      {
+        "cask": "discord-canary",
+        "count": "21"
+      }
+    ],
+    "discord-ptb": [
+      {
+        "cask": "discord-ptb",
+        "count": "18"
+      }
+    ],
+    "discretescroll": [
+      {
+        "cask": "discretescroll",
+        "count": "8"
+      }
+    ],
+    "disk-arbitrator": [
+      {
+        "cask": "disk-arbitrator",
+        "count": "22"
+      }
+    ],
+    "disk-drill": [
+      {
+        "cask": "disk-drill",
+        "count": "111"
+      }
+    ],
+    "disk-inventory-x": [
+      {
+        "cask": "disk-inventory-x",
+        "count": "411"
+      }
+    ],
+    "diskcatalogmaker": [
+      {
+        "cask": "diskcatalogmaker",
+        "count": "5"
+      }
+    ],
+    "diskmaker-x": [
+      {
+        "cask": "diskmaker-x",
+        "count": "36"
+      }
+    ],
+    "diskwave": [
+      {
+        "cask": "diskwave",
+        "count": "31"
+      }
+    ],
+    "displaperture": [
+      {
+        "cask": "displaperture",
+        "count": "2"
+      }
+    ],
+    "displaycal": [
+      {
+        "cask": "displaycal",
+        "count": "37"
+      }
+    ],
+    "displaylink": [
+      {
+        "cask": "displaylink",
+        "count": "40"
+      }
+    ],
+    "dissenter-browser": [
+      {
+        "cask": "dissenter-browser",
+        "count": "4"
+      }
+    ],
+    "divvy": [
+      {
+        "cask": "divvy",
+        "count": "102"
+      }
+    ],
+    "djay-pro": [
+      {
+        "cask": "djay-pro",
+        "count": "15"
+      }
+    ],
+    "djv": [
+      {
+        "cask": "djv",
+        "count": "4"
+      }
+    ],
+    "djview": [
+      {
+        "cask": "djview",
+        "count": "80"
+      }
+    ],
+    "dlan-cockpit": [
+      {
+        "cask": "dlan-cockpit",
+        "count": "5"
+      }
+    ],
+    "dmenu": [
+      {
+        "cask": "dmenu",
+        "count": "9"
+      }
+    ],
+    "dmenu-mac": [
+      {
+        "cask": "dmenu-mac",
+        "count": "17"
+      }
+    ],
+    "dmm-player": [
+      {
+        "cask": "dmm-player",
+        "count": "6"
+      }
+    ],
+    "dnie": [
+      {
+        "cask": "dnie",
+        "count": "3"
+      }
+    ],
+    "do-not-disturb": [
+      {
+        "cask": "do-not-disturb",
+        "count": "26"
+      }
+    ],
+    "docear": [
+      {
+        "cask": "docear",
+        "count": "7"
+      }
+    ],
+    "docker": [
+      {
+        "cask": "docker",
+        "count": "17,070"
+      }
+    ],
+    "docker-2_1": [
+      {
+        "cask": "docker-2_1",
+        "count": "1"
+      }
+    ],
+    "docker-desktop": [
+      {
+        "cask": "docker-desktop",
+        "count": "1"
+      }
+    ],
+    "docker-edge": [
+      {
+        "cask": "docker-edge",
+        "count": "177"
+      }
+    ],
+    "docker-toolbox": [
+      {
+        "cask": "docker-toolbox",
+        "count": "423"
+      }
+    ],
+    "dockey": [
+      {
+        "cask": "dockey",
+        "count": "14"
+      }
+    ],
+    "dockstation": [
+      {
+        "cask": "dockstation",
+        "count": "29"
+      }
+    ],
+    "dogecoin": [
+      {
+        "cask": "dogecoin",
+        "count": "3"
+      }
+    ],
+    "dolphin": [
+      {
+        "cask": "dolphin",
+        "count": "83"
+      }
+    ],
+    "dolphin-dev": [
+      {
+        "cask": "dolphin-dev",
+        "count": "8"
+      }
+    ],
+    "doly": [
+      {
+        "cask": "doly",
+        "count": "2"
+      }
+    ],
+    "doomrl": [
+      {
+        "cask": "doomrl",
+        "count": "7"
+      }
+    ],
+    "doomsday-engine": [
+      {
+        "cask": "doomsday-engine",
+        "count": "3"
+      }
+    ],
+    "dosbox": [
+      {
+        "cask": "dosbox",
+        "count": "153"
+      }
+    ],
+    "dosbox-x": [
+      {
+        "cask": "dosbox-x",
+        "count": "44"
+      }
+    ],
+    "doteditor": [
+      {
+        "cask": "doteditor",
+        "count": "10"
+      }
+    ],
+    "dotnet": [
+      {
+        "cask": "dotnet",
+        "count": "665"
+      }
+    ],
+    "dotnet-preview": [
+      {
+        "cask": "dotnet-preview",
+        "count": "2"
+      }
+    ],
+    "dotnet-sdk": [
+      {
+        "cask": "dotnet-sdk",
+        "count": "1,367"
+      }
+    ],
+    "dotnet-sdk-2.1.400": [
+      {
+        "cask": "dotnet-sdk-2.1.400",
+        "count": "4"
+      }
+    ],
+    "dotnet-sdk-2.1.500": [
+      {
+        "cask": "dotnet-sdk-2.1.500",
+        "count": "2"
+      }
+    ],
+    "dotnet-sdk-2.1.800": [
+      {
+        "cask": "dotnet-sdk-2.1.800",
+        "count": "31"
+      }
+    ],
+    "dotnet-sdk-2.2.100": [
+      {
+        "cask": "dotnet-sdk-2.2.100",
+        "count": "31"
+      }
+    ],
+    "dotnet-sdk-2.2.200": [
+      {
+        "cask": "dotnet-sdk-2.2.200",
+        "count": "4"
+      }
+    ],
+    "dotnet-sdk-2.2.300": [
+      {
+        "cask": "dotnet-sdk-2.2.300",
+        "count": "5"
+      }
+    ],
+    "dotnet-sdk-2.2.400": [
+      {
+        "cask": "dotnet-sdk-2.2.400",
+        "count": "40"
+      }
+    ],
+    "dotnet-sdk-3.0.100": [
+      {
+        "cask": "dotnet-sdk-3.0.100",
+        "count": "4"
+      }
+    ],
+    "dotnet-sdk-3.1.100": [
+      {
+        "cask": "dotnet-sdk-3.1.100",
+        "count": "9"
+      }
+    ],
+    "dotnet-sdk-3.1.200": [
+      {
+        "cask": "dotnet-sdk-3.1.200",
+        "count": "62"
+      }
+    ],
+    "dotnet-sdk-pinned": [
+      {
+        "cask": "dotnet-sdk-pinned",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-preview": [
+      {
+        "cask": "dotnet-sdk-preview",
+        "count": "8"
+      }
+    ],
+    "double-commander": [
+      {
+        "cask": "double-commander",
+        "count": "138"
+      }
+    ],
+    "doubletwist": [
+      {
+        "cask": "doubletwist",
+        "count": "34"
+      }
+    ],
+    "downie": [
+      {
+        "cask": "downie",
+        "count": "210"
+      }
+    ],
+    "doxie": [
+      {
+        "cask": "doxie",
+        "count": "18"
+      }
+    ],
+    "doxygen": [
+      {
+        "cask": "doxygen",
+        "count": "50"
+      }
+    ],
+    "dozer": [
+      {
+        "cask": "dozer",
+        "count": "1,134"
+      }
+    ],
+    "drama": [
+      {
+        "cask": "drama",
+        "count": "5"
+      }
+    ],
+    "drawbot": [
+      {
+        "cask": "drawbot",
+        "count": "4"
+      }
+    ],
+    "drawio": [
+      {
+        "cask": "drawio",
+        "count": "1,395"
+      }
+    ],
+    "drivedx": [
+      {
+        "cask": "drivedx",
+        "count": "46"
+      }
+    ],
+    "drivethrurpg": [
+      {
+        "cask": "drivethrurpg",
+        "count": "9"
+      }
+    ],
+    "drobo-dashboard": [
+      {
+        "cask": "drobo-dashboard",
+        "count": "10"
+      }
+    ],
+    "droidid": [
+      {
+        "cask": "droidid",
+        "count": "3"
+      }
+    ],
+    "drop-to-gif": [
+      {
+        "cask": "drop-to-gif",
+        "count": "27"
+      }
+    ],
+    "dropbox": [
+      {
+        "cask": "dropbox",
+        "count": "2,202"
+      }
+    ],
+    "dropbox-beta": [
+      {
+        "cask": "dropbox-beta",
+        "count": "30"
+      }
+    ],
+    "dropbox-encore": [
+      {
+        "cask": "dropbox-encore",
+        "count": "4"
+      }
+    ],
+    "dropdmg": [
+      {
+        "cask": "dropdmg",
+        "count": "3"
+      }
+    ],
+    "dropletmanager": [
+      {
+        "cask": "dropletmanager",
+        "count": "6"
+      }
+    ],
+    "droplr": [
+      {
+        "cask": "droplr",
+        "count": "25"
+      }
+    ],
+    "dropshare": [
+      {
+        "cask": "dropshare",
+        "count": "11"
+      }
+    ],
+    "duckietv": [
+      {
+        "cask": "duckietv",
+        "count": "4"
+      }
+    ],
+    "duefocus": [
+      {
+        "cask": "duefocus",
+        "count": "1"
+      }
+    ],
+    "duet": [
+      {
+        "cask": "duet",
+        "count": "365"
+      }
+    ],
+    "dukto": [
+      {
+        "cask": "dukto",
+        "count": "8"
+      }
+    ],
+    "dungeon-crawl-stone-soup-console": [
+      {
+        "cask": "dungeon-crawl-stone-soup-console",
+        "count": "16"
+      }
+    ],
+    "dungeon-crawl-stone-soup-tiles": [
+      {
+        "cask": "dungeon-crawl-stone-soup-tiles",
+        "count": "23"
+      }
+    ],
+    "duo-connect": [
+      {
+        "cask": "duo-connect",
+        "count": "14"
+      }
+    ],
+    "dupeguru": [
+      {
+        "cask": "dupeguru",
+        "count": "84"
+      }
+    ],
+    "duplicacy": [
+      {
+        "cask": "duplicacy",
+        "count": "10"
+      }
+    ],
+    "duplicacy-web-edition": [
+      {
+        "cask": "duplicacy-web-edition",
+        "count": "6"
+      }
+    ],
+    "duplicate-annihilator-for-photos": [
+      {
+        "cask": "duplicate-annihilator-for-photos",
+        "count": "5"
+      }
+    ],
+    "duplicati": [
+      {
+        "cask": "duplicati",
+        "count": "40"
+      }
+    ],
+    "dupscanub": [
+      {
+        "cask": "dupscanub",
+        "count": "2"
+      }
+    ],
+    "dust3d": [
+      {
+        "cask": "dust3d",
+        "count": "7"
+      }
+    ],
+    "dvdstyler": [
+      {
+        "cask": "dvdstyler",
+        "count": "5"
+      }
+    ],
+    "dwarf-fortress": [
+      {
+        "cask": "dwarf-fortress",
+        "count": "65"
+      }
+    ],
+    "dwarf-fortress-lmp": [
+      {
+        "cask": "dwarf-fortress-lmp",
+        "count": "27"
+      }
+    ],
+    "dwgsee": [
+      {
+        "cask": "dwgsee",
+        "count": "12"
+      }
+    ],
+    "dwihn0r-keepassx": [
+      {
+        "cask": "dwihn0r-keepassx",
+        "count": "7"
+      }
+    ],
+    "dymo-label": [
+      {
+        "cask": "dymo-label",
+        "count": "7"
+      }
+    ],
+    "dyn-updater": [
+      {
+        "cask": "dyn-updater",
+        "count": "3"
+      }
+    ],
+    "dynalist": [
+      {
+        "cask": "dynalist",
+        "count": "25"
+      }
+    ],
+    "dynamic-dark-mode": [
+      {
+        "cask": "dynamic-dark-mode",
+        "count": "24"
+      }
+    ],
+    "dynamodb-local": [
+      {
+        "cask": "dynamodb-local",
+        "count": "98"
+      }
+    ],
+    "dynobase": [
+      {
+        "cask": "dynobase",
+        "count": "6"
+      }
+    ],
+    "dystextia": [
+      {
+        "cask": "dystextia",
+        "count": "1"
+      }
+    ],
+    "eagle": [
+      {
+        "cask": "eagle",
+        "count": "93"
+      }
+    ],
+    "eaglefiler": [
+      {
+        "cask": "eaglefiler",
+        "count": "11"
+      }
+    ],
+    "ealeksandrov-cd-to": [
+      {
+        "cask": "ealeksandrov-cd-to",
+        "count": "2"
+      }
+    ],
+    "easy-move-plus-resize": [
+      {
+        "cask": "easy-move-plus-resize",
+        "count": "86"
+      }
+    ],
+    "easyeda": [
+      {
+        "cask": "easyeda",
+        "count": "22"
+      }
+    ],
+    "easyfind": [
+      {
+        "cask": "easyfind",
+        "count": "76"
+      }
+    ],
+    "easytether": [
+      {
+        "cask": "easytether",
+        "count": "5"
+      }
+    ],
+    "ebmac": [
+      {
+        "cask": "ebmac",
+        "count": "6"
+      }
+    ],
+    "eclipse-cpp": [
+      {
+        "cask": "eclipse-cpp",
+        "count": "119"
+      }
+    ],
+    "eclipse-dsl": [
+      {
+        "cask": "eclipse-dsl",
+        "count": "2"
+      }
+    ],
+    "eclipse-ide": [
+      {
+        "cask": "eclipse-ide",
+        "count": "374"
+      }
+    ],
+    "eclipse-installer": [
+      {
+        "cask": "eclipse-installer",
+        "count": "71"
+      }
+    ],
+    "eclipse-java": [
+      {
+        "cask": "eclipse-java",
+        "count": "575"
+      }
+    ],
+    "eclipse-javascript": [
+      {
+        "cask": "eclipse-javascript",
+        "count": "23"
+      }
+    ],
+    "eclipse-jee": [
+      {
+        "cask": "eclipse-jee",
+        "count": "723"
+      }
+    ],
+    "eclipse-modeling": [
+      {
+        "cask": "eclipse-modeling",
+        "count": "15"
+      }
+    ],
+    "eclipse-php": [
+      {
+        "cask": "eclipse-php",
+        "count": "18"
+      }
+    ],
+    "eclipse-platform": [
+      {
+        "cask": "eclipse-platform",
+        "count": "23"
+      }
+    ],
+    "eclipse-rcp": [
+      {
+        "cask": "eclipse-rcp",
+        "count": "9"
+      }
+    ],
+    "eclipse-testing": [
+      {
+        "cask": "eclipse-testing",
+        "count": "3"
+      }
+    ],
+    "eddie": [
+      {
+        "cask": "eddie",
+        "count": "9"
+      }
+    ],
+    "edex-ui": [
+      {
+        "cask": "edex-ui",
+        "count": "53"
+      }
+    ],
+    "edfbrowser": [
+      {
+        "cask": "edfbrowser",
+        "count": "51"
+      }
+    ],
+    "editaro": [
+      {
+        "cask": "editaro",
+        "count": "1"
+      }
+    ],
+    "editready": [
+      {
+        "cask": "editready",
+        "count": "1"
+      }
+    ],
+    "edrawmax": [
+      {
+        "cask": "edrawmax",
+        "count": "19"
+      }
+    ],
+    "eggplant": [
+      {
+        "cask": "eggplant",
+        "count": "3"
+      }
+    ],
+    "eid-be": [
+      {
+        "cask": "eid-be",
+        "count": "2"
+      }
+    ],
+    "eid-be-viewer": [
+      {
+        "cask": "eid-be-viewer",
+        "count": "1"
+      }
+    ],
+    "eid-ee": [
+      {
+        "cask": "eid-ee",
+        "count": "1"
+      }
+    ],
+    "eiskaltdcpp": [
+      {
+        "cask": "eiskaltdcpp",
+        "count": "15"
+      }
+    ],
+    "ejectionseat": [
+      {
+        "cask": "ejectionseat",
+        "count": "1"
+      }
+    ],
+    "ejector": [
+      {
+        "cask": "ejector",
+        "count": "6"
+      }
+    ],
+    "elan": [
+      {
+        "cask": "elan",
+        "count": "2"
+      }
+    ],
+    "elasticwolf": [
+      {
+        "cask": "elasticwolf",
+        "count": "1"
+      }
+    ],
+    "electerm": [
+      {
+        "cask": "electerm",
+        "count": "51"
+      }
+    ],
+    "electorrent": [
+      {
+        "cask": "electorrent",
+        "count": "36"
+      }
+    ],
+    "electric-sheep": [
+      {
+        "cask": "electric-sheep",
+        "count": "9"
+      }
+    ],
+    "electrocrud": [
+      {
+        "cask": "electrocrud",
+        "count": "8"
+      }
+    ],
+    "electron": [
+      {
+        "cask": "electron",
+        "count": "193"
+      }
+    ],
+    "electron-api-demos": [
+      {
+        "cask": "electron-api-demos",
+        "count": "5"
+      }
+    ],
+    "electron-cash": [
+      {
+        "cask": "electron-cash",
+        "count": "8"
+      }
+    ],
+    "electron-fiddle": [
+      {
+        "cask": "electron-fiddle",
+        "count": "17"
+      }
+    ],
+    "electronic-wechat": [
+      {
+        "cask": "electronic-wechat",
+        "count": "5"
+      }
+    ],
+    "electronmail": [
+      {
+        "cask": "electronmail",
+        "count": "15"
+      }
+    ],
+    "electrum": [
+      {
+        "cask": "electrum",
+        "count": "108"
+      }
+    ],
+    "electrum-ltc": [
+      {
+        "cask": "electrum-ltc",
+        "count": "2"
+      }
+    ],
+    "elektron-overbridge": [
+      {
+        "cask": "elektron-overbridge",
+        "count": "8"
+      }
+    ],
+    "elektron-transfer": [
+      {
+        "cask": "elektron-transfer",
+        "count": "1"
+      }
+    ],
+    "elgato-control-center": [
+      {
+        "cask": "elgato-control-center",
+        "count": "8"
+      }
+    ],
+    "elgato-game-capture-hd": [
+      {
+        "cask": "elgato-game-capture-hd",
+        "count": "24"
+      }
+    ],
+    "elgato-stream-deck": [
+      {
+        "cask": "elgato-stream-deck",
+        "count": "20"
+      }
+    ],
+    "elgato-thunderbolt-dock": [
+      {
+        "cask": "elgato-thunderbolt-dock",
+        "count": "12"
+      }
+    ],
+    "elgato-video-capture": [
+      {
+        "cask": "elgato-video-capture",
+        "count": "4"
+      }
+    ],
+    "elmedia-player": [
+      {
+        "cask": "elmedia-player",
+        "count": "129"
+      }
+    ],
+    "eloston-chromium": [
+      {
+        "cask": "eloston-chromium",
+        "count": "495"
+      }
+    ],
+    "elpass": [
+      {
+        "cask": "elpass",
+        "count": "8"
+      }
+    ],
+    "emacs": [
+      {
+        "cask": "emacs",
+        "count": "4,650"
+      }
+    ],
+    "emacs-mac": [
+      {
+        "cask": "emacs-mac",
+        "count": "276"
+      }
+    ],
+    "emacs-mac-spacemacs-icon": [
+      {
+        "cask": "emacs-mac-spacemacs-icon",
+        "count": "49"
+      }
+    ],
+    "emacs-nightly": [
+      {
+        "cask": "emacs-nightly",
+        "count": "32"
+      }
+    ],
+    "emacs-pretest": [
+      {
+        "cask": "emacs-pretest",
+        "count": "35"
+      }
+    ],
+    "emacsclient": [
+      {
+        "cask": "emacsclient",
+        "count": "45"
+      }
+    ],
+    "emby-server": [
+      {
+        "cask": "emby-server",
+        "count": "32"
+      }
+    ],
+    "emclient": [
+      {
+        "cask": "emclient",
+        "count": "11"
+      }
+    ],
+    "eme": [
+      {
+        "cask": "eme",
+        "count": "1"
+      }
+    ],
+    "emojipedia": [
+      {
+        "cask": "emojipedia",
+        "count": "9"
+      }
+    ],
+    "empoche": [
+      {
+        "cask": "empoche",
+        "count": "5"
+      }
+    ],
+    "encryptme": [
+      {
+        "cask": "encryptme",
+        "count": "31"
+      }
+    ],
+    "encryptr": [
+      {
+        "cask": "encryptr",
+        "count": "2"
+      }
+    ],
+    "endless-sky": [
+      {
+        "cask": "endless-sky",
+        "count": "9"
+      }
+    ],
+    "endnote": [
+      {
+        "cask": "endnote",
+        "count": "23"
+      }
+    ],
+    "endurance": [
+      {
+        "cask": "endurance",
+        "count": "15"
+      }
+    ],
+    "energybar": [
+      {
+        "cask": "energybar",
+        "count": "13"
+      }
+    ],
+    "enfusegui": [
+      {
+        "cask": "enfusegui",
+        "count": "3"
+      }
+    ],
+    "engine-prime": [
+      {
+        "cask": "engine-prime",
+        "count": "3"
+      }
+    ],
+    "enjoyable": [
+      {
+        "cask": "enjoyable",
+        "count": "31"
+      }
+    ],
+    "enolsoft-chm-view": [
+      {
+        "cask": "enolsoft-chm-view",
+        "count": "14"
+      }
+    ],
+    "enpass": [
+      {
+        "cask": "enpass",
+        "count": "124"
+      }
+    ],
+    "entropy": [
+      {
+        "cask": "entropy",
+        "count": "5"
+      }
+    ],
+    "envkey": [
+      {
+        "cask": "envkey",
+        "count": "4"
+      }
+    ],
+    "enzymex": [
+      {
+        "cask": "enzymex",
+        "count": "1"
+      }
+    ],
+    "epic": [
+      {
+        "cask": "epic",
+        "count": "18"
+      }
+    ],
+    "epic-games": [
+      {
+        "cask": "epic-games",
+        "count": "232"
+      }
+    ],
+    "epichrome": [
+      {
+        "cask": "epichrome",
+        "count": "19"
+      }
+    ],
+    "epoch-flip-clock": [
+      {
+        "cask": "epoch-flip-clock",
+        "count": "2"
+      }
+    ],
+    "epub-services": [
+      {
+        "cask": "epub-services",
+        "count": "4"
+      }
+    ],
+    "epub-to-pdf": [
+      {
+        "cask": "epub-to-pdf",
+        "count": "15"
+      }
+    ],
+    "epubmdimporter": [
+      {
+        "cask": "epubmdimporter",
+        "count": "31"
+      }
+    ],
+    "epubquicklook": [
+      {
+        "cask": "epubquicklook",
+        "count": "83"
+      }
+    ],
+    "eqmac": [
+      {
+        "cask": "eqmac",
+        "count": "86"
+      }
+    ],
+    "eset-cyber-security-pro": [
+      {
+        "cask": "eset-cyber-security-pro",
+        "count": "14"
+      }
+    ],
+    "eset-endpoint-security": [
+      {
+        "cask": "eset-endpoint-security",
+        "count": "339"
+      }
+    ],
+    "espresso": [
+      {
+        "cask": "espresso",
+        "count": "11"
+      }
+    ],
+    "etcher": [
+      {
+        "cask": "etcher",
+        "count": "1"
+      }
+    ],
+    "ethereum-wallet": [
+      {
+        "cask": "ethereum-wallet",
+        "count": "10"
+      }
+    ],
+    "etrecheckpro": [
+      {
+        "cask": "etrecheckpro",
+        "count": "48"
+      }
+    ],
+    "eudic": [
+      {
+        "cask": "eudic",
+        "count": "54"
+      }
+    ],
+    "eurkey": [
+      {
+        "cask": "eurkey",
+        "count": "2"
+      }
+    ],
+    "eve-launcher": [
+      {
+        "cask": "eve-launcher",
+        "count": "20"
+      }
+    ],
+    "eventstore": [
+      {
+        "cask": "eventstore",
+        "count": "90"
+      }
+    ],
+    "evernote": [
+      {
+        "cask": "evernote",
+        "count": "756"
+      }
+    ],
+    "evolv-escribe-suite": [
+      {
+        "cask": "evolv-escribe-suite",
+        "count": "1"
+      }
+    ],
+    "evom": [
+      {
+        "cask": "evom",
+        "count": "2"
+      }
+    ],
+    "exactscan": [
+      {
+        "cask": "exactscan",
+        "count": "6"
+      }
+    ],
+    "exfalso": [
+      {
+        "cask": "exfalso",
+        "count": "8"
+      }
+    ],
+    "exifrenamer": [
+      {
+        "cask": "exifrenamer",
+        "count": "27"
+      }
+    ],
+    "exist-db": [
+      {
+        "cask": "exist-db",
+        "count": "6"
+      }
+    ],
+    "exmancmd": [
+      {
+        "cask": "exmancmd",
+        "count": "66"
+      }
+    ],
+    "exodus": [
+      {
+        "cask": "exodus",
+        "count": "70"
+      }
+    ],
+    "expandrive": [
+      {
+        "cask": "expandrive",
+        "count": "32"
+      }
+    ],
+    "explorer": [
+      {
+        "cask": "explorer",
+        "count": "2"
+      }
+    ],
+    "expo-xde": [
+      {
+        "cask": "expo-xde",
+        "count": "22"
+      }
+    ],
+    "expressions": [
+      {
+        "cask": "expressions",
+        "count": "15"
+      }
+    ],
+    "expressscribe": [
+      {
+        "cask": "expressscribe",
+        "count": "4"
+      }
+    ],
+    "expressvpn": [
+      {
+        "cask": "expressvpn",
+        "count": "258"
+      }
+    ],
+    "extraterm": [
+      {
+        "cask": "extraterm",
+        "count": "16"
+      }
+    ],
+    "ezip": [
+      {
+        "cask": "ezip",
+        "count": "129"
+      }
+    ],
+    "facebook-ios-sdk": [
+      {
+        "cask": "facebook-ios-sdk",
+        "count": "11"
+      }
+    ],
+    "factor": [
+      {
+        "cask": "factor",
+        "count": "12"
+      }
+    ],
+    "fake": [
+      {
+        "cask": "fake",
+        "count": "8"
+      }
+    ],
+    "falcon-sql-client": [
+      {
+        "cask": "falcon-sql-client",
+        "count": "122"
+      }
+    ],
+    "family-tree-builder": [
+      {
+        "cask": "family-tree-builder",
+        "count": "1"
+      }
+    ],
+    "fanny": [
+      {
+        "cask": "fanny",
+        "count": "127"
+      }
+    ],
+    "fantastical": [
+      {
+        "cask": "fantastical",
+        "count": "331"
+      }
+    ],
+    "fantasy-grounds": [
+      {
+        "cask": "fantasy-grounds",
+        "count": "6"
+      }
+    ],
+    "fantasy-map-generator": [
+      {
+        "cask": "fantasy-map-generator",
+        "count": "4"
+      }
+    ],
+    "farrago": [
+      {
+        "cask": "farrago",
+        "count": "19"
+      }
+    ],
+    "fastlane": [
+      {
+        "cask": "fastlane",
+        "count": "1,892"
+      }
+    ],
+    "fastonosql": [
+      {
+        "cask": "fastonosql",
+        "count": "5"
+      }
+    ],
+    "fastrawviewer": [
+      {
+        "cask": "fastrawviewer",
+        "count": "3"
+      }
+    ],
+    "fastscripts": [
+      {
+        "cask": "fastscripts",
+        "count": "5"
+      }
+    ],
+    "fauxpas": [
+      {
+        "cask": "fauxpas",
+        "count": "34"
+      }
+    ],
+    "favro": [
+      {
+        "cask": "favro",
+        "count": "2"
+      }
+    ],
+    "faxbot": [
+      {
+        "cask": "faxbot",
+        "count": "1"
+      }
+    ],
+    "fb3300": [
+      {
+        "cask": "fb3300",
+        "count": "2"
+      }
+    ],
+    "fbreader": [
+      {
+        "cask": "fbreader",
+        "count": "34"
+      }
+    ],
+    "fedora-media-writer": [
+      {
+        "cask": "fedora-media-writer",
+        "count": "25"
+      }
+    ],
+    "feed-the-beast": [
+      {
+        "cask": "feed-the-beast",
+        "count": "6"
+      }
+    ],
+    "feem": [
+      {
+        "cask": "feem",
+        "count": "6"
+      }
+    ],
+    "feishu": [
+      {
+        "cask": "feishu",
+        "count": "114"
+      }
+    ],
+    "fenix": [
+      {
+        "cask": "fenix",
+        "count": "3"
+      }
+    ],
+    "ferdi": [
+      {
+        "cask": "ferdi",
+        "count": "199"
+      }
+    ],
+    "ferdi-beta": [
+      {
+        "cask": "ferdi-beta",
+        "count": "5"
+      }
+    ],
+    "fetch": [
+      {
+        "cask": "fetch",
+        "count": "49"
+      }
+    ],
+    "ff-works": [
+      {
+        "cask": "ff-works",
+        "count": "18"
+      }
+    ],
+    "fiddler": [
+      {
+        "cask": "fiddler",
+        "count": "1"
+      }
+    ],
+    "figma": [
+      {
+        "cask": "figma",
+        "count": "688"
+      }
+    ],
+    "figmadaemon": [
+      {
+        "cask": "figmadaemon",
+        "count": "12"
+      }
+    ],
+    "figtree": [
+      {
+        "cask": "figtree",
+        "count": "18"
+      }
+    ],
+    "fiji": [
+      {
+        "cask": "fiji",
+        "count": "41"
+      }
+    ],
+    "file-juicer": [
+      {
+        "cask": "file-juicer",
+        "count": "9"
+      }
+    ],
+    "filebot": [
+      {
+        "cask": "filebot",
+        "count": "224"
+      }
+    ],
+    "filedrop": [
+      {
+        "cask": "filedrop",
+        "count": "6"
+      }
+    ],
+    "filemaker-pro-advanced": [
+      {
+        "cask": "filemaker-pro-advanced",
+        "count": "16"
+      }
+    ],
+    "filemon": [
+      {
+        "cask": "filemon",
+        "count": "9"
+      }
+    ],
+    "filepane": [
+      {
+        "cask": "filepane",
+        "count": "2"
+      }
+    ],
+    "filezilla": [
+      {
+        "cask": "filezilla",
+        "count": "2"
+      }
+    ],
+    "final-cut-library-manager": [
+      {
+        "cask": "final-cut-library-manager",
+        "count": "8"
+      }
+    ],
+    "find-any-file": [
+      {
+        "cask": "find-any-file",
+        "count": "15"
+      }
+    ],
+    "find-empty-folders": [
+      {
+        "cask": "find-empty-folders",
+        "count": "5"
+      }
+    ],
+    "findergo": [
+      {
+        "cask": "findergo",
+        "count": "33"
+      }
+    ],
+    "finereader": [
+      {
+        "cask": "finereader",
+        "count": "17"
+      }
+    ],
+    "fing": [
+      {
+        "cask": "fing",
+        "count": "155"
+      }
+    ],
+    "finicky": [
+      {
+        "cask": "finicky",
+        "count": "119"
+      }
+    ],
+    "firealpaca": [
+      {
+        "cask": "firealpaca",
+        "count": "47"
+      }
+    ],
+    "firebase-admin": [
+      {
+        "cask": "firebase-admin",
+        "count": "16"
+      }
+    ],
+    "firebird-emu": [
+      {
+        "cask": "firebird-emu",
+        "count": "4"
+      }
+    ],
+    "firecamp": [
+      {
+        "cask": "firecamp",
+        "count": "151"
+      }
+    ],
+    "firefox": [
+      {
+        "cask": "firefox",
+        "count": "10,059"
+      }
+    ],
+    "firefox-45": [
+      {
+        "cask": "firefox-45",
+        "count": "4"
+      }
+    ],
+    "firefox-beta": [
+      {
+        "cask": "firefox-beta",
+        "count": "43"
+      }
+    ],
+    "firefox-developer-edition": [
+      {
+        "cask": "firefox-developer-edition",
+        "count": "653"
+      }
+    ],
+    "firefox-esr": [
+      {
+        "cask": "firefox-esr",
+        "count": "73"
+      }
+    ],
+    "firefox-esr-52-2-1": [
+      {
+        "cask": "firefox-esr-52-2-1",
+        "count": "1"
+      }
+    ],
+    "firefox-nightly": [
+      {
+        "cask": "firefox-nightly",
+        "count": "170"
+      }
+    ],
+    "firestorm": [
+      {
+        "cask": "firestorm",
+        "count": "12"
+      }
+    ],
+    "firestorm-opensim": [
+      {
+        "cask": "firestorm-opensim",
+        "count": "2"
+      }
+    ],
+    "fiscript": [
+      {
+        "cask": "fiscript",
+        "count": "29"
+      }
+    ],
+    "fission": [
+      {
+        "cask": "fission",
+        "count": "30"
+      }
+    ],
+    "fitbit-connect": [
+      {
+        "cask": "fitbit-connect",
+        "count": "3"
+      }
+    ],
+    "fitbit-os-simulator": [
+      {
+        "cask": "fitbit-os-simulator",
+        "count": "4"
+      }
+    ],
+    "fl-studio": [
+      {
+        "cask": "fl-studio",
+        "count": "24"
+      }
+    ],
+    "flame": [
+      {
+        "cask": "flame",
+        "count": "2"
+      }
+    ],
+    "flash-decompiler-trillix": [
+      {
+        "cask": "flash-decompiler-trillix",
+        "count": "3"
+      }
+    ],
+    "flash-npapi": [
+      {
+        "cask": "flash-npapi",
+        "count": "670"
+      }
+    ],
+    "flash-player": [
+      {
+        "cask": "flash-player",
+        "count": "1,067"
+      }
+    ],
+    "flash-player-debugger": [
+      {
+        "cask": "flash-player-debugger",
+        "count": "6"
+      }
+    ],
+    "flash-player-debugger-npapi": [
+      {
+        "cask": "flash-player-debugger-npapi",
+        "count": "6"
+      }
+    ],
+    "flash-player-debugger-ppapi": [
+      {
+        "cask": "flash-player-debugger-ppapi",
+        "count": "3"
+      }
+    ],
+    "flash-ppapi": [
+      {
+        "cask": "flash-ppapi",
+        "count": "387"
+      }
+    ],
+    "flashforge-flashprint": [
+      {
+        "cask": "flashforge-flashprint",
+        "count": "4"
+      }
+    ],
+    "flashlighttool": [
+      {
+        "cask": "flashlighttool",
+        "count": "19"
+      }
+    ],
+    "flashprint": [
+      {
+        "cask": "flashprint",
+        "count": "1"
+      }
+    ],
+    "fldigi": [
+      {
+        "cask": "fldigi",
+        "count": "16"
+      }
+    ],
+    "flexiglass": [
+      {
+        "cask": "flexiglass",
+        "count": "13"
+      }
+    ],
+    "flic": [
+      {
+        "cask": "flic",
+        "count": "1"
+      }
+    ],
+    "flickr-uploadr": [
+      {
+        "cask": "flickr-uploadr",
+        "count": "1"
+      }
+    ],
+    "flightgear": [
+      {
+        "cask": "flightgear",
+        "count": "13"
+      }
+    ],
+    "flip4mac": [
+      {
+        "cask": "flip4mac",
+        "count": "9"
+      }
+    ],
+    "flipper": [
+      {
+        "cask": "flipper",
+        "count": "248"
+      }
+    ],
+    "fliqlo": [
+      {
+        "cask": "fliqlo",
+        "count": "153"
+      }
+    ],
+    "flirc": [
+      {
+        "cask": "flirc",
+        "count": "2"
+      }
+    ],
+    "flixtools": [
+      {
+        "cask": "flixtools",
+        "count": "30"
+      }
+    ],
+    "flock": [
+      {
+        "cask": "flock",
+        "count": "45"
+      }
+    ],
+    "flock-agent": [
+      {
+        "cask": "flock-agent",
+        "count": "6"
+      }
+    ],
+    "flotato": [
+      {
+        "cask": "flotato",
+        "count": "76"
+      }
+    ],
+    "flow": [
+      {
+        "cask": "flow",
+        "count": "6"
+      }
+    ],
+    "flowdock": [
+      {
+        "cask": "flowdock",
+        "count": "18"
+      }
+    ],
+    "flowsync": [
+      {
+        "cask": "flowsync",
+        "count": "5"
+      }
+    ],
+    "fluid": [
+      {
+        "cask": "fluid",
+        "count": "83"
+      }
+    ],
+    "flume": [
+      {
+        "cask": "flume",
+        "count": "90"
+      }
+    ],
+    "fluor": [
+      {
+        "cask": "fluor",
+        "count": "115"
+      }
+    ],
+    "flutter": [
+      {
+        "cask": "flutter",
+        "count": "55"
+      }
+    ],
+    "flux": [
+      {
+        "cask": "flux",
+        "count": "954"
+      }
+    ],
+    "flvcd-bigrats": [
+      {
+        "cask": "flvcd-bigrats",
+        "count": "1"
+      }
+    ],
+    "fly": [
+      {
+        "cask": "fly",
+        "count": "268"
+      }
+    ],
+    "flycut": [
+      {
+        "cask": "flycut",
+        "count": "310"
+      }
+    ],
+    "fman": [
+      {
+        "cask": "fman",
+        "count": "24"
+      }
+    ],
+    "fme-desktop": [
+      {
+        "cask": "fme-desktop",
+        "count": "2"
+      }
+    ],
+    "focus": [
+      {
+        "cask": "focus",
+        "count": "35"
+      }
+    ],
+    "focus-booster": [
+      {
+        "cask": "focus-booster",
+        "count": "8"
+      }
+    ],
+    "focusatwill": [
+      {
+        "cask": "focusatwill",
+        "count": "5"
+      }
+    ],
+    "focused": [
+      {
+        "cask": "focused",
+        "count": "6"
+      }
+    ],
+    "focusrite-control": [
+      {
+        "cask": "focusrite-control",
+        "count": "13"
+      }
+    ],
+    "focusrite-saffire-mixcontrol": [
+      {
+        "cask": "focusrite-saffire-mixcontrol",
+        "count": "4"
+      }
+    ],
+    "focuswriter": [
+      {
+        "cask": "focuswriter",
+        "count": "25"
+      }
+    ],
+    "fog": [
+      {
+        "cask": "fog",
+        "count": "9"
+      }
+    ],
+    "folding-at-home": [
+      {
+        "cask": "folding-at-home",
+        "count": "297"
+      }
+    ],
+    "foldingtext": [
+      {
+        "cask": "foldingtext",
+        "count": "9"
+      }
+    ],
+    "foldit": [
+      {
+        "cask": "foldit",
+        "count": "13"
+      }
+    ],
+    "folx": [
+      {
+        "cask": "folx",
+        "count": "366"
+      }
+    ],
+    "font-3270": [
+      {
+        "cask": "font-3270",
+        "count": "33"
+      }
+    ],
+    "font-3270-nerd-font": [
+      {
+        "cask": "font-3270-nerd-font",
+        "count": "84"
+      }
+    ],
+    "font-3270-nerd-font-mono": [
+      {
+        "cask": "font-3270-nerd-font-mono",
+        "count": "7"
+      }
+    ],
+    "font-abeezee": [
+      {
+        "cask": "font-abeezee",
+        "count": "11"
+      }
+    ],
+    "font-abel": [
+      {
+        "cask": "font-abel",
+        "count": "12"
+      }
+    ],
+    "font-aboriginal-sans": [
+      {
+        "cask": "font-aboriginal-sans",
+        "count": "11"
+      }
+    ],
+    "font-aboriginal-serif": [
+      {
+        "cask": "font-aboriginal-serif",
+        "count": "11"
+      }
+    ],
+    "font-abril-fatface": [
+      {
+        "cask": "font-abril-fatface",
+        "count": "11"
+      }
+    ],
+    "font-academicons": [
+      {
+        "cask": "font-academicons",
+        "count": "12"
+      }
+    ],
+    "font-aclonica": [
+      {
+        "cask": "font-aclonica",
+        "count": "9"
+      }
+    ],
+    "font-acme": [
+      {
+        "cask": "font-acme",
+        "count": "11"
+      }
+    ],
+    "font-actor": [
+      {
+        "cask": "font-actor",
+        "count": "10"
+      }
+    ],
+    "font-adamina": [
+      {
+        "cask": "font-adamina",
+        "count": "10"
+      }
+    ],
+    "font-adinatha-tamil-brahmi": [
+      {
+        "cask": "font-adinatha-tamil-brahmi",
+        "count": "9"
+      }
+    ],
+    "font-advent-pro": [
+      {
+        "cask": "font-advent-pro",
+        "count": "10"
+      }
+    ],
+    "font-african-sans": [
+      {
+        "cask": "font-african-sans",
+        "count": "10"
+      }
+    ],
+    "font-african-serif": [
+      {
+        "cask": "font-african-serif",
+        "count": "11"
+      }
+    ],
+    "font-agave-nerd-font": [
+      {
+        "cask": "font-agave-nerd-font",
+        "count": "39"
+      }
+    ],
+    "font-aguafina-script": [
+      {
+        "cask": "font-aguafina-script",
+        "count": "11"
+      }
+    ],
+    "font-ahuramzda": [
+      {
+        "cask": "font-ahuramzda",
+        "count": "11"
+      }
+    ],
+    "font-aileron": [
+      {
+        "cask": "font-aileron",
+        "count": "11"
+      }
+    ],
+    "font-akronim": [
+      {
+        "cask": "font-akronim",
+        "count": "10"
+      }
+    ],
+    "font-aladin": [
+      {
+        "cask": "font-aladin",
+        "count": "10"
+      }
+    ],
+    "font-aldrich": [
+      {
+        "cask": "font-aldrich",
+        "count": "10"
+      }
+    ],
+    "font-alef": [
+      {
+        "cask": "font-alef",
+        "count": "10"
+      }
+    ],
+    "font-alegreya": [
+      {
+        "cask": "font-alegreya",
+        "count": "18"
+      }
+    ],
+    "font-alegreya-sans": [
+      {
+        "cask": "font-alegreya-sans",
+        "count": "16"
+      }
+    ],
+    "font-alex-brush": [
+      {
+        "cask": "font-alex-brush",
+        "count": "10"
+      }
+    ],
+    "font-alfa-slab-one": [
+      {
+        "cask": "font-alfa-slab-one",
+        "count": "12"
+      }
+    ],
+    "font-alice": [
+      {
+        "cask": "font-alice",
+        "count": "12"
+      }
+    ],
+    "font-alike": [
+      {
+        "cask": "font-alike",
+        "count": "10"
+      }
+    ],
+    "font-alike-angular": [
+      {
+        "cask": "font-alike-angular",
+        "count": "10"
+      }
+    ],
+    "font-allan": [
+      {
+        "cask": "font-allan",
+        "count": "10"
+      }
+    ],
+    "font-allerta": [
+      {
+        "cask": "font-allerta",
+        "count": "10"
+      }
+    ],
+    "font-allerta-stencil": [
+      {
+        "cask": "font-allerta-stencil",
+        "count": "11"
+      }
+    ],
+    "font-allura": [
+      {
+        "cask": "font-allura",
+        "count": "11"
+      }
+    ],
+    "font-almendra": [
+      {
+        "cask": "font-almendra",
+        "count": "10"
+      }
+    ],
+    "font-almendra-display": [
+      {
+        "cask": "font-almendra-display",
+        "count": "10"
+      }
+    ],
+    "font-almendra-sc": [
+      {
+        "cask": "font-almendra-sc",
+        "count": "10"
+      }
+    ],
+    "font-amarante": [
+      {
+        "cask": "font-amarante",
+        "count": "10"
+      }
+    ],
+    "font-amaranth": [
+      {
+        "cask": "font-amaranth",
+        "count": "10"
+      }
+    ],
+    "font-amatic-sc": [
+      {
+        "cask": "font-amatic-sc",
+        "count": "10"
+      }
+    ],
+    "font-amethysta": [
+      {
+        "cask": "font-amethysta",
+        "count": "10"
+      }
+    ],
+    "font-amiri": [
+      {
+        "cask": "font-amiri",
+        "count": "9"
+      }
+    ],
+    "font-anaheim": [
+      {
+        "cask": "font-anaheim",
+        "count": "10"
+      }
+    ],
+    "font-andada": [
+      {
+        "cask": "font-andada",
+        "count": "11"
+      }
+    ],
+    "font-andada-sc": [
+      {
+        "cask": "font-andada-sc",
+        "count": "10"
+      }
+    ],
+    "font-andagii": [
+      {
+        "cask": "font-andagii",
+        "count": "9"
+      }
+    ],
+    "font-andale-mono": [
+      {
+        "cask": "font-andale-mono",
+        "count": "13"
+      }
+    ],
+    "font-andika": [
+      {
+        "cask": "font-andika",
+        "count": "10"
+      }
+    ],
+    "font-andron-scriptor-web": [
+      {
+        "cask": "font-andron-scriptor-web",
+        "count": "10"
+      }
+    ],
+    "font-angkor": [
+      {
+        "cask": "font-angkor",
+        "count": "9"
+      }
+    ],
+    "font-anka-coder": [
+      {
+        "cask": "font-anka-coder",
+        "count": "12"
+      }
+    ],
+    "font-annie-use-your-telescope": [
+      {
+        "cask": "font-annie-use-your-telescope",
+        "count": "10"
+      }
+    ],
+    "font-anonymice-nerd-font": [
+      {
+        "cask": "font-anonymice-nerd-font",
+        "count": "37"
+      }
+    ],
+    "font-anonymice-powerline": [
+      {
+        "cask": "font-anonymice-powerline",
+        "count": "46"
+      }
+    ],
+    "font-anonymous-pro": [
+      {
+        "cask": "font-anonymous-pro",
+        "count": "70"
+      }
+    ],
+    "font-anonymouspro-nerd-font": [
+      {
+        "cask": "font-anonymouspro-nerd-font",
+        "count": "9"
+      }
+    ],
+    "font-anonymouspro-nerd-font-mono": [
+      {
+        "cask": "font-anonymouspro-nerd-font-mono",
+        "count": "8"
+      }
+    ],
+    "font-antic": [
+      {
+        "cask": "font-antic",
+        "count": "9"
+      }
+    ],
+    "font-antic-didone": [
+      {
+        "cask": "font-antic-didone",
+        "count": "9"
+      }
+    ],
+    "font-antic-slab": [
+      {
+        "cask": "font-antic-slab",
+        "count": "9"
+      }
+    ],
+    "font-antinoou": [
+      {
+        "cask": "font-antinoou",
+        "count": "9"
+      }
+    ],
+    "font-anton": [
+      {
+        "cask": "font-anton",
+        "count": "9"
+      }
+    ],
+    "font-arapey": [
+      {
+        "cask": "font-arapey",
+        "count": "9"
+      }
+    ],
+    "font-arbutus": [
+      {
+        "cask": "font-arbutus",
+        "count": "9"
+      }
+    ],
+    "font-arbutus-slab": [
+      {
+        "cask": "font-arbutus-slab",
+        "count": "9"
+      }
+    ],
+    "font-architects-daughter": [
+      {
+        "cask": "font-architects-daughter",
+        "count": "11"
+      }
+    ],
+    "font-architype-renner": [
+      {
+        "cask": "font-architype-renner",
+        "count": "11"
+      }
+    ],
+    "font-archivo-black": [
+      {
+        "cask": "font-archivo-black",
+        "count": "9"
+      }
+    ],
+    "font-archivo-narrow": [
+      {
+        "cask": "font-archivo-narrow",
+        "count": "10"
+      }
+    ],
+    "font-arial": [
+      {
+        "cask": "font-arial",
+        "count": "11"
+      }
+    ],
+    "font-arial-black": [
+      {
+        "cask": "font-arial-black",
+        "count": "10"
+      }
+    ],
+    "font-arimo": [
+      {
+        "cask": "font-arimo",
+        "count": "12"
+      }
+    ],
+    "font-arimo-nerd-font": [
+      {
+        "cask": "font-arimo-nerd-font",
+        "count": "45"
+      }
+    ],
+    "font-arimo-nerd-font-mono": [
+      {
+        "cask": "font-arimo-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-arizonia": [
+      {
+        "cask": "font-arizonia",
+        "count": "9"
+      }
+    ],
+    "font-armata": [
+      {
+        "cask": "font-armata",
+        "count": "9"
+      }
+    ],
+    "font-artifika": [
+      {
+        "cask": "font-artifika",
+        "count": "9"
+      }
+    ],
+    "font-arvo": [
+      {
+        "cask": "font-arvo",
+        "count": "11"
+      }
+    ],
+    "font-asset": [
+      {
+        "cask": "font-asset",
+        "count": "9"
+      }
+    ],
+    "font-astloch": [
+      {
+        "cask": "font-astloch",
+        "count": "9"
+      }
+    ],
+    "font-asul": [
+      {
+        "cask": "font-asul",
+        "count": "9"
+      }
+    ],
+    "font-atomic-age": [
+      {
+        "cask": "font-atomic-age",
+        "count": "11"
+      }
+    ],
+    "font-aubrey": [
+      {
+        "cask": "font-aubrey",
+        "count": "9"
+      }
+    ],
+    "font-audiowide": [
+      {
+        "cask": "font-audiowide",
+        "count": "10"
+      }
+    ],
+    "font-aurulentsansmono-nerd-font": [
+      {
+        "cask": "font-aurulentsansmono-nerd-font",
+        "count": "45"
+      }
+    ],
+    "font-aurulentsansmono-nerd-font-mono": [
+      {
+        "cask": "font-aurulentsansmono-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-autour-one": [
+      {
+        "cask": "font-autour-one",
+        "count": "9"
+      }
+    ],
+    "font-average": [
+      {
+        "cask": "font-average",
+        "count": "10"
+      }
+    ],
+    "font-average-mono": [
+      {
+        "cask": "font-average-mono",
+        "count": "9"
+      }
+    ],
+    "font-average-sans": [
+      {
+        "cask": "font-average-sans",
+        "count": "8"
+      }
+    ],
+    "font-averia-gruesa-libre": [
+      {
+        "cask": "font-averia-gruesa-libre",
+        "count": "9"
+      }
+    ],
+    "font-averia-libre": [
+      {
+        "cask": "font-averia-libre",
+        "count": "10"
+      }
+    ],
+    "font-averia-sans-libre": [
+      {
+        "cask": "font-averia-sans-libre",
+        "count": "9"
+      }
+    ],
+    "font-averia-serif-libre": [
+      {
+        "cask": "font-averia-serif-libre",
+        "count": "10"
+      }
+    ],
+    "font-awesome-5-pro": [
+      {
+        "cask": "font-awesome-5-pro",
+        "count": "9"
+      }
+    ],
+    "font-awesome-terminal-fonts": [
+      {
+        "cask": "font-awesome-terminal-fonts",
+        "count": "118"
+      }
+    ],
+    "font-b612": [
+      {
+        "cask": "font-b612",
+        "count": "11"
+      }
+    ],
+    "font-bad-script": [
+      {
+        "cask": "font-bad-script",
+        "count": "10"
+      }
+    ],
+    "font-bahnschrift": [
+      {
+        "cask": "font-bahnschrift",
+        "count": "10"
+      }
+    ],
+    "font-baloo": [
+      {
+        "cask": "font-baloo",
+        "count": "9"
+      }
+    ],
+    "font-balsamiq-sans": [
+      {
+        "cask": "font-balsamiq-sans",
+        "count": "2"
+      }
+    ],
+    "font-balthazar": [
+      {
+        "cask": "font-balthazar",
+        "count": "8"
+      }
+    ],
+    "font-bangers": [
+      {
+        "cask": "font-bangers",
+        "count": "7"
+      }
+    ],
+    "font-barlow": [
+      {
+        "cask": "font-barlow",
+        "count": "9"
+      }
+    ],
+    "font-basic": [
+      {
+        "cask": "font-basic",
+        "count": "7"
+      }
+    ],
+    "font-battambang": [
+      {
+        "cask": "font-battambang",
+        "count": "8"
+      }
+    ],
+    "font-baumans": [
+      {
+        "cask": "font-baumans",
+        "count": "8"
+      }
+    ],
+    "font-bayon": [
+      {
+        "cask": "font-bayon",
+        "count": "6"
+      }
+    ],
+    "font-belgrano": [
+      {
+        "cask": "font-belgrano",
+        "count": "7"
+      }
+    ],
+    "font-belleza": [
+      {
+        "cask": "font-belleza",
+        "count": "7"
+      }
+    ],
+    "font-benchnine": [
+      {
+        "cask": "font-benchnine",
+        "count": "7"
+      }
+    ],
+    "font-bentham": [
+      {
+        "cask": "font-bentham",
+        "count": "7"
+      }
+    ],
+    "font-berkshire-swash": [
+      {
+        "cask": "font-berkshire-swash",
+        "count": "8"
+      }
+    ],
+    "font-bevan": [
+      {
+        "cask": "font-bevan",
+        "count": "7"
+      }
+    ],
+    "font-bigblue-terminal-nerd-font": [
+      {
+        "cask": "font-bigblue-terminal-nerd-font",
+        "count": "18"
+      }
+    ],
+    "font-bigelow-rules": [
+      {
+        "cask": "font-bigelow-rules",
+        "count": "7"
+      }
+    ],
+    "font-bigshot-one": [
+      {
+        "cask": "font-bigshot-one",
+        "count": "7"
+      }
+    ],
+    "font-bilbo": [
+      {
+        "cask": "font-bilbo",
+        "count": "7"
+      }
+    ],
+    "font-bilbo-swash-caps": [
+      {
+        "cask": "font-bilbo-swash-caps",
+        "count": "7"
+      }
+    ],
+    "font-bitstream-vera": [
+      {
+        "cask": "font-bitstream-vera",
+        "count": "19"
+      }
+    ],
+    "font-bitstreamverasansmono-nerd-font": [
+      {
+        "cask": "font-bitstreamverasansmono-nerd-font",
+        "count": "60"
+      }
+    ],
+    "font-bitstreamverasansmono-nerd-font-mono": [
+      {
+        "cask": "font-bitstreamverasansmono-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-bitter": [
+      {
+        "cask": "font-bitter",
+        "count": "10"
+      }
+    ],
+    "font-black-ops-one": [
+      {
+        "cask": "font-black-ops-one",
+        "count": "7"
+      }
+    ],
+    "font-blackout": [
+      {
+        "cask": "font-blackout",
+        "count": "7"
+      }
+    ],
+    "font-blexmono-nerd-font": [
+      {
+        "cask": "font-blexmono-nerd-font",
+        "count": "40"
+      }
+    ],
+    "font-blokk-neue": [
+      {
+        "cask": "font-blokk-neue",
+        "count": "7"
+      }
+    ],
+    "font-bokor": [
+      {
+        "cask": "font-bokor",
+        "count": "6"
+      }
+    ],
+    "font-bonbon": [
+      {
+        "cask": "font-bonbon",
+        "count": "7"
+      }
+    ],
+    "font-boogaloo": [
+      {
+        "cask": "font-boogaloo",
+        "count": "7"
+      }
+    ],
+    "font-bowlby-one": [
+      {
+        "cask": "font-bowlby-one",
+        "count": "7"
+      }
+    ],
+    "font-bowlby-one-sc": [
+      {
+        "cask": "font-bowlby-one-sc",
+        "count": "8"
+      }
+    ],
+    "font-brawler": [
+      {
+        "cask": "font-brawler",
+        "count": "7"
+      }
+    ],
+    "font-bree-serif": [
+      {
+        "cask": "font-bree-serif",
+        "count": "11"
+      }
+    ],
+    "font-brill": [
+      {
+        "cask": "font-brill",
+        "count": "7"
+      }
+    ],
+    "font-bubblegum-sans": [
+      {
+        "cask": "font-bubblegum-sans",
+        "count": "7"
+      }
+    ],
+    "font-bubbler-one": [
+      {
+        "cask": "font-bubbler-one",
+        "count": "7"
+      }
+    ],
+    "font-buda": [
+      {
+        "cask": "font-buda",
+        "count": "7"
+      }
+    ],
+    "font-buenard": [
+      {
+        "cask": "font-buenard",
+        "count": "7"
+      }
+    ],
+    "font-bukyvede-bold": [
+      {
+        "cask": "font-bukyvede-bold",
+        "count": "6"
+      }
+    ],
+    "font-bukyvede-italic": [
+      {
+        "cask": "font-bukyvede-italic",
+        "count": "7"
+      }
+    ],
+    "font-bukyvede-regular": [
+      {
+        "cask": "font-bukyvede-regular",
+        "count": "7"
+      }
+    ],
+    "font-bungee": [
+      {
+        "cask": "font-bungee",
+        "count": "7"
+      }
+    ],
+    "font-butcherman": [
+      {
+        "cask": "font-butcherman",
+        "count": "6"
+      }
+    ],
+    "font-butterfly-kids": [
+      {
+        "cask": "font-butterfly-kids",
+        "count": "7"
+      }
+    ],
+    "font-cabin": [
+      {
+        "cask": "font-cabin",
+        "count": "9"
+      }
+    ],
+    "font-cabin-condensed": [
+      {
+        "cask": "font-cabin-condensed",
+        "count": "8"
+      }
+    ],
+    "font-cabin-sketch": [
+      {
+        "cask": "font-cabin-sketch",
+        "count": "8"
+      }
+    ],
+    "font-caesar-dressing": [
+      {
+        "cask": "font-caesar-dressing",
+        "count": "8"
+      }
+    ],
+    "font-cagliostro": [
+      {
+        "cask": "font-cagliostro",
+        "count": "8"
+      }
+    ],
+    "font-calligraffitti": [
+      {
+        "cask": "font-calligraffitti",
+        "count": "8"
+      }
+    ],
+    "font-cambo": [
+      {
+        "cask": "font-cambo",
+        "count": "8"
+      }
+    ],
+    "font-camingocode": [
+      {
+        "cask": "font-camingocode",
+        "count": "20"
+      }
+    ],
+    "font-candal": [
+      {
+        "cask": "font-candal",
+        "count": "8"
+      }
+    ],
+    "font-cantarell": [
+      {
+        "cask": "font-cantarell",
+        "count": "9"
+      }
+    ],
+    "font-cantata-one": [
+      {
+        "cask": "font-cantata-one",
+        "count": "8"
+      }
+    ],
+    "font-cantora-one": [
+      {
+        "cask": "font-cantora-one",
+        "count": "8"
+      }
+    ],
+    "font-capriola": [
+      {
+        "cask": "font-capriola",
+        "count": "8"
+      }
+    ],
+    "font-cardo": [
+      {
+        "cask": "font-cardo",
+        "count": "11"
+      }
+    ],
+    "font-carme": [
+      {
+        "cask": "font-carme",
+        "count": "8"
+      }
+    ],
+    "font-carrois-gothic": [
+      {
+        "cask": "font-carrois-gothic",
+        "count": "8"
+      }
+    ],
+    "font-carrois-gothic-sc": [
+      {
+        "cask": "font-carrois-gothic-sc",
+        "count": "9"
+      }
+    ],
+    "font-carter-one": [
+      {
+        "cask": "font-carter-one",
+        "count": "8"
+      }
+    ],
+    "font-cascadia": [
+      {
+        "cask": "font-cascadia",
+        "count": "210"
+      }
+    ],
+    "font-cascadia-mono": [
+      {
+        "cask": "font-cascadia-mono",
+        "count": "98"
+      }
+    ],
+    "font-cascadia-mono-pl": [
+      {
+        "cask": "font-cascadia-mono-pl",
+        "count": "56"
+      }
+    ],
+    "font-cascadia-nerd-font": [
+      {
+        "cask": "font-cascadia-nerd-font",
+        "count": "28"
+      }
+    ],
+    "font-cascadia-nerd-font-mono": [
+      {
+        "cask": "font-cascadia-nerd-font-mono",
+        "count": "15"
+      }
+    ],
+    "font-cascadia-pl": [
+      {
+        "cask": "font-cascadia-pl",
+        "count": "52"
+      }
+    ],
+    "font-caskaydiacove-nerd-font": [
+      {
+        "cask": "font-caskaydiacove-nerd-font",
+        "count": "51"
+      }
+    ],
+    "font-caudex": [
+      {
+        "cask": "font-caudex",
+        "count": "8"
+      }
+    ],
+    "font-cedarville-cursive": [
+      {
+        "cask": "font-cedarville-cursive",
+        "count": "8"
+      }
+    ],
+    "font-ceviche-one": [
+      {
+        "cask": "font-ceviche-one",
+        "count": "8"
+      }
+    ],
+    "font-chalet": [
+      {
+        "cask": "font-chalet",
+        "count": "1"
+      }
+    ],
+    "font-changa-one": [
+      {
+        "cask": "font-changa-one",
+        "count": "9"
+      }
+    ],
+    "font-chango": [
+      {
+        "cask": "font-chango",
+        "count": "8"
+      }
+    ],
+    "font-chapbook": [
+      {
+        "cask": "font-chapbook",
+        "count": "9"
+      }
+    ],
+    "font-charis-sil": [
+      {
+        "cask": "font-charis-sil",
+        "count": "9"
+      }
+    ],
+    "font-charter": [
+      {
+        "cask": "font-charter",
+        "count": "13"
+      }
+    ],
+    "font-chau-philomene-one": [
+      {
+        "cask": "font-chau-philomene-one",
+        "count": "8"
+      }
+    ],
+    "font-chela-one": [
+      {
+        "cask": "font-chela-one",
+        "count": "8"
+      }
+    ],
+    "font-chelsea-market": [
+      {
+        "cask": "font-chelsea-market",
+        "count": "8"
+      }
+    ],
+    "font-chenla": [
+      {
+        "cask": "font-chenla",
+        "count": "8"
+      }
+    ],
+    "font-cherry-cream-soda": [
+      {
+        "cask": "font-cherry-cream-soda",
+        "count": "8"
+      }
+    ],
+    "font-cherry-swash": [
+      {
+        "cask": "font-cherry-swash",
+        "count": "8"
+      }
+    ],
+    "font-chewy": [
+      {
+        "cask": "font-chewy",
+        "count": "9"
+      }
+    ],
+    "font-chicle": [
+      {
+        "cask": "font-chicle",
+        "count": "8"
+      }
+    ],
+    "font-chivo": [
+      {
+        "cask": "font-chivo",
+        "count": "11"
+      }
+    ],
+    "font-church-slavonic": [
+      {
+        "cask": "font-church-slavonic",
+        "count": "8"
+      }
+    ],
+    "font-cica": [
+      {
+        "cask": "font-cica",
+        "count": "56"
+      }
+    ],
+    "font-cinzel": [
+      {
+        "cask": "font-cinzel",
+        "count": "9"
+      }
+    ],
+    "font-cinzel-decorative": [
+      {
+        "cask": "font-cinzel-decorative",
+        "count": "8"
+      }
+    ],
+    "font-clear-sans": [
+      {
+        "cask": "font-clear-sans",
+        "count": "17"
+      }
+    ],
+    "font-clicker-script": [
+      {
+        "cask": "font-clicker-script",
+        "count": "8"
+      }
+    ],
+    "font-cochineal": [
+      {
+        "cask": "font-cochineal",
+        "count": "8"
+      }
+    ],
+    "font-coda": [
+      {
+        "cask": "font-coda",
+        "count": "9"
+      }
+    ],
+    "font-coda-caption": [
+      {
+        "cask": "font-coda-caption",
+        "count": "8"
+      }
+    ],
+    "font-code2002": [
+      {
+        "cask": "font-code2002",
+        "count": "8"
+      }
+    ],
+    "font-codenewroman-nerd-font": [
+      {
+        "cask": "font-codenewroman-nerd-font",
+        "count": "58"
+      }
+    ],
+    "font-codenewroman-nerd-font-mono": [
+      {
+        "cask": "font-codenewroman-nerd-font-mono",
+        "count": "4"
+      }
+    ],
+    "font-codystar": [
+      {
+        "cask": "font-codystar",
+        "count": "8"
+      }
+    ],
+    "font-combo": [
+      {
+        "cask": "font-combo",
+        "count": "8"
+      }
+    ],
+    "font-comfortaa": [
+      {
+        "cask": "font-comfortaa",
+        "count": "9"
+      }
+    ],
+    "font-comic-neue": [
+      {
+        "cask": "font-comic-neue",
+        "count": "11"
+      }
+    ],
+    "font-comic-sans-ms": [
+      {
+        "cask": "font-comic-sans-ms",
+        "count": "10"
+      }
+    ],
+    "font-coming-soon": [
+      {
+        "cask": "font-coming-soon",
+        "count": "8"
+      }
+    ],
+    "font-computer-modern": [
+      {
+        "cask": "font-computer-modern",
+        "count": "55"
+      }
+    ],
+    "font-conakry": [
+      {
+        "cask": "font-conakry",
+        "count": "7"
+      }
+    ],
+    "font-concert-one": [
+      {
+        "cask": "font-concert-one",
+        "count": "8"
+      }
+    ],
+    "font-condiment": [
+      {
+        "cask": "font-condiment",
+        "count": "7"
+      }
+    ],
+    "font-consolas-for-powerline": [
+      {
+        "cask": "font-consolas-for-powerline",
+        "count": "119"
+      }
+    ],
+    "font-constructium": [
+      {
+        "cask": "font-constructium",
+        "count": "6"
+      }
+    ],
+    "font-content": [
+      {
+        "cask": "font-content",
+        "count": "7"
+      }
+    ],
+    "font-contrail-one": [
+      {
+        "cask": "font-contrail-one",
+        "count": "7"
+      }
+    ],
+    "font-convergence": [
+      {
+        "cask": "font-convergence",
+        "count": "7"
+      }
+    ],
+    "font-cookie": [
+      {
+        "cask": "font-cookie",
+        "count": "8"
+      }
+    ],
+    "font-cooper-hewitt": [
+      {
+        "cask": "font-cooper-hewitt",
+        "count": "9"
+      }
+    ],
+    "font-copse": [
+      {
+        "cask": "font-copse",
+        "count": "7"
+      }
+    ],
+    "font-corben": [
+      {
+        "cask": "font-corben",
+        "count": "8"
+      }
+    ],
+    "font-cormorant": [
+      {
+        "cask": "font-cormorant",
+        "count": "10"
+      }
+    ],
+    "font-courgette": [
+      {
+        "cask": "font-courgette",
+        "count": "8"
+      }
+    ],
+    "font-courier-new": [
+      {
+        "cask": "font-courier-new",
+        "count": "11"
+      }
+    ],
+    "font-courier-prime": [
+      {
+        "cask": "font-courier-prime",
+        "count": "24"
+      }
+    ],
+    "font-courier-prime-code": [
+      {
+        "cask": "font-courier-prime-code",
+        "count": "21"
+      }
+    ],
+    "font-courier-prime-medium-and-semi-bold": [
+      {
+        "cask": "font-courier-prime-medium-and-semi-bold",
+        "count": "12"
+      }
+    ],
+    "font-courier-prime-sans": [
+      {
+        "cask": "font-courier-prime-sans",
+        "count": "16"
+      }
+    ],
+    "font-cousine": [
+      {
+        "cask": "font-cousine",
+        "count": "12"
+      }
+    ],
+    "font-cousine-nerd-font": [
+      {
+        "cask": "font-cousine-nerd-font",
+        "count": "48"
+      }
+    ],
+    "font-cousine-nerd-font-mono": [
+      {
+        "cask": "font-cousine-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-coustard": [
+      {
+        "cask": "font-coustard",
+        "count": "7"
+      }
+    ],
+    "font-covered-by-your-grace": [
+      {
+        "cask": "font-covered-by-your-grace",
+        "count": "7"
+      }
+    ],
+    "font-cozette": [
+      {
+        "cask": "font-cozette",
+        "count": "21"
+      }
+    ],
+    "font-crafty-girls": [
+      {
+        "cask": "font-crafty-girls",
+        "count": "7"
+      }
+    ],
+    "font-creepster": [
+      {
+        "cask": "font-creepster",
+        "count": "7"
+      }
+    ],
+    "font-crete-round": [
+      {
+        "cask": "font-crete-round",
+        "count": "7"
+      }
+    ],
+    "font-crimson-pro": [
+      {
+        "cask": "font-crimson-pro",
+        "count": "6"
+      }
+    ],
+    "font-crimson-text": [
+      {
+        "cask": "font-crimson-text",
+        "count": "17"
+      }
+    ],
+    "font-croissant-one": [
+      {
+        "cask": "font-croissant-one",
+        "count": "7"
+      }
+    ],
+    "font-crushed": [
+      {
+        "cask": "font-crushed",
+        "count": "7"
+      }
+    ],
+    "font-cuprum": [
+      {
+        "cask": "font-cuprum",
+        "count": "8"
+      }
+    ],
+    "font-cutive": [
+      {
+        "cask": "font-cutive",
+        "count": "7"
+      }
+    ],
+    "font-cutive-mono": [
+      {
+        "cask": "font-cutive-mono",
+        "count": "6"
+      }
+    ],
+    "font-d2coding": [
+      {
+        "cask": "font-d2coding",
+        "count": "53"
+      }
+    ],
+    "font-daddytimemono-nerd-font": [
+      {
+        "cask": "font-daddytimemono-nerd-font",
+        "count": "29"
+      }
+    ],
+    "font-damion": [
+      {
+        "cask": "font-damion",
+        "count": "8"
+      }
+    ],
+    "font-dancing-script": [
+      {
+        "cask": "font-dancing-script",
+        "count": "8"
+      }
+    ],
+    "font-dashicons": [
+      {
+        "cask": "font-dashicons",
+        "count": "32"
+      }
+    ],
+    "font-david-clm": [
+      {
+        "cask": "font-david-clm",
+        "count": "7"
+      }
+    ],
+    "font-dawning-of-a-new-day": [
+      {
+        "cask": "font-dawning-of-a-new-day",
+        "count": "8"
+      }
+    ],
+    "font-days-one": [
+      {
+        "cask": "font-days-one",
+        "count": "8"
+      }
+    ],
+    "font-dejavu": [
+      {
+        "cask": "font-dejavu",
+        "count": "67"
+      }
+    ],
+    "font-dejavu-sans": [
+      {
+        "cask": "font-dejavu-sans",
+        "count": "38"
+      }
+    ],
+    "font-dejavu-sans-mono-for-powerline": [
+      {
+        "cask": "font-dejavu-sans-mono-for-powerline",
+        "count": "67"
+      }
+    ],
+    "font-dejavusansmono-nerd-font": [
+      {
+        "cask": "font-dejavusansmono-nerd-font",
+        "count": "133"
+      }
+    ],
+    "font-dejavusansmono-nerd-font-mono": [
+      {
+        "cask": "font-dejavusansmono-nerd-font-mono",
+        "count": "12"
+      }
+    ],
+    "font-delius": [
+      {
+        "cask": "font-delius",
+        "count": "8"
+      }
+    ],
+    "font-delius-swash-caps": [
+      {
+        "cask": "font-delius-swash-caps",
+        "count": "8"
+      }
+    ],
+    "font-delius-unicase": [
+      {
+        "cask": "font-delius-unicase",
+        "count": "8"
+      }
+    ],
+    "font-della-respira": [
+      {
+        "cask": "font-della-respira",
+        "count": "9"
+      }
+    ],
+    "font-denk-one": [
+      {
+        "cask": "font-denk-one",
+        "count": "9"
+      }
+    ],
+    "font-devicons": [
+      {
+        "cask": "font-devicons",
+        "count": "43"
+      }
+    ],
+    "font-devonshire": [
+      {
+        "cask": "font-devonshire",
+        "count": "8"
+      }
+    ],
+    "font-dhyana": [
+      {
+        "cask": "font-dhyana",
+        "count": "8"
+      }
+    ],
+    "font-didact-gothic": [
+      {
+        "cask": "font-didact-gothic",
+        "count": "8"
+      }
+    ],
+    "font-digohweli-old-do": [
+      {
+        "cask": "font-digohweli-old-do",
+        "count": "8"
+      }
+    ],
+    "font-diplomata": [
+      {
+        "cask": "font-diplomata",
+        "count": "8"
+      }
+    ],
+    "font-diplomata-sc": [
+      {
+        "cask": "font-diplomata-sc",
+        "count": "9"
+      }
+    ],
+    "font-domine": [
+      {
+        "cask": "font-domine",
+        "count": "9"
+      }
+    ],
+    "font-donegal-one": [
+      {
+        "cask": "font-donegal-one",
+        "count": "8"
+      }
+    ],
+    "font-doppio-one": [
+      {
+        "cask": "font-doppio-one",
+        "count": "8"
+      }
+    ],
+    "font-dorsa": [
+      {
+        "cask": "font-dorsa",
+        "count": "8"
+      }
+    ],
+    "font-dosis": [
+      {
+        "cask": "font-dosis",
+        "count": "12"
+      }
+    ],
+    "font-doulos-sil": [
+      {
+        "cask": "font-doulos-sil",
+        "count": "8"
+      }
+    ],
+    "font-droid-sans-mono-for-powerline": [
+      {
+        "cask": "font-droid-sans-mono-for-powerline",
+        "count": "70"
+      }
+    ],
+    "font-droidsansmono-nerd-font": [
+      {
+        "cask": "font-droidsansmono-nerd-font",
+        "count": "117"
+      }
+    ],
+    "font-droidsansmono-nerd-font-mono": [
+      {
+        "cask": "font-droidsansmono-nerd-font-mono",
+        "count": "11"
+      }
+    ],
+    "font-duru-sans": [
+      {
+        "cask": "font-duru-sans",
+        "count": "9"
+      }
+    ],
+    "font-dynalight": [
+      {
+        "cask": "font-dynalight",
+        "count": "9"
+      }
+    ],
+    "font-eagle-lake": [
+      {
+        "cask": "font-eagle-lake",
+        "count": "8"
+      }
+    ],
+    "font-eater": [
+      {
+        "cask": "font-eater",
+        "count": "8"
+      }
+    ],
+    "font-eb-garamond": [
+      {
+        "cask": "font-eb-garamond",
+        "count": "29"
+      }
+    ],
+    "font-economica": [
+      {
+        "cask": "font-economica",
+        "count": "8"
+      }
+    ],
+    "font-edlo": [
+      {
+        "cask": "font-edlo",
+        "count": "8"
+      }
+    ],
+    "font-electrolize": [
+      {
+        "cask": "font-electrolize",
+        "count": "8"
+      }
+    ],
+    "font-elsie": [
+      {
+        "cask": "font-elsie",
+        "count": "8"
+      }
+    ],
+    "font-elsie-swash-caps": [
+      {
+        "cask": "font-elsie-swash-caps",
+        "count": "8"
+      }
+    ],
+    "font-emilys-candy": [
+      {
+        "cask": "font-emilys-candy",
+        "count": "8"
+      }
+    ],
+    "font-encodesans": [
+      {
+        "cask": "font-encodesans",
+        "count": "8"
+      }
+    ],
+    "font-encodesans-condensed": [
+      {
+        "cask": "font-encodesans-condensed",
+        "count": "9"
+      }
+    ],
+    "font-encodesans-expanded": [
+      {
+        "cask": "font-encodesans-expanded",
+        "count": "8"
+      }
+    ],
+    "font-encodesans-semicondensed": [
+      {
+        "cask": "font-encodesans-semicondensed",
+        "count": "8"
+      }
+    ],
+    "font-encodesans-semiexpanded": [
+      {
+        "cask": "font-encodesans-semiexpanded",
+        "count": "8"
+      }
+    ],
+    "font-engagement": [
+      {
+        "cask": "font-engagement",
+        "count": "9"
+      }
+    ],
+    "font-englebert": [
+      {
+        "cask": "font-englebert",
+        "count": "8"
+      }
+    ],
+    "font-enriqueta": [
+      {
+        "cask": "font-enriqueta",
+        "count": "8"
+      }
+    ],
+    "font-envy-code-r": [
+      {
+        "cask": "font-envy-code-r",
+        "count": "18"
+      }
+    ],
+    "font-erica-one": [
+      {
+        "cask": "font-erica-one",
+        "count": "8"
+      }
+    ],
+    "font-esteban": [
+      {
+        "cask": "font-esteban",
+        "count": "8"
+      }
+    ],
+    "font-et-book": [
+      {
+        "cask": "font-et-book",
+        "count": "17"
+      }
+    ],
+    "font-euphoria-script": [
+      {
+        "cask": "font-euphoria-script",
+        "count": "9"
+      }
+    ],
+    "font-everson-mono": [
+      {
+        "cask": "font-everson-mono",
+        "count": "10"
+      }
+    ],
+    "font-ewert": [
+      {
+        "cask": "font-ewert",
+        "count": "8"
+      }
+    ],
+    "font-exo": [
+      {
+        "cask": "font-exo",
+        "count": "10"
+      }
+    ],
+    "font-exo2": [
+      {
+        "cask": "font-exo2",
+        "count": "11"
+      }
+    ],
+    "font-ezra-sil": [
+      {
+        "cask": "font-ezra-sil",
+        "count": "10"
+      }
+    ],
+    "font-fairfax": [
+      {
+        "cask": "font-fairfax",
+        "count": "8"
+      }
+    ],
+    "font-fandol": [
+      {
+        "cask": "font-fandol",
+        "count": "9"
+      }
+    ],
+    "font-fantasque-sans-mono": [
+      {
+        "cask": "font-fantasque-sans-mono",
+        "count": "123"
+      }
+    ],
+    "font-fantasque-sans-mono-noloopk": [
+      {
+        "cask": "font-fantasque-sans-mono-noloopk",
+        "count": "7"
+      }
+    ],
+    "font-fantasquesansmono-nerd-font": [
+      {
+        "cask": "font-fantasquesansmono-nerd-font",
+        "count": "53"
+      }
+    ],
+    "font-fantasquesansmono-nerd-font-mono": [
+      {
+        "cask": "font-fantasquesansmono-nerd-font-mono",
+        "count": "9"
+      }
+    ],
+    "font-fanwood-text": [
+      {
+        "cask": "font-fanwood-text",
+        "count": "8"
+      }
+    ],
+    "font-fascinate": [
+      {
+        "cask": "font-fascinate",
+        "count": "9"
+      }
+    ],
+    "font-fascinate-inline": [
+      {
+        "cask": "font-fascinate-inline",
+        "count": "8"
+      }
+    ],
+    "font-faster-one": [
+      {
+        "cask": "font-faster-one",
+        "count": "8"
+      }
+    ],
+    "font-fasthand": [
+      {
+        "cask": "font-fasthand",
+        "count": "8"
+      }
+    ],
+    "font-fauna-one": [
+      {
+        "cask": "font-fauna-one",
+        "count": "8"
+      }
+    ],
+    "font-federant": [
+      {
+        "cask": "font-federant",
+        "count": "8"
+      }
+    ],
+    "font-federo": [
+      {
+        "cask": "font-federo",
+        "count": "8"
+      }
+    ],
+    "font-felipa": [
+      {
+        "cask": "font-felipa",
+        "count": "8"
+      }
+    ],
+    "font-fenix": [
+      {
+        "cask": "font-fenix",
+        "count": "8"
+      }
+    ],
+    "font-finger-paint": [
+      {
+        "cask": "font-finger-paint",
+        "count": "8"
+      }
+    ],
+    "font-fira-code": [
+      {
+        "cask": "font-fira-code",
+        "count": "4,492"
+      }
+    ],
+    "font-fira-mono": [
+      {
+        "cask": "font-fira-mono",
+        "count": "217"
+      }
+    ],
+    "font-fira-mono-for-powerline": [
+      {
+        "cask": "font-fira-mono-for-powerline",
+        "count": "139"
+      }
+    ],
+    "font-fira-sans": [
+      {
+        "cask": "font-fira-sans",
+        "count": "133"
+      }
+    ],
+    "font-firacode-nerd-font": [
+      {
+        "cask": "font-firacode-nerd-font",
+        "count": "714"
+      }
+    ],
+    "font-firacode-nerd-font-mono": [
+      {
+        "cask": "font-firacode-nerd-font-mono",
+        "count": "44"
+      }
+    ],
+    "font-firamono-nerd-font": [
+      {
+        "cask": "font-firamono-nerd-font",
+        "count": "149"
+      }
+    ],
+    "font-firamono-nerd-font-mono": [
+      {
+        "cask": "font-firamono-nerd-font-mono",
+        "count": "11"
+      }
+    ],
+    "font-fjalla-one": [
+      {
+        "cask": "font-fjalla-one",
+        "count": "8"
+      }
+    ],
+    "font-fjord-one": [
+      {
+        "cask": "font-fjord-one",
+        "count": "8"
+      }
+    ],
+    "font-flamenco": [
+      {
+        "cask": "font-flamenco",
+        "count": "8"
+      }
+    ],
+    "font-flavors": [
+      {
+        "cask": "font-flavors",
+        "count": "8"
+      }
+    ],
+    "font-fondamento": [
+      {
+        "cask": "font-fondamento",
+        "count": "8"
+      }
+    ],
+    "font-fontawesome": [
+      {
+        "cask": "font-fontawesome",
+        "count": "178"
+      }
+    ],
+    "font-fontdiner-swanky": [
+      {
+        "cask": "font-fontdiner-swanky",
+        "count": "8"
+      }
+    ],
+    "font-forum": [
+      {
+        "cask": "font-forum",
+        "count": "9"
+      }
+    ],
+    "font-foundation-icons": [
+      {
+        "cask": "font-foundation-icons",
+        "count": "9"
+      }
+    ],
+    "font-foundry-sterling": [
+      {
+        "cask": "font-foundry-sterling",
+        "count": "8"
+      }
+    ],
+    "font-francois-one": [
+      {
+        "cask": "font-francois-one",
+        "count": "8"
+      }
+    ],
+    "font-freckle-face": [
+      {
+        "cask": "font-freckle-face",
+        "count": "8"
+      }
+    ],
+    "font-fredericka-the-great": [
+      {
+        "cask": "font-fredericka-the-great",
+        "count": "8"
+      }
+    ],
+    "font-fredoka-one": [
+      {
+        "cask": "font-fredoka-one",
+        "count": "8"
+      }
+    ],
+    "font-freehand": [
+      {
+        "cask": "font-freehand",
+        "count": "8"
+      }
+    ],
+    "font-freesans": [
+      {
+        "cask": "font-freesans",
+        "count": "12"
+      }
+    ],
+    "font-fresca": [
+      {
+        "cask": "font-fresca",
+        "count": "8"
+      }
+    ],
+    "font-frijole": [
+      {
+        "cask": "font-frijole",
+        "count": "8"
+      }
+    ],
+    "font-fruktur": [
+      {
+        "cask": "font-fruktur",
+        "count": "7"
+      }
+    ],
+    "font-fzshusong-z01": [
+      {
+        "cask": "font-fzshusong-z01",
+        "count": "6"
+      }
+    ],
+    "font-gabriela": [
+      {
+        "cask": "font-gabriela",
+        "count": "7"
+      }
+    ],
+    "font-gafata": [
+      {
+        "cask": "font-gafata",
+        "count": "7"
+      }
+    ],
+    "font-galdeano": [
+      {
+        "cask": "font-galdeano",
+        "count": "7"
+      }
+    ],
+    "font-galindo": [
+      {
+        "cask": "font-galindo",
+        "count": "7"
+      }
+    ],
+    "font-gandhi-sans": [
+      {
+        "cask": "font-gandhi-sans",
+        "count": "7"
+      }
+    ],
+    "font-genjyuugothic": [
+      {
+        "cask": "font-genjyuugothic",
+        "count": "5"
+      }
+    ],
+    "font-genjyuugothic-x": [
+      {
+        "cask": "font-genjyuugothic-x",
+        "count": "4"
+      }
+    ],
+    "font-genryumin": [
+      {
+        "cask": "font-genryumin",
+        "count": "3"
+      }
+    ],
+    "font-gensekigothic": [
+      {
+        "cask": "font-gensekigothic",
+        "count": "2"
+      }
+    ],
+    "font-gensenrounded": [
+      {
+        "cask": "font-gensenrounded",
+        "count": "4"
+      }
+    ],
+    "font-genshingothic": [
+      {
+        "cask": "font-genshingothic",
+        "count": "6"
+      }
+    ],
+    "font-gentium-basic": [
+      {
+        "cask": "font-gentium-basic",
+        "count": "11"
+      }
+    ],
+    "font-gentium-book-basic": [
+      {
+        "cask": "font-gentium-book-basic",
+        "count": "10"
+      }
+    ],
+    "font-gentium-plus": [
+      {
+        "cask": "font-gentium-plus",
+        "count": "11"
+      }
+    ],
+    "font-genwanmin": [
+      {
+        "cask": "font-genwanmin",
+        "count": "3"
+      }
+    ],
+    "font-genyogothic": [
+      {
+        "cask": "font-genyogothic",
+        "count": "3"
+      }
+    ],
+    "font-genyomin": [
+      {
+        "cask": "font-genyomin",
+        "count": "3"
+      }
+    ],
+    "font-geo": [
+      {
+        "cask": "font-geo",
+        "count": "7"
+      }
+    ],
+    "font-georgia": [
+      {
+        "cask": "font-georgia",
+        "count": "8"
+      }
+    ],
+    "font-geostar": [
+      {
+        "cask": "font-geostar",
+        "count": "7"
+      }
+    ],
+    "font-geostar-fill": [
+      {
+        "cask": "font-geostar-fill",
+        "count": "7"
+      }
+    ],
+    "font-germania-one": [
+      {
+        "cask": "font-germania-one",
+        "count": "7"
+      }
+    ],
+    "font-gfs-didot": [
+      {
+        "cask": "font-gfs-didot",
+        "count": "9"
+      }
+    ],
+    "font-gfs-neohellenic": [
+      {
+        "cask": "font-gfs-neohellenic",
+        "count": "7"
+      }
+    ],
+    "font-gidole": [
+      {
+        "cask": "font-gidole",
+        "count": "10"
+      }
+    ],
+    "font-gilbert": [
+      {
+        "cask": "font-gilbert",
+        "count": "7"
+      }
+    ],
+    "font-gilda-display": [
+      {
+        "cask": "font-gilda-display",
+        "count": "7"
+      }
+    ],
+    "font-give-you-glory": [
+      {
+        "cask": "font-give-you-glory",
+        "count": "7"
+      }
+    ],
+    "font-glass-antiqua": [
+      {
+        "cask": "font-glass-antiqua",
+        "count": "7"
+      }
+    ],
+    "font-glegoo": [
+      {
+        "cask": "font-glegoo",
+        "count": "7"
+      }
+    ],
+    "font-gloria-hallelujah": [
+      {
+        "cask": "font-gloria-hallelujah",
+        "count": "7"
+      }
+    ],
+    "font-gnu-unifont": [
+      {
+        "cask": "font-gnu-unifont",
+        "count": "19"
+      }
+    ],
+    "font-go": [
+      {
+        "cask": "font-go",
+        "count": "23"
+      }
+    ],
+    "font-go-mono-nerd-font": [
+      {
+        "cask": "font-go-mono-nerd-font",
+        "count": "7"
+      }
+    ],
+    "font-go-mono-nerd-font-mono": [
+      {
+        "cask": "font-go-mono-nerd-font-mono",
+        "count": "7"
+      }
+    ],
+    "font-goblin-one": [
+      {
+        "cask": "font-goblin-one",
+        "count": "7"
+      }
+    ],
+    "font-gochi-hand": [
+      {
+        "cask": "font-gochi-hand",
+        "count": "9"
+      }
+    ],
+    "font-gohu-nerd-font": [
+      {
+        "cask": "font-gohu-nerd-font",
+        "count": "5"
+      }
+    ],
+    "font-gohu-nerd-font-mono": [
+      {
+        "cask": "font-gohu-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-gohufont-nerd-font": [
+      {
+        "cask": "font-gohufont-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-gomono-nerd-font": [
+      {
+        "cask": "font-gomono-nerd-font",
+        "count": "34"
+      }
+    ],
+    "font-gorditas": [
+      {
+        "cask": "font-gorditas",
+        "count": "7"
+      }
+    ],
+    "font-goudy-bookletter1911": [
+      {
+        "cask": "font-goudy-bookletter1911",
+        "count": "8"
+      }
+    ],
+    "font-graduate": [
+      {
+        "cask": "font-graduate",
+        "count": "8"
+      }
+    ],
+    "font-grand-hotel": [
+      {
+        "cask": "font-grand-hotel",
+        "count": "7"
+      }
+    ],
+    "font-gravitas-one": [
+      {
+        "cask": "font-gravitas-one",
+        "count": "8"
+      }
+    ],
+    "font-great-vibes": [
+      {
+        "cask": "font-great-vibes",
+        "count": "8"
+      }
+    ],
+    "font-griffy": [
+      {
+        "cask": "font-griffy",
+        "count": "8"
+      }
+    ],
+    "font-gruppo": [
+      {
+        "cask": "font-gruppo",
+        "count": "8"
+      }
+    ],
+    "font-gudea": [
+      {
+        "cask": "font-gudea",
+        "count": "8"
+      }
+    ],
+    "font-habibi": [
+      {
+        "cask": "font-habibi",
+        "count": "8"
+      }
+    ],
+    "font-hack": [
+      {
+        "cask": "font-hack",
+        "count": "251"
+      }
+    ],
+    "font-hack-nerd-font": [
+      {
+        "cask": "font-hack-nerd-font",
+        "count": "3,889"
+      }
+    ],
+    "font-hack-nerd-font-mono": [
+      {
+        "cask": "font-hack-nerd-font-mono",
+        "count": "20"
+      }
+    ],
+    "font-hackgen": [
+      {
+        "cask": "font-hackgen",
+        "count": "124"
+      }
+    ],
+    "font-halant": [
+      {
+        "cask": "font-halant",
+        "count": "8"
+      }
+    ],
+    "font-hammersmith-one": [
+      {
+        "cask": "font-hammersmith-one",
+        "count": "8"
+      }
+    ],
+    "font-han-nom-a": [
+      {
+        "cask": "font-han-nom-a",
+        "count": "8"
+      }
+    ],
+    "font-hanalei": [
+      {
+        "cask": "font-hanalei",
+        "count": "8"
+      }
+    ],
+    "font-hanalei-fill": [
+      {
+        "cask": "font-hanalei-fill",
+        "count": "8"
+      }
+    ],
+    "font-hanamina": [
+      {
+        "cask": "font-hanamina",
+        "count": "13"
+      }
+    ],
+    "font-handlee": [
+      {
+        "cask": "font-handlee",
+        "count": "11"
+      }
+    ],
+    "font-hanuman": [
+      {
+        "cask": "font-hanuman",
+        "count": "8"
+      }
+    ],
+    "font-happy-monkey": [
+      {
+        "cask": "font-happy-monkey",
+        "count": "8"
+      }
+    ],
+    "font-hasklig": [
+      {
+        "cask": "font-hasklig",
+        "count": "77"
+      }
+    ],
+    "font-hasklig-nerd-font": [
+      {
+        "cask": "font-hasklig-nerd-font",
+        "count": "16"
+      }
+    ],
+    "font-hasklig-nerd-font-mono": [
+      {
+        "cask": "font-hasklig-nerd-font-mono",
+        "count": "10"
+      }
+    ],
+    "font-hasklug-nerd-font": [
+      {
+        "cask": "font-hasklug-nerd-font",
+        "count": "44"
+      }
+    ],
+    "font-haskplex": [
+      {
+        "cask": "font-haskplex",
+        "count": "5"
+      }
+    ],
+    "font-haskplex-nerd": [
+      {
+        "cask": "font-haskplex-nerd",
+        "count": "4"
+      }
+    ],
+    "font-headland-one": [
+      {
+        "cask": "font-headland-one",
+        "count": "8"
+      }
+    ],
+    "font-heavydata-nerd-font": [
+      {
+        "cask": "font-heavydata-nerd-font",
+        "count": "42"
+      }
+    ],
+    "font-heavydata-nerd-font-mono": [
+      {
+        "cask": "font-heavydata-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-henny-penny": [
+      {
+        "cask": "font-henny-penny",
+        "count": "9"
+      }
+    ],
+    "font-hermit-nerd-font": [
+      {
+        "cask": "font-hermit-nerd-font",
+        "count": "10"
+      }
+    ],
+    "font-hermit-nerd-font-mono": [
+      {
+        "cask": "font-hermit-nerd-font-mono",
+        "count": "9"
+      }
+    ],
+    "font-herr-von-muellerhoff": [
+      {
+        "cask": "font-herr-von-muellerhoff",
+        "count": "8"
+      }
+    ],
+    "font-hind": [
+      {
+        "cask": "font-hind",
+        "count": "10"
+      }
+    ],
+    "font-holtwood-one-sc": [
+      {
+        "cask": "font-holtwood-one-sc",
+        "count": "9"
+      }
+    ],
+    "font-homemade-apple": [
+      {
+        "cask": "font-homemade-apple",
+        "count": "10"
+      }
+    ],
+    "font-homenaje": [
+      {
+        "cask": "font-homenaje",
+        "count": "8"
+      }
+    ],
+    "font-humor-sans": [
+      {
+        "cask": "font-humor-sans",
+        "count": "12"
+      }
+    ],
+    "font-hurmit-nerd-font": [
+      {
+        "cask": "font-hurmit-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-hyppolit": [
+      {
+        "cask": "font-hyppolit",
+        "count": "8"
+      }
+    ],
+    "font-ia-writer-duo": [
+      {
+        "cask": "font-ia-writer-duo",
+        "count": "21"
+      }
+    ],
+    "font-ia-writer-duospace": [
+      {
+        "cask": "font-ia-writer-duospace",
+        "count": "19"
+      }
+    ],
+    "font-ia-writer-mono": [
+      {
+        "cask": "font-ia-writer-mono",
+        "count": "27"
+      }
+    ],
+    "font-ia-writer-quattro": [
+      {
+        "cask": "font-ia-writer-quattro",
+        "count": "26"
+      }
+    ],
+    "font-ibm-plex": [
+      {
+        "cask": "font-ibm-plex",
+        "count": "149"
+      }
+    ],
+    "font-ibmplexmono-nerd-font": [
+      {
+        "cask": "font-ibmplexmono-nerd-font",
+        "count": "11"
+      }
+    ],
+    "font-ibmplexmono-nerd-font-mono": [
+      {
+        "cask": "font-ibmplexmono-nerd-font-mono",
+        "count": "11"
+      }
+    ],
+    "font-iceberg": [
+      {
+        "cask": "font-iceberg",
+        "count": "10"
+      }
+    ],
+    "font-iceland": [
+      {
+        "cask": "font-iceland",
+        "count": "9"
+      }
+    ],
+    "font-icomoon": [
+      {
+        "cask": "font-icomoon",
+        "count": "10"
+      }
+    ],
+    "font-im-fell-types": [
+      {
+        "cask": "font-im-fell-types",
+        "count": "8"
+      }
+    ],
+    "font-impact": [
+      {
+        "cask": "font-impact",
+        "count": "11"
+      }
+    ],
+    "font-imprima": [
+      {
+        "cask": "font-imprima",
+        "count": "9"
+      }
+    ],
+    "font-imwriting-nerd-font": [
+      {
+        "cask": "font-imwriting-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-inconsolata": [
+      {
+        "cask": "font-inconsolata",
+        "count": "218"
+      }
+    ],
+    "font-inconsolata-dz-for-powerline": [
+      {
+        "cask": "font-inconsolata-dz-for-powerline",
+        "count": "44"
+      }
+    ],
+    "font-inconsolata-for-powerline": [
+      {
+        "cask": "font-inconsolata-for-powerline",
+        "count": "103"
+      }
+    ],
+    "font-inconsolata-for-powerline-bold": [
+      {
+        "cask": "font-inconsolata-for-powerline-bold",
+        "count": "35"
+      }
+    ],
+    "font-inconsolata-g": [
+      {
+        "cask": "font-inconsolata-g",
+        "count": "27"
+      }
+    ],
+    "font-inconsolata-g-for-powerline": [
+      {
+        "cask": "font-inconsolata-g-for-powerline",
+        "count": "37"
+      }
+    ],
+    "font-inconsolata-lgc": [
+      {
+        "cask": "font-inconsolata-lgc",
+        "count": "14"
+      }
+    ],
+    "font-inconsolata-nerd-font": [
+      {
+        "cask": "font-inconsolata-nerd-font",
+        "count": "186"
+      }
+    ],
+    "font-inconsolata-nerd-font-mono": [
+      {
+        "cask": "font-inconsolata-nerd-font-mono",
+        "count": "13"
+      }
+    ],
+    "font-inconsolatago-nerd-font": [
+      {
+        "cask": "font-inconsolatago-nerd-font",
+        "count": "73"
+      }
+    ],
+    "font-inconsolatago-nerd-font-mono": [
+      {
+        "cask": "font-inconsolatago-nerd-font-mono",
+        "count": "7"
+      }
+    ],
+    "font-inconsolatalgc-nerd-font": [
+      {
+        "cask": "font-inconsolatalgc-nerd-font",
+        "count": "59"
+      }
+    ],
+    "font-inconsolatalgc-nerd-font-mono": [
+      {
+        "cask": "font-inconsolatalgc-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-inder": [
+      {
+        "cask": "font-inder",
+        "count": "7"
+      }
+    ],
+    "font-indie-flower": [
+      {
+        "cask": "font-indie-flower",
+        "count": "9"
+      }
+    ],
+    "font-inika": [
+      {
+        "cask": "font-inika",
+        "count": "8"
+      }
+    ],
+    "font-input": [
+      {
+        "cask": "font-input",
+        "count": "93"
+      }
+    ],
+    "font-inria": [
+      {
+        "cask": "font-inria",
+        "count": "11"
+      }
+    ],
+    "font-inter": [
+      {
+        "cask": "font-inter",
+        "count": "55"
+      }
+    ],
+    "font-ionicons": [
+      {
+        "cask": "font-ionicons",
+        "count": "31"
+      }
+    ],
+    "font-iosevka": [
+      {
+        "cask": "font-iosevka",
+        "count": "509"
+      }
+    ],
+    "font-iosevka-beta": [
+      {
+        "cask": "font-iosevka-beta",
+        "count": "2"
+      }
+    ],
+    "font-iosevka-nerd-font": [
+      {
+        "cask": "font-iosevka-nerd-font",
+        "count": "139"
+      }
+    ],
+    "font-iosevka-nerd-font-mono": [
+      {
+        "cask": "font-iosevka-nerd-font-mono",
+        "count": "15"
+      }
+    ],
+    "font-iosevka-slab": [
+      {
+        "cask": "font-iosevka-slab",
+        "count": "341"
+      }
+    ],
+    "font-iosevka-slab-beta": [
+      {
+        "cask": "font-iosevka-slab-beta",
+        "count": "2"
+      }
+    ],
+    "font-iosevka-sparkle-beta": [
+      {
+        "cask": "font-iosevka-sparkle-beta",
+        "count": "2"
+      }
+    ],
+    "font-ipaexfont": [
+      {
+        "cask": "font-ipaexfont",
+        "count": "11"
+      }
+    ],
+    "font-ipafont": [
+      {
+        "cask": "font-ipafont",
+        "count": "15"
+      }
+    ],
+    "font-ipamjmincho": [
+      {
+        "cask": "font-ipamjmincho",
+        "count": "5"
+      }
+    ],
+    "font-iranian-sans": [
+      {
+        "cask": "font-iranian-sans",
+        "count": "7"
+      }
+    ],
+    "font-iranian-serif": [
+      {
+        "cask": "font-iranian-serif",
+        "count": "7"
+      }
+    ],
+    "font-irish-grover": [
+      {
+        "cask": "font-irish-grover",
+        "count": "7"
+      }
+    ],
+    "font-istok-web": [
+      {
+        "cask": "font-istok-web",
+        "count": "9"
+      }
+    ],
+    "font-italiana": [
+      {
+        "cask": "font-italiana",
+        "count": "7"
+      }
+    ],
+    "font-italianno": [
+      {
+        "cask": "font-italianno",
+        "count": "8"
+      }
+    ],
+    "font-jaapokki": [
+      {
+        "cask": "font-jaapokki",
+        "count": "7"
+      }
+    ],
+    "font-jacques-francois": [
+      {
+        "cask": "font-jacques-francois",
+        "count": "7"
+      }
+    ],
+    "font-jacques-francois-shadow": [
+      {
+        "cask": "font-jacques-francois-shadow",
+        "count": "7"
+      }
+    ],
+    "font-jetbrains-mono": [
+      {
+        "cask": "font-jetbrains-mono",
+        "count": "960"
+      }
+    ],
+    "font-jetbrainsmono-nerd-font": [
+      {
+        "cask": "font-jetbrainsmono-nerd-font",
+        "count": "347"
+      }
+    ],
+    "font-jetbrainsmono-nerd-font-mono": [
+      {
+        "cask": "font-jetbrainsmono-nerd-font-mono",
+        "count": "35"
+      }
+    ],
+    "font-jf-open-huninn": [
+      {
+        "cask": "font-jf-open-huninn",
+        "count": "14"
+      }
+    ],
+    "font-jim-nightshade": [
+      {
+        "cask": "font-jim-nightshade",
+        "count": "8"
+      }
+    ],
+    "font-jockey-one": [
+      {
+        "cask": "font-jockey-one",
+        "count": "7"
+      }
+    ],
+    "font-jolly-lodger": [
+      {
+        "cask": "font-jolly-lodger",
+        "count": "7"
+      }
+    ],
+    "font-joscelyn": [
+      {
+        "cask": "font-joscelyn",
+        "count": "6"
+      }
+    ],
+    "font-josefin-sans": [
+      {
+        "cask": "font-josefin-sans",
+        "count": "10"
+      }
+    ],
+    "font-josefin-slab": [
+      {
+        "cask": "font-josefin-slab",
+        "count": "9"
+      }
+    ],
+    "font-joti-one": [
+      {
+        "cask": "font-joti-one",
+        "count": "7"
+      }
+    ],
+    "font-jsmath-cmbx10": [
+      {
+        "cask": "font-jsmath-cmbx10",
+        "count": "10"
+      }
+    ],
+    "font-judson": [
+      {
+        "cask": "font-judson",
+        "count": "7"
+      }
+    ],
+    "font-julee": [
+      {
+        "cask": "font-julee",
+        "count": "7"
+      }
+    ],
+    "font-julius-sans-one": [
+      {
+        "cask": "font-julius-sans-one",
+        "count": "7"
+      }
+    ],
+    "font-junction": [
+      {
+        "cask": "font-junction",
+        "count": "8"
+      }
+    ],
+    "font-junge": [
+      {
+        "cask": "font-junge",
+        "count": "7"
+      }
+    ],
+    "font-junicode": [
+      {
+        "cask": "font-junicode",
+        "count": "9"
+      }
+    ],
+    "font-jura": [
+      {
+        "cask": "font-jura",
+        "count": "9"
+      }
+    ],
+    "font-just-another-hand": [
+      {
+        "cask": "font-just-another-hand",
+        "count": "9"
+      }
+    ],
+    "font-kalam": [
+      {
+        "cask": "font-kalam",
+        "count": "10"
+      }
+    ],
+    "font-kameron": [
+      {
+        "cask": "font-kameron",
+        "count": "9"
+      }
+    ],
+    "font-karla": [
+      {
+        "cask": "font-karla",
+        "count": "12"
+      }
+    ],
+    "font-karma": [
+      {
+        "cask": "font-karma",
+        "count": "9"
+      }
+    ],
+    "font-kaushan-script": [
+      {
+        "cask": "font-kaushan-script",
+        "count": "8"
+      }
+    ],
+    "font-kawkab-mono": [
+      {
+        "cask": "font-kawkab-mono",
+        "count": "9"
+      }
+    ],
+    "font-khmer": [
+      {
+        "cask": "font-khmer",
+        "count": "9"
+      }
+    ],
+    "font-kite-one": [
+      {
+        "cask": "font-kite-one",
+        "count": "8"
+      }
+    ],
+    "font-koruri": [
+      {
+        "cask": "font-koruri",
+        "count": "1"
+      }
+    ],
+    "font-kranky": [
+      {
+        "cask": "font-kranky",
+        "count": "8"
+      }
+    ],
+    "font-kreon": [
+      {
+        "cask": "font-kreon",
+        "count": "8"
+      }
+    ],
+    "font-kristi": [
+      {
+        "cask": "font-kristi",
+        "count": "8"
+      }
+    ],
+    "font-krona-one": [
+      {
+        "cask": "font-krona-one",
+        "count": "9"
+      }
+    ],
+    "font-la-belle-aurore": [
+      {
+        "cask": "font-la-belle-aurore",
+        "count": "8"
+      }
+    ],
+    "font-laila": [
+      {
+        "cask": "font-laila",
+        "count": "8"
+      }
+    ],
+    "font-lancelot": [
+      {
+        "cask": "font-lancelot",
+        "count": "8"
+      }
+    ],
+    "font-langdon": [
+      {
+        "cask": "font-langdon",
+        "count": "8"
+      }
+    ],
+    "font-latin-modern": [
+      {
+        "cask": "font-latin-modern",
+        "count": "21"
+      }
+    ],
+    "font-latin-modern-math": [
+      {
+        "cask": "font-latin-modern-math",
+        "count": "16"
+      }
+    ],
+    "font-lato": [
+      {
+        "cask": "font-lato",
+        "count": "108"
+      }
+    ],
+    "font-league-gothic": [
+      {
+        "cask": "font-league-gothic",
+        "count": "13"
+      }
+    ],
+    "font-league-spartan": [
+      {
+        "cask": "font-league-spartan",
+        "count": "10"
+      }
+    ],
+    "font-leckerli-one": [
+      {
+        "cask": "font-leckerli-one",
+        "count": "7"
+      }
+    ],
+    "font-ledger": [
+      {
+        "cask": "font-ledger",
+        "count": "8"
+      }
+    ],
+    "font-lekton": [
+      {
+        "cask": "font-lekton",
+        "count": "7"
+      }
+    ],
+    "font-lekton-nerd-font": [
+      {
+        "cask": "font-lekton-nerd-font",
+        "count": "41"
+      }
+    ],
+    "font-lekton-nerd-font-mono": [
+      {
+        "cask": "font-lekton-nerd-font-mono",
+        "count": "4"
+      }
+    ],
+    "font-lemon": [
+      {
+        "cask": "font-lemon",
+        "count": "7"
+      }
+    ],
+    "font-lexend-deca": [
+      {
+        "cask": "font-lexend-deca",
+        "count": "4"
+      }
+    ],
+    "font-liberation-mono-for-powerline": [
+      {
+        "cask": "font-liberation-mono-for-powerline",
+        "count": "40"
+      }
+    ],
+    "font-liberation-nerd-font": [
+      {
+        "cask": "font-liberation-nerd-font",
+        "count": "26"
+      }
+    ],
+    "font-liberation-sans": [
+      {
+        "cask": "font-liberation-sans",
+        "count": "25"
+      }
+    ],
+    "font-liberationmono-nerd-font": [
+      {
+        "cask": "font-liberationmono-nerd-font",
+        "count": "6"
+      }
+    ],
+    "font-liberationmono-nerd-font-mono": [
+      {
+        "cask": "font-liberationmono-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-libertinus": [
+      {
+        "cask": "font-libertinus",
+        "count": "19"
+      }
+    ],
+    "font-libre-baskerville": [
+      {
+        "cask": "font-libre-baskerville",
+        "count": "15"
+      }
+    ],
+    "font-libre-caslon-display": [
+      {
+        "cask": "font-libre-caslon-display",
+        "count": "9"
+      }
+    ],
+    "font-libre-caslon-text": [
+      {
+        "cask": "font-libre-caslon-text",
+        "count": "8"
+      }
+    ],
+    "font-libre-franklin": [
+      {
+        "cask": "font-libre-franklin",
+        "count": "18"
+      }
+    ],
+    "font-life-savers": [
+      {
+        "cask": "font-life-savers",
+        "count": "6"
+      }
+    ],
+    "font-ligature-symbols": [
+      {
+        "cask": "font-ligature-symbols",
+        "count": "7"
+      }
+    ],
+    "font-lilex": [
+      {
+        "cask": "font-lilex",
+        "count": "9"
+      }
+    ],
+    "font-lilita-one": [
+      {
+        "cask": "font-lilita-one",
+        "count": "6"
+      }
+    ],
+    "font-limelight": [
+      {
+        "cask": "font-limelight",
+        "count": "7"
+      }
+    ],
+    "font-linden-hill": [
+      {
+        "cask": "font-linden-hill",
+        "count": "6"
+      }
+    ],
+    "font-linux-biolinum": [
+      {
+        "cask": "font-linux-biolinum",
+        "count": "8"
+      }
+    ],
+    "font-linux-libertine": [
+      {
+        "cask": "font-linux-libertine",
+        "count": "19"
+      }
+    ],
+    "font-lobster": [
+      {
+        "cask": "font-lobster",
+        "count": "12"
+      }
+    ],
+    "font-lobster-two": [
+      {
+        "cask": "font-lobster-two",
+        "count": "10"
+      }
+    ],
+    "font-londrina-outline": [
+      {
+        "cask": "font-londrina-outline",
+        "count": "6"
+      }
+    ],
+    "font-londrina-shadow": [
+      {
+        "cask": "font-londrina-shadow",
+        "count": "6"
+      }
+    ],
+    "font-londrina-sketch": [
+      {
+        "cask": "font-londrina-sketch",
+        "count": "6"
+      }
+    ],
+    "font-londrina-solid": [
+      {
+        "cask": "font-londrina-solid",
+        "count": "6"
+      }
+    ],
+    "font-lora": [
+      {
+        "cask": "font-lora",
+        "count": "20"
+      }
+    ],
+    "font-love-ya-like-a-sister": [
+      {
+        "cask": "font-love-ya-like-a-sister",
+        "count": "6"
+      }
+    ],
+    "font-loved-by-the-king": [
+      {
+        "cask": "font-loved-by-the-king",
+        "count": "6"
+      }
+    ],
+    "font-lovers-quarrel": [
+      {
+        "cask": "font-lovers-quarrel",
+        "count": "6"
+      }
+    ],
+    "font-luckiest-guy": [
+      {
+        "cask": "font-luckiest-guy",
+        "count": "6"
+      }
+    ],
+    "font-luculent": [
+      {
+        "cask": "font-luculent",
+        "count": "5"
+      }
+    ],
+    "font-lusitana": [
+      {
+        "cask": "font-lusitana",
+        "count": "6"
+      }
+    ],
+    "font-lustria": [
+      {
+        "cask": "font-lustria",
+        "count": "6"
+      }
+    ],
+    "font-m-plus": [
+      {
+        "cask": "font-m-plus",
+        "count": "28"
+      }
+    ],
+    "font-macondo": [
+      {
+        "cask": "font-macondo",
+        "count": "6"
+      }
+    ],
+    "font-macondo-swash-caps": [
+      {
+        "cask": "font-macondo-swash-caps",
+        "count": "6"
+      }
+    ],
+    "font-magra": [
+      {
+        "cask": "font-magra",
+        "count": "6"
+      }
+    ],
+    "font-maiden-orange": [
+      {
+        "cask": "font-maiden-orange",
+        "count": "6"
+      }
+    ],
+    "font-mako": [
+      {
+        "cask": "font-mako",
+        "count": "6"
+      }
+    ],
+    "font-marcellus": [
+      {
+        "cask": "font-marcellus",
+        "count": "6"
+      }
+    ],
+    "font-marcellus-sc": [
+      {
+        "cask": "font-marcellus-sc",
+        "count": "7"
+      }
+    ],
+    "font-marck-script": [
+      {
+        "cask": "font-marck-script",
+        "count": "6"
+      }
+    ],
+    "font-margarine": [
+      {
+        "cask": "font-margarine",
+        "count": "6"
+      }
+    ],
+    "font-marko-one": [
+      {
+        "cask": "font-marko-one",
+        "count": "6"
+      }
+    ],
+    "font-marmelad": [
+      {
+        "cask": "font-marmelad",
+        "count": "6"
+      }
+    ],
+    "font-marvel": [
+      {
+        "cask": "font-marvel",
+        "count": "7"
+      }
+    ],
+    "font-masinahikan": [
+      {
+        "cask": "font-masinahikan",
+        "count": "6"
+      }
+    ],
+    "font-masinahikan-dene": [
+      {
+        "cask": "font-masinahikan-dene",
+        "count": "6"
+      }
+    ],
+    "font-mate": [
+      {
+        "cask": "font-mate",
+        "count": "6"
+      }
+    ],
+    "font-mate-sc": [
+      {
+        "cask": "font-mate-sc",
+        "count": "7"
+      }
+    ],
+    "font-material-icons": [
+      {
+        "cask": "font-material-icons",
+        "count": "37"
+      }
+    ],
+    "font-materialdesignicons-webfont": [
+      {
+        "cask": "font-materialdesignicons-webfont",
+        "count": "9"
+      }
+    ],
+    "font-maven-pro": [
+      {
+        "cask": "font-maven-pro",
+        "count": "7"
+      }
+    ],
+    "font-mclaren": [
+      {
+        "cask": "font-mclaren",
+        "count": "7"
+      }
+    ],
+    "font-meddon": [
+      {
+        "cask": "font-meddon",
+        "count": "6"
+      }
+    ],
+    "font-medievalsharp": [
+      {
+        "cask": "font-medievalsharp",
+        "count": "6"
+      }
+    ],
+    "font-medula-one": [
+      {
+        "cask": "font-medula-one",
+        "count": "6"
+      }
+    ],
+    "font-megrim": [
+      {
+        "cask": "font-megrim",
+        "count": "5"
+      }
+    ],
+    "font-meie-script": [
+      {
+        "cask": "font-meie-script",
+        "count": "5"
+      }
+    ],
+    "font-meltho": [
+      {
+        "cask": "font-meltho",
+        "count": "5"
+      }
+    ],
+    "font-menlo-for-powerline": [
+      {
+        "cask": "font-menlo-for-powerline",
+        "count": "175"
+      }
+    ],
+    "font-merienda": [
+      {
+        "cask": "font-merienda",
+        "count": "5"
+      }
+    ],
+    "font-merienda-one": [
+      {
+        "cask": "font-merienda-one",
+        "count": "5"
+      }
+    ],
+    "font-merriweather": [
+      {
+        "cask": "font-merriweather",
+        "count": "22"
+      }
+    ],
+    "font-merriweather-sans": [
+      {
+        "cask": "font-merriweather-sans",
+        "count": "11"
+      }
+    ],
+    "font-meslo-for-powerline": [
+      {
+        "cask": "font-meslo-for-powerline",
+        "count": "165"
+      }
+    ],
+    "font-meslo-lg": [
+      {
+        "cask": "font-meslo-lg",
+        "count": "39"
+      }
+    ],
+    "font-meslo-lgs-nf-bold": [
+      {
+        "cask": "font-meslo-lgs-nf-bold",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-bold-italic": [
+      {
+        "cask": "font-meslo-lgs-nf-bold-italic",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-italic": [
+      {
+        "cask": "font-meslo-lgs-nf-italic",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-regular": [
+      {
+        "cask": "font-meslo-lgs-nf-regular",
+        "count": "1"
+      }
+    ],
+    "font-meslo-nerd-font": [
+      {
+        "cask": "font-meslo-nerd-font",
+        "count": "63"
+      }
+    ],
+    "font-meslo-nerd-font-mono": [
+      {
+        "cask": "font-meslo-nerd-font-mono",
+        "count": "22"
+      }
+    ],
+    "font-meslolg-nerd-font": [
+      {
+        "cask": "font-meslolg-nerd-font",
+        "count": "167"
+      }
+    ],
+    "font-metal": [
+      {
+        "cask": "font-metal",
+        "count": "5"
+      }
+    ],
+    "font-metal-mania": [
+      {
+        "cask": "font-metal-mania",
+        "count": "5"
+      }
+    ],
+    "font-metamorphous": [
+      {
+        "cask": "font-metamorphous",
+        "count": "4"
+      }
+    ],
+    "font-metrophobic": [
+      {
+        "cask": "font-metrophobic",
+        "count": "5"
+      }
+    ],
+    "font-metropolis": [
+      {
+        "cask": "font-metropolis",
+        "count": "8"
+      }
+    ],
+    "font-miao-unicode": [
+      {
+        "cask": "font-miao-unicode",
+        "count": "4"
+      }
+    ],
+    "font-michroma": [
+      {
+        "cask": "font-michroma",
+        "count": "4"
+      }
+    ],
+    "font-microsoft-office": [
+      {
+        "cask": "font-microsoft-office",
+        "count": "23"
+      }
+    ],
+    "font-migmix-1m": [
+      {
+        "cask": "font-migmix-1m",
+        "count": "7"
+      }
+    ],
+    "font-migmix-1p": [
+      {
+        "cask": "font-migmix-1p",
+        "count": "14"
+      }
+    ],
+    "font-migmix-2m": [
+      {
+        "cask": "font-migmix-2m",
+        "count": "6"
+      }
+    ],
+    "font-migmix-2p": [
+      {
+        "cask": "font-migmix-2p",
+        "count": "6"
+      }
+    ],
+    "font-migu-1c": [
+      {
+        "cask": "font-migu-1c",
+        "count": "7"
+      }
+    ],
+    "font-migu-1m": [
+      {
+        "cask": "font-migu-1m",
+        "count": "20"
+      }
+    ],
+    "font-migu-1p": [
+      {
+        "cask": "font-migu-1p",
+        "count": "9"
+      }
+    ],
+    "font-migu-2m": [
+      {
+        "cask": "font-migu-2m",
+        "count": "9"
+      }
+    ],
+    "font-milonga": [
+      {
+        "cask": "font-milonga",
+        "count": "5"
+      }
+    ],
+    "font-miltonian": [
+      {
+        "cask": "font-miltonian",
+        "count": "4"
+      }
+    ],
+    "font-miltonian-tattoo": [
+      {
+        "cask": "font-miltonian-tattoo",
+        "count": "5"
+      }
+    ],
+    "font-miniver": [
+      {
+        "cask": "font-miniver",
+        "count": "5"
+      }
+    ],
+    "font-miriam-mono-clm": [
+      {
+        "cask": "font-miriam-mono-clm",
+        "count": "5"
+      }
+    ],
+    "font-miss-fajardose": [
+      {
+        "cask": "font-miss-fajardose",
+        "count": "4"
+      }
+    ],
+    "font-modern-antiqua": [
+      {
+        "cask": "font-modern-antiqua",
+        "count": "4"
+      }
+    ],
+    "font-molle": [
+      {
+        "cask": "font-molle",
+        "count": "4"
+      }
+    ],
+    "font-monda": [
+      {
+        "cask": "font-monda",
+        "count": "4"
+      }
+    ],
+    "font-monofur-for-powerline": [
+      {
+        "cask": "font-monofur-for-powerline",
+        "count": "29"
+      }
+    ],
+    "font-monofur-nerd-font": [
+      {
+        "cask": "font-monofur-nerd-font",
+        "count": "53"
+      }
+    ],
+    "font-monofur-nerd-font-mono": [
+      {
+        "cask": "font-monofur-nerd-font-mono",
+        "count": "4"
+      }
+    ],
+    "font-monoid": [
+      {
+        "cask": "font-monoid",
+        "count": "59"
+      }
+    ],
+    "font-monoid-halfloose-large": [
+      {
+        "cask": "font-monoid-halfloose-large",
+        "count": "1"
+      }
+    ],
+    "font-monoid-halftight-large-dollar": [
+      {
+        "cask": "font-monoid-halftight-large-dollar",
+        "count": "1"
+      }
+    ],
+    "font-monoid-large": [
+      {
+        "cask": "font-monoid-large",
+        "count": "1"
+      }
+    ],
+    "font-monoid-large-dollar": [
+      {
+        "cask": "font-monoid-large-dollar",
+        "count": "1"
+      }
+    ],
+    "font-monoid-nerd-font": [
+      {
+        "cask": "font-monoid-nerd-font",
+        "count": "101"
+      }
+    ],
+    "font-monoid-nerd-font-mono": [
+      {
+        "cask": "font-monoid-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-monoisome": [
+      {
+        "cask": "font-monoisome",
+        "count": "12"
+      }
+    ],
+    "font-mononoki": [
+      {
+        "cask": "font-mononoki",
+        "count": "36"
+      }
+    ],
+    "font-mononoki-nerd-font": [
+      {
+        "cask": "font-mononoki-nerd-font",
+        "count": "97"
+      }
+    ],
+    "font-mononoki-nerd-font-mono": [
+      {
+        "cask": "font-mononoki-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-monoton": [
+      {
+        "cask": "font-monoton",
+        "count": "5"
+      }
+    ],
+    "font-monsieur-la-doulaise": [
+      {
+        "cask": "font-monsieur-la-doulaise",
+        "count": "4"
+      }
+    ],
+    "font-montaga": [
+      {
+        "cask": "font-montaga",
+        "count": "4"
+      }
+    ],
+    "font-montez": [
+      {
+        "cask": "font-montez",
+        "count": "4"
+      }
+    ],
+    "font-montserrat": [
+      {
+        "cask": "font-montserrat",
+        "count": "42"
+      }
+    ],
+    "font-montserrat-subrayada": [
+      {
+        "cask": "font-montserrat-subrayada",
+        "count": "5"
+      }
+    ],
+    "font-moul": [
+      {
+        "cask": "font-moul",
+        "count": "4"
+      }
+    ],
+    "font-mountains-of-christmas": [
+      {
+        "cask": "font-mountains-of-christmas",
+        "count": "4"
+      }
+    ],
+    "font-mouse-memoirs": [
+      {
+        "cask": "font-mouse-memoirs",
+        "count": "4"
+      }
+    ],
+    "font-mplus-1mn-nerd-font-mono": [
+      {
+        "cask": "font-mplus-1mn-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-mplus-nerd-font": [
+      {
+        "cask": "font-mplus-nerd-font",
+        "count": "48"
+      }
+    ],
+    "font-mplus-nerd-font-mono": [
+      {
+        "cask": "font-mplus-nerd-font-mono",
+        "count": "4"
+      }
+    ],
+    "font-mr-bedfort": [
+      {
+        "cask": "font-mr-bedfort",
+        "count": "3"
+      }
+    ],
+    "font-mr-dafoe": [
+      {
+        "cask": "font-mr-dafoe",
+        "count": "3"
+      }
+    ],
+    "font-mrs-saint-delafield": [
+      {
+        "cask": "font-mrs-saint-delafield",
+        "count": "3"
+      }
+    ],
+    "font-mrs-sheppards": [
+      {
+        "cask": "font-mrs-sheppards",
+        "count": "3"
+      }
+    ],
+    "font-mukti-narrow": [
+      {
+        "cask": "font-mukti-narrow",
+        "count": "3"
+      }
+    ],
+    "font-muli": [
+      {
+        "cask": "font-muli",
+        "count": "8"
+      }
+    ],
+    "font-museo": [
+      {
+        "cask": "font-museo",
+        "count": "4"
+      }
+    ],
+    "font-myrica": [
+      {
+        "cask": "font-myrica",
+        "count": "32"
+      }
+    ],
+    "font-myricam": [
+      {
+        "cask": "font-myricam",
+        "count": "20"
+      }
+    ],
+    "font-mystery-quest": [
+      {
+        "cask": "font-mystery-quest",
+        "count": "4"
+      }
+    ],
+    "font-n-gage": [
+      {
+        "cask": "font-n-gage",
+        "count": "4"
+      }
+    ],
+    "font-nanumgothic": [
+      {
+        "cask": "font-nanumgothic",
+        "count": "7"
+      }
+    ],
+    "font-nanumgothiccoding": [
+      {
+        "cask": "font-nanumgothiccoding",
+        "count": "7"
+      }
+    ],
+    "font-nanummyeongjo": [
+      {
+        "cask": "font-nanummyeongjo",
+        "count": "5"
+      }
+    ],
+    "font-national-park": [
+      {
+        "cask": "font-national-park",
+        "count": "9"
+      }
+    ],
+    "font-neodunggeunmo": [
+      {
+        "cask": "font-neodunggeunmo",
+        "count": "5"
+      }
+    ],
+    "font-neodunggeunmo-code": [
+      {
+        "cask": "font-neodunggeunmo-code",
+        "count": "8"
+      }
+    ],
+    "font-neucha": [
+      {
+        "cask": "font-neucha",
+        "count": "5"
+      }
+    ],
+    "font-neuton": [
+      {
+        "cask": "font-neuton",
+        "count": "5"
+      }
+    ],
+    "font-new-rocker": [
+      {
+        "cask": "font-new-rocker",
+        "count": "4"
+      }
+    ],
+    "font-new-york": [
+      {
+        "cask": "font-new-york",
+        "count": "4"
+      }
+    ],
+    "font-news-cycle": [
+      {
+        "cask": "font-news-cycle",
+        "count": "4"
+      }
+    ],
+    "font-niconne": [
+      {
+        "cask": "font-niconne",
+        "count": "4"
+      }
+    ],
+    "font-nimbus-sans-l": [
+      {
+        "cask": "font-nimbus-sans-l",
+        "count": "5"
+      }
+    ],
+    "font-nixie-one": [
+      {
+        "cask": "font-nixie-one",
+        "count": "8"
+      }
+    ],
+    "font-nobile": [
+      {
+        "cask": "font-nobile",
+        "count": "5"
+      }
+    ],
+    "font-nokora": [
+      {
+        "cask": "font-nokora",
+        "count": "4"
+      }
+    ],
+    "font-norican": [
+      {
+        "cask": "font-norican",
+        "count": "4"
+      }
+    ],
+    "font-nosifer": [
+      {
+        "cask": "font-nosifer",
+        "count": "4"
+      }
+    ],
+    "font-nothing-you-could-do": [
+      {
+        "cask": "font-nothing-you-could-do",
+        "count": "4"
+      }
+    ],
+    "font-noticia-text": [
+      {
+        "cask": "font-noticia-text",
+        "count": "4"
+      }
+    ],
+    "font-noto-color-emoji": [
+      {
+        "cask": "font-noto-color-emoji",
+        "count": "29"
+      }
+    ],
+    "font-noto-emoji": [
+      {
+        "cask": "font-noto-emoji",
+        "count": "18"
+      }
+    ],
+    "font-noto-kufi-arabic": [
+      {
+        "cask": "font-noto-kufi-arabic",
+        "count": "3"
+      }
+    ],
+    "font-noto-mono": [
+      {
+        "cask": "font-noto-mono",
+        "count": "41"
+      }
+    ],
+    "font-noto-mono-for-powerline": [
+      {
+        "cask": "font-noto-mono-for-powerline",
+        "count": "42"
+      }
+    ],
+    "font-noto-naskh-arabic": [
+      {
+        "cask": "font-noto-naskh-arabic",
+        "count": "3"
+      }
+    ],
+    "font-noto-nastaliq-urdu": [
+      {
+        "cask": "font-noto-nastaliq-urdu",
+        "count": "3"
+      }
+    ],
+    "font-noto-nerd-font": [
+      {
+        "cask": "font-noto-nerd-font",
+        "count": "55"
+      }
+    ],
+    "font-noto-nerd-font-mono": [
+      {
+        "cask": "font-noto-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-noto-sans": [
+      {
+        "cask": "font-noto-sans",
+        "count": "65"
+      }
+    ],
+    "font-noto-sans-adlam": [
+      {
+        "cask": "font-noto-sans-adlam",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-adlam-unjoined": [
+      {
+        "cask": "font-noto-sans-adlam-unjoined",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-anatolian-hieroglyphs": [
+      {
+        "cask": "font-noto-sans-anatolian-hieroglyphs",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-arabic": [
+      {
+        "cask": "font-noto-sans-arabic",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-armenian": [
+      {
+        "cask": "font-noto-sans-armenian",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-avestan": [
+      {
+        "cask": "font-noto-sans-avestan",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-balinese": [
+      {
+        "cask": "font-noto-sans-balinese",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-bamum": [
+      {
+        "cask": "font-noto-sans-bamum",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-batak": [
+      {
+        "cask": "font-noto-sans-batak",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-bengali": [
+      {
+        "cask": "font-noto-sans-bengali",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-brahmi": [
+      {
+        "cask": "font-noto-sans-brahmi",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-buginese": [
+      {
+        "cask": "font-noto-sans-buginese",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-buhid": [
+      {
+        "cask": "font-noto-sans-buhid",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-canadian-aboriginal": [
+      {
+        "cask": "font-noto-sans-canadian-aboriginal",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-carian": [
+      {
+        "cask": "font-noto-sans-carian",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-chakma": [
+      {
+        "cask": "font-noto-sans-chakma",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-cham": [
+      {
+        "cask": "font-noto-sans-cham",
+        "count": "5"
+      }
+    ],
+    "font-noto-sans-cherokee": [
+      {
+        "cask": "font-noto-sans-cherokee",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-cjk": [
+      {
+        "cask": "font-noto-sans-cjk",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-cjk-jp": [
+      {
+        "cask": "font-noto-sans-cjk-jp",
+        "count": "63"
+      }
+    ],
+    "font-noto-sans-cjk-kr": [
+      {
+        "cask": "font-noto-sans-cjk-kr",
+        "count": "5"
+      }
+    ],
+    "font-noto-sans-cjk-sc": [
+      {
+        "cask": "font-noto-sans-cjk-sc",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-cjk-tc": [
+      {
+        "cask": "font-noto-sans-cjk-tc",
+        "count": "12"
+      }
+    ],
+    "font-noto-sans-coptic": [
+      {
+        "cask": "font-noto-sans-coptic",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-cuneiform": [
+      {
+        "cask": "font-noto-sans-cuneiform",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-cypriot": [
+      {
+        "cask": "font-noto-sans-cypriot",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-deseret": [
+      {
+        "cask": "font-noto-sans-deseret",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-devanagari": [
+      {
+        "cask": "font-noto-sans-devanagari",
+        "count": "5"
+      }
+    ],
+    "font-noto-sans-display": [
+      {
+        "cask": "font-noto-sans-display",
+        "count": "5"
+      }
+    ],
+    "font-noto-sans-egyptian-hieroglyphs": [
+      {
+        "cask": "font-noto-sans-egyptian-hieroglyphs",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-ethiopic": [
+      {
+        "cask": "font-noto-sans-ethiopic",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-georgian": [
+      {
+        "cask": "font-noto-sans-georgian",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-glagolitic": [
+      {
+        "cask": "font-noto-sans-glagolitic",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-gothic": [
+      {
+        "cask": "font-noto-sans-gothic",
+        "count": "5"
+      }
+    ],
+    "font-noto-sans-gujarati": [
+      {
+        "cask": "font-noto-sans-gujarati",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-gurmukhi": [
+      {
+        "cask": "font-noto-sans-gurmukhi",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-hanunoo": [
+      {
+        "cask": "font-noto-sans-hanunoo",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-hebrew": [
+      {
+        "cask": "font-noto-sans-hebrew",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-imperial-aramaic": [
+      {
+        "cask": "font-noto-sans-imperial-aramaic",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-inscriptional-pahlavi": [
+      {
+        "cask": "font-noto-sans-inscriptional-pahlavi",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-inscriptional-parthian": [
+      {
+        "cask": "font-noto-sans-inscriptional-parthian",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-javanese": [
+      {
+        "cask": "font-noto-sans-javanese",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-kaithi": [
+      {
+        "cask": "font-noto-sans-kaithi",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-kannada": [
+      {
+        "cask": "font-noto-sans-kannada",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-kayah-li": [
+      {
+        "cask": "font-noto-sans-kayah-li",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-kharoshthi": [
+      {
+        "cask": "font-noto-sans-kharoshthi",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-khmer": [
+      {
+        "cask": "font-noto-sans-khmer",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-lao": [
+      {
+        "cask": "font-noto-sans-lao",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-lepcha": [
+      {
+        "cask": "font-noto-sans-lepcha",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-limbu": [
+      {
+        "cask": "font-noto-sans-limbu",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-linear-b": [
+      {
+        "cask": "font-noto-sans-linear-b",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-lisu": [
+      {
+        "cask": "font-noto-sans-lisu",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-lycian": [
+      {
+        "cask": "font-noto-sans-lycian",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-lydian": [
+      {
+        "cask": "font-noto-sans-lydian",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-malayalam": [
+      {
+        "cask": "font-noto-sans-malayalam",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-mandaic": [
+      {
+        "cask": "font-noto-sans-mandaic",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-meetei-mayek": [
+      {
+        "cask": "font-noto-sans-meetei-mayek",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-mongolian": [
+      {
+        "cask": "font-noto-sans-mongolian",
+        "count": "2"
+      }
+    ],
+    "font-noto-sans-mono": [
+      {
+        "cask": "font-noto-sans-mono",
+        "count": "19"
+      }
+    ],
+    "font-noto-sans-myanmar": [
+      {
+        "cask": "font-noto-sans-myanmar",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-n-ko": [
+      {
+        "cask": "font-noto-sans-n-ko",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-new-tai-lue": [
+      {
+        "cask": "font-noto-sans-new-tai-lue",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-ogham": [
+      {
+        "cask": "font-noto-sans-ogham",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-ol-chiki": [
+      {
+        "cask": "font-noto-sans-ol-chiki",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-old-italic": [
+      {
+        "cask": "font-noto-sans-old-italic",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-old-persian": [
+      {
+        "cask": "font-noto-sans-old-persian",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-old-south-arabian": [
+      {
+        "cask": "font-noto-sans-old-south-arabian",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-old-turkic": [
+      {
+        "cask": "font-noto-sans-old-turkic",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-oriya": [
+      {
+        "cask": "font-noto-sans-oriya",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-osage": [
+      {
+        "cask": "font-noto-sans-osage",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-osmanya": [
+      {
+        "cask": "font-noto-sans-osmanya",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-phags-pa": [
+      {
+        "cask": "font-noto-sans-phags-pa",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-phoenician": [
+      {
+        "cask": "font-noto-sans-phoenician",
+        "count": "4"
+      }
+    ],
+    "font-noto-sans-rejang": [
+      {
+        "cask": "font-noto-sans-rejang",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-runic": [
+      {
+        "cask": "font-noto-sans-runic",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-samaritan": [
+      {
+        "cask": "font-noto-sans-samaritan",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-saurashtra": [
+      {
+        "cask": "font-noto-sans-saurashtra",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-shavian": [
+      {
+        "cask": "font-noto-sans-shavian",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-sinhala": [
+      {
+        "cask": "font-noto-sans-sinhala",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-sundanese": [
+      {
+        "cask": "font-noto-sans-sundanese",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-syloti-nagri": [
+      {
+        "cask": "font-noto-sans-syloti-nagri",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-symbols": [
+      {
+        "cask": "font-noto-sans-symbols",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-symbols2": [
+      {
+        "cask": "font-noto-sans-symbols2",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-syriac-eastern": [
+      {
+        "cask": "font-noto-sans-syriac-eastern",
+        "count": "4"
+      }
+    ],
+    "font-noto-sans-syriac-estrangela": [
+      {
+        "cask": "font-noto-sans-syriac-estrangela",
+        "count": "4"
+      }
+    ],
+    "font-noto-sans-syriac-western": [
+      {
+        "cask": "font-noto-sans-syriac-western",
+        "count": "4"
+      }
+    ],
+    "font-noto-sans-tagalog": [
+      {
+        "cask": "font-noto-sans-tagalog",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-tagbanwa": [
+      {
+        "cask": "font-noto-sans-tagbanwa",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-tai-le": [
+      {
+        "cask": "font-noto-sans-tai-le",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-tai-tham": [
+      {
+        "cask": "font-noto-sans-tai-tham",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-tai-viet": [
+      {
+        "cask": "font-noto-sans-tai-viet",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-tamil": [
+      {
+        "cask": "font-noto-sans-tamil",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-telugu": [
+      {
+        "cask": "font-noto-sans-telugu",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-thaana": [
+      {
+        "cask": "font-noto-sans-thaana",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-thai": [
+      {
+        "cask": "font-noto-sans-thai",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-tibetan": [
+      {
+        "cask": "font-noto-sans-tibetan",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-tifinagh": [
+      {
+        "cask": "font-noto-sans-tifinagh",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-ugaritic": [
+      {
+        "cask": "font-noto-sans-ugaritic",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-vai": [
+      {
+        "cask": "font-noto-sans-vai",
+        "count": "3"
+      }
+    ],
+    "font-noto-sans-yi": [
+      {
+        "cask": "font-noto-sans-yi",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif": [
+      {
+        "cask": "font-noto-serif",
+        "count": "32"
+      }
+    ],
+    "font-noto-serif-armenian": [
+      {
+        "cask": "font-noto-serif-armenian",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-bengali": [
+      {
+        "cask": "font-noto-serif-bengali",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-cjk": [
+      {
+        "cask": "font-noto-serif-cjk",
+        "count": "19"
+      }
+    ],
+    "font-noto-serif-cjk-jp": [
+      {
+        "cask": "font-noto-serif-cjk-jp",
+        "count": "44"
+      }
+    ],
+    "font-noto-serif-cjk-kr": [
+      {
+        "cask": "font-noto-serif-cjk-kr",
+        "count": "5"
+      }
+    ],
+    "font-noto-serif-cjk-sc": [
+      {
+        "cask": "font-noto-serif-cjk-sc",
+        "count": "4"
+      }
+    ],
+    "font-noto-serif-cjk-tc": [
+      {
+        "cask": "font-noto-serif-cjk-tc",
+        "count": "15"
+      }
+    ],
+    "font-noto-serif-devanagari": [
+      {
+        "cask": "font-noto-serif-devanagari",
+        "count": "7"
+      }
+    ],
+    "font-noto-serif-display": [
+      {
+        "cask": "font-noto-serif-display",
+        "count": "5"
+      }
+    ],
+    "font-noto-serif-ethiopic": [
+      {
+        "cask": "font-noto-serif-ethiopic",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-gujarati": [
+      {
+        "cask": "font-noto-serif-gujarati",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-hebrew": [
+      {
+        "cask": "font-noto-serif-hebrew",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-kannada": [
+      {
+        "cask": "font-noto-serif-kannada",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-khmer": [
+      {
+        "cask": "font-noto-serif-khmer",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-lao": [
+      {
+        "cask": "font-noto-serif-lao",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-malayalam": [
+      {
+        "cask": "font-noto-serif-malayalam",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-myanmar": [
+      {
+        "cask": "font-noto-serif-myanmar",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-sinhala": [
+      {
+        "cask": "font-noto-serif-sinhala",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-tamil": [
+      {
+        "cask": "font-noto-serif-tamil",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-telugu": [
+      {
+        "cask": "font-noto-serif-telugu",
+        "count": "3"
+      }
+    ],
+    "font-noto-serif-thai": [
+      {
+        "cask": "font-noto-serif-thai",
+        "count": "9"
+      }
+    ],
+    "font-nova-cut": [
+      {
+        "cask": "font-nova-cut",
+        "count": "4"
+      }
+    ],
+    "font-nova-flat": [
+      {
+        "cask": "font-nova-flat",
+        "count": "4"
+      }
+    ],
+    "font-nova-mono": [
+      {
+        "cask": "font-nova-mono",
+        "count": "8"
+      }
+    ],
+    "font-nova-oval": [
+      {
+        "cask": "font-nova-oval",
+        "count": "3"
+      }
+    ],
+    "font-nova-round": [
+      {
+        "cask": "font-nova-round",
+        "count": "3"
+      }
+    ],
+    "font-nova-script": [
+      {
+        "cask": "font-nova-script",
+        "count": "3"
+      }
+    ],
+    "font-nova-slim": [
+      {
+        "cask": "font-nova-slim",
+        "count": "3"
+      }
+    ],
+    "font-nova-square": [
+      {
+        "cask": "font-nova-square",
+        "count": "3"
+      }
+    ],
+    "font-nunito": [
+      {
+        "cask": "font-nunito",
+        "count": "13"
+      }
+    ],
+    "font-ocr": [
+      {
+        "cask": "font-ocr",
+        "count": "6"
+      }
+    ],
+    "font-octicons": [
+      {
+        "cask": "font-octicons",
+        "count": "2"
+      }
+    ],
+    "font-office-code-pro": [
+      {
+        "cask": "font-office-code-pro",
+        "count": "30"
+      }
+    ],
+    "font-old-standard-tt": [
+      {
+        "cask": "font-old-standard-tt",
+        "count": "7"
+      }
+    ],
+    "font-open-iconic": [
+      {
+        "cask": "font-open-iconic",
+        "count": "6"
+      }
+    ],
+    "font-open-sans": [
+      {
+        "cask": "font-open-sans",
+        "count": "96"
+      }
+    ],
+    "font-open-sans-condensed": [
+      {
+        "cask": "font-open-sans-condensed",
+        "count": "22"
+      }
+    ],
+    "font-open-sans-hebrew": [
+      {
+        "cask": "font-open-sans-hebrew",
+        "count": "4"
+      }
+    ],
+    "font-open-sans-hebrew-condensed": [
+      {
+        "cask": "font-open-sans-hebrew-condensed",
+        "count": "4"
+      }
+    ],
+    "font-opendyslexic": [
+      {
+        "cask": "font-opendyslexic",
+        "count": "8"
+      }
+    ],
+    "font-opendyslexic-nerd-font": [
+      {
+        "cask": "font-opendyslexic-nerd-font",
+        "count": "18"
+      }
+    ],
+    "font-optician-sans": [
+      {
+        "cask": "font-optician-sans",
+        "count": "3"
+      }
+    ],
+    "font-oranienbaum": [
+      {
+        "cask": "font-oranienbaum",
+        "count": "3"
+      }
+    ],
+    "font-orbitron": [
+      {
+        "cask": "font-orbitron",
+        "count": "4"
+      }
+    ],
+    "font-ostrich-sans": [
+      {
+        "cask": "font-ostrich-sans",
+        "count": "3"
+      }
+    ],
+    "font-oswald": [
+      {
+        "cask": "font-oswald",
+        "count": "14"
+      }
+    ],
+    "font-overlock": [
+      {
+        "cask": "font-overlock",
+        "count": "4"
+      }
+    ],
+    "font-overlock-sc": [
+      {
+        "cask": "font-overlock-sc",
+        "count": "3"
+      }
+    ],
+    "font-overpass": [
+      {
+        "cask": "font-overpass",
+        "count": "21"
+      }
+    ],
+    "font-overpass-nerd-font": [
+      {
+        "cask": "font-overpass-nerd-font",
+        "count": "27"
+      }
+    ],
+    "font-oxygen": [
+      {
+        "cask": "font-oxygen",
+        "count": "4"
+      }
+    ],
+    "font-oxygen-mono": [
+      {
+        "cask": "font-oxygen-mono",
+        "count": "7"
+      }
+    ],
+    "font-pacifico": [
+      {
+        "cask": "font-pacifico",
+        "count": "10"
+      }
+    ],
+    "font-padauk": [
+      {
+        "cask": "font-padauk",
+        "count": "3"
+      }
+    ],
+    "font-passion-one": [
+      {
+        "cask": "font-passion-one",
+        "count": "3"
+      }
+    ],
+    "font-patua-one": [
+      {
+        "cask": "font-patua-one",
+        "count": "5"
+      }
+    ],
+    "font-permanent-marker": [
+      {
+        "cask": "font-permanent-marker",
+        "count": "9"
+      }
+    ],
+    "font-petit-formal-script": [
+      {
+        "cask": "font-petit-formal-script",
+        "count": "16"
+      }
+    ],
+    "font-playfair-display": [
+      {
+        "cask": "font-playfair-display",
+        "count": "12"
+      }
+    ],
+    "font-playfair-display-sc": [
+      {
+        "cask": "font-playfair-display-sc",
+        "count": "4"
+      }
+    ],
+    "font-poiret-one": [
+      {
+        "cask": "font-poiret-one",
+        "count": "3"
+      }
+    ],
+    "font-poller-one": [
+      {
+        "cask": "font-poller-one",
+        "count": "2"
+      }
+    ],
+    "font-poppins": [
+      {
+        "cask": "font-poppins",
+        "count": "12"
+      }
+    ],
+    "font-poppins-latin": [
+      {
+        "cask": "font-poppins-latin",
+        "count": "2"
+      }
+    ],
+    "font-powerline-symbols": [
+      {
+        "cask": "font-powerline-symbols",
+        "count": "140"
+      }
+    ],
+    "font-prata": [
+      {
+        "cask": "font-prata",
+        "count": "3"
+      }
+    ],
+    "font-press-start2p": [
+      {
+        "cask": "font-press-start2p",
+        "count": "4"
+      }
+    ],
+    "font-princess-sofia": [
+      {
+        "cask": "font-princess-sofia",
+        "count": "2"
+      }
+    ],
+    "font-prociono": [
+      {
+        "cask": "font-prociono",
+        "count": "3"
+      }
+    ],
+    "font-profont-nerd-font": [
+      {
+        "cask": "font-profont-nerd-font",
+        "count": "48"
+      }
+    ],
+    "font-profont-nerd-font-mono": [
+      {
+        "cask": "font-profont-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-profontx": [
+      {
+        "cask": "font-profontx",
+        "count": "5"
+      }
+    ],
+    "font-proggyclean-nerd-font": [
+      {
+        "cask": "font-proggyclean-nerd-font",
+        "count": "4"
+      }
+    ],
+    "font-proggyclean-nerd-font-mono": [
+      {
+        "cask": "font-proggyclean-nerd-font-mono",
+        "count": "5"
+      }
+    ],
+    "font-proggycleantt-nerd-font": [
+      {
+        "cask": "font-proggycleantt-nerd-font",
+        "count": "22"
+      }
+    ],
+    "font-proza-libre": [
+      {
+        "cask": "font-proza-libre",
+        "count": "4"
+      }
+    ],
+    "font-pt-mono": [
+      {
+        "cask": "font-pt-mono",
+        "count": "13"
+      }
+    ],
+    "font-pt-sans": [
+      {
+        "cask": "font-pt-sans",
+        "count": "11"
+      }
+    ],
+    "font-pt-serif": [
+      {
+        "cask": "font-pt-serif",
+        "count": "10"
+      }
+    ],
+    "font-public-sans": [
+      {
+        "cask": "font-public-sans",
+        "count": "13"
+      }
+    ],
+    "font-px437-pxplus": [
+      {
+        "cask": "font-px437-pxplus",
+        "count": "7"
+      }
+    ],
+    "font-quattrocento": [
+      {
+        "cask": "font-quattrocento",
+        "count": "2"
+      }
+    ],
+    "font-quattrocento-sans": [
+      {
+        "cask": "font-quattrocento-sans",
+        "count": "2"
+      }
+    ],
+    "font-quebec-serial": [
+      {
+        "cask": "font-quebec-serial",
+        "count": "3"
+      }
+    ],
+    "font-questrial": [
+      {
+        "cask": "font-questrial",
+        "count": "4"
+      }
+    ],
+    "font-quicksand": [
+      {
+        "cask": "font-quicksand",
+        "count": "13"
+      }
+    ],
+    "font-rajdhani": [
+      {
+        "cask": "font-rajdhani",
+        "count": "2"
+      }
+    ],
+    "font-raleway": [
+      {
+        "cask": "font-raleway",
+        "count": "18"
+      }
+    ],
+    "font-raleway-dots": [
+      {
+        "cask": "font-raleway-dots",
+        "count": "4"
+      }
+    ],
+    "font-ranchers": [
+      {
+        "cask": "font-ranchers",
+        "count": "2"
+      }
+    ],
+    "font-redacted": [
+      {
+        "cask": "font-redacted",
+        "count": "3"
+      }
+    ],
+    "font-redhat": [
+      {
+        "cask": "font-redhat",
+        "count": "18"
+      }
+    ],
+    "font-ribeye": [
+      {
+        "cask": "font-ribeye",
+        "count": "2"
+      }
+    ],
+    "font-ribeye-marrow": [
+      {
+        "cask": "font-ribeye-marrow",
+        "count": "2"
+      }
+    ],
+    "font-ricty-diminished": [
+      {
+        "cask": "font-ricty-diminished",
+        "count": "194"
+      }
+    ],
+    "font-righteous": [
+      {
+        "cask": "font-righteous",
+        "count": "2"
+      }
+    ],
+    "font-roboto": [
+      {
+        "cask": "font-roboto",
+        "count": "148"
+      }
+    ],
+    "font-roboto-condensed": [
+      {
+        "cask": "font-roboto-condensed",
+        "count": "44"
+      }
+    ],
+    "font-roboto-mono": [
+      {
+        "cask": "font-roboto-mono",
+        "count": "76"
+      }
+    ],
+    "font-roboto-mono-for-powerline": [
+      {
+        "cask": "font-roboto-mono-for-powerline",
+        "count": "68"
+      }
+    ],
+    "font-roboto-slab": [
+      {
+        "cask": "font-roboto-slab",
+        "count": "25"
+      }
+    ],
+    "font-robotomono-nerd-font": [
+      {
+        "cask": "font-robotomono-nerd-font",
+        "count": "133"
+      }
+    ],
+    "font-robotomono-nerd-font-mono": [
+      {
+        "cask": "font-robotomono-nerd-font-mono",
+        "count": "17"
+      }
+    ],
+    "font-rock-salt": [
+      {
+        "cask": "font-rock-salt",
+        "count": "2"
+      }
+    ],
+    "font-rounded-m-plus": [
+      {
+        "cask": "font-rounded-m-plus",
+        "count": "8"
+      }
+    ],
+    "font-routed-gothic": [
+      {
+        "cask": "font-routed-gothic",
+        "count": "3"
+      }
+    ],
+    "font-rubik": [
+      {
+        "cask": "font-rubik",
+        "count": "18"
+      }
+    ],
+    "font-ruda": [
+      {
+        "cask": "font-ruda",
+        "count": "1"
+      }
+    ],
+    "font-ruda-black": [
+      {
+        "cask": "font-ruda-black",
+        "count": "1"
+      }
+    ],
+    "font-ruda-bold": [
+      {
+        "cask": "font-ruda-bold",
+        "count": "1"
+      }
+    ],
+    "font-sacramento": [
+      {
+        "cask": "font-sacramento",
+        "count": "4"
+      }
+    ],
+    "font-san-francisco-compact": [
+      {
+        "cask": "font-san-francisco-compact",
+        "count": "1"
+      }
+    ],
+    "font-san-francisco-pro": [
+      {
+        "cask": "font-san-francisco-pro",
+        "count": "1"
+      }
+    ],
+    "font-sans-forgetica": [
+      {
+        "cask": "font-sans-forgetica",
+        "count": "12"
+      }
+    ],
+    "font-sarasa-gothic": [
+      {
+        "cask": "font-sarasa-gothic",
+        "count": "89"
+      }
+    ],
+    "font-satisfy": [
+      {
+        "cask": "font-satisfy",
+        "count": "3"
+      }
+    ],
+    "font-saucecodepro-nerd-font": [
+      {
+        "cask": "font-saucecodepro-nerd-font",
+        "count": "256"
+      }
+    ],
+    "font-scheherazade": [
+      {
+        "cask": "font-scheherazade",
+        "count": "4"
+      }
+    ],
+    "font-sf-compact": [
+      {
+        "cask": "font-sf-compact",
+        "count": "1"
+      }
+    ],
+    "font-sf-mono": [
+      {
+        "cask": "font-sf-mono",
+        "count": "4"
+      }
+    ],
+    "font-sf-mono-nerd-font": [
+      {
+        "cask": "font-sf-mono-nerd-font",
+        "count": "20"
+      }
+    ],
+    "font-sf-pro": [
+      {
+        "cask": "font-sf-pro",
+        "count": "1"
+      }
+    ],
+    "font-shadows-into-light-two": [
+      {
+        "cask": "font-shadows-into-light-two",
+        "count": "3"
+      }
+    ],
+    "font-share": [
+      {
+        "cask": "font-share",
+        "count": "3"
+      }
+    ],
+    "font-share-tech": [
+      {
+        "cask": "font-share-tech",
+        "count": "5"
+      }
+    ],
+    "font-share-tech-mono": [
+      {
+        "cask": "font-share-tech-mono",
+        "count": "6"
+      }
+    ],
+    "font-sharetechmono-nerd-font": [
+      {
+        "cask": "font-sharetechmono-nerd-font",
+        "count": "4"
+      }
+    ],
+    "font-sharetechmono-nerd-font-mono": [
+      {
+        "cask": "font-sharetechmono-nerd-font-mono",
+        "count": "3"
+      }
+    ],
+    "font-shuretechmono-nerd-font": [
+      {
+        "cask": "font-shuretechmono-nerd-font",
+        "count": "17"
+      }
+    ],
+    "font-sigmar-one": [
+      {
+        "cask": "font-sigmar-one",
+        "count": "3"
+      }
+    ],
+    "font-simonetta": [
+      {
+        "cask": "font-simonetta",
+        "count": "3"
+      }
+    ],
+    "font-simple-line-icons": [
+      {
+        "cask": "font-simple-line-icons",
+        "count": "27"
+      }
+    ],
+    "font-six-caps": [
+      {
+        "cask": "font-six-caps",
+        "count": "3"
+      }
+    ],
+    "font-sniglet": [
+      {
+        "cask": "font-sniglet",
+        "count": "3"
+      }
+    ],
+    "font-sorts-mill-goudy": [
+      {
+        "cask": "font-sorts-mill-goudy",
+        "count": "3"
+      }
+    ],
+    "font-source-code-pro": [
+      {
+        "cask": "font-source-code-pro",
+        "count": "1,245"
+      }
+    ],
+    "font-source-code-pro-for-powerline": [
+      {
+        "cask": "font-source-code-pro-for-powerline",
+        "count": "204"
+      }
+    ],
+    "font-source-han-code-jp": [
+      {
+        "cask": "font-source-han-code-jp",
+        "count": "130"
+      }
+    ],
+    "font-source-han-mono": [
+      {
+        "cask": "font-source-han-mono",
+        "count": "13"
+      }
+    ],
+    "font-source-han-noto-cjk": [
+      {
+        "cask": "font-source-han-noto-cjk",
+        "count": "17"
+      }
+    ],
+    "font-source-han-sans": [
+      {
+        "cask": "font-source-han-sans",
+        "count": "58"
+      }
+    ],
+    "font-source-han-serif": [
+      {
+        "cask": "font-source-han-serif",
+        "count": "32"
+      }
+    ],
+    "font-source-han-serif-el-m": [
+      {
+        "cask": "font-source-han-serif-el-m",
+        "count": "4"
+      }
+    ],
+    "font-source-han-serif-sb-h": [
+      {
+        "cask": "font-source-han-serif-sb-h",
+        "count": "4"
+      }
+    ],
+    "font-source-sans-pro": [
+      {
+        "cask": "font-source-sans-pro",
+        "count": "124"
+      }
+    ],
+    "font-source-serif-pro": [
+      {
+        "cask": "font-source-serif-pro",
+        "count": "82"
+      }
+    ],
+    "font-sourcecodepro-nerd-font": [
+      {
+        "cask": "font-sourcecodepro-nerd-font",
+        "count": "159"
+      }
+    ],
+    "font-sourcecodepro-nerd-font-mono": [
+      {
+        "cask": "font-sourcecodepro-nerd-font-mono",
+        "count": "22"
+      }
+    ],
+    "font-space-grotesk": [
+      {
+        "cask": "font-space-grotesk",
+        "count": "6"
+      }
+    ],
+    "font-space-mono": [
+      {
+        "cask": "font-space-mono",
+        "count": "26"
+      }
+    ],
+    "font-spacemono-nerd-font": [
+      {
+        "cask": "font-spacemono-nerd-font",
+        "count": "66"
+      }
+    ],
+    "font-spacemono-nerd-font-mono": [
+      {
+        "cask": "font-spacemono-nerd-font-mono",
+        "count": "4"
+      }
+    ],
+    "font-special-elite": [
+      {
+        "cask": "font-special-elite",
+        "count": "5"
+      }
+    ],
+    "font-spectral": [
+      {
+        "cask": "font-spectral",
+        "count": "5"
+      }
+    ],
+    "font-spleen": [
+      {
+        "cask": "font-spleen",
+        "count": "7"
+      }
+    ],
+    "font-stix": [
+      {
+        "cask": "font-stix",
+        "count": "9"
+      }
+    ],
+    "font-sudo": [
+      {
+        "cask": "font-sudo",
+        "count": "15"
+      }
+    ],
+    "font-takaoex": [
+      {
+        "cask": "font-takaoex",
+        "count": "5"
+      }
+    ],
+    "font-tangerine": [
+      {
+        "cask": "font-tangerine",
+        "count": "3"
+      }
+    ],
+    "font-terminessttf-nerd-font": [
+      {
+        "cask": "font-terminessttf-nerd-font",
+        "count": "23"
+      }
+    ],
+    "font-terminus": [
+      {
+        "cask": "font-terminus",
+        "count": "64"
+      }
+    ],
+    "font-terminus-nerd-font": [
+      {
+        "cask": "font-terminus-nerd-font",
+        "count": "7"
+      }
+    ],
+    "font-terminus-nerd-font-mono": [
+      {
+        "cask": "font-terminus-nerd-font-mono",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-adventor": [
+      {
+        "cask": "font-tex-gyre-adventor",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-bonum": [
+      {
+        "cask": "font-tex-gyre-bonum",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-bonum-math": [
+      {
+        "cask": "font-tex-gyre-bonum-math",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-chorus": [
+      {
+        "cask": "font-tex-gyre-chorus",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-cursor": [
+      {
+        "cask": "font-tex-gyre-cursor",
+        "count": "9"
+      }
+    ],
+    "font-tex-gyre-heros": [
+      {
+        "cask": "font-tex-gyre-heros",
+        "count": "9"
+      }
+    ],
+    "font-tex-gyre-pagella": [
+      {
+        "cask": "font-tex-gyre-pagella",
+        "count": "8"
+      }
+    ],
+    "font-tex-gyre-pagella-math": [
+      {
+        "cask": "font-tex-gyre-pagella-math",
+        "count": "9"
+      }
+    ],
+    "font-tex-gyre-schola": [
+      {
+        "cask": "font-tex-gyre-schola",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-schola-math": [
+      {
+        "cask": "font-tex-gyre-schola-math",
+        "count": "7"
+      }
+    ],
+    "font-tex-gyre-termes": [
+      {
+        "cask": "font-tex-gyre-termes",
+        "count": "11"
+      }
+    ],
+    "font-tex-gyre-termes-math": [
+      {
+        "cask": "font-tex-gyre-termes-math",
+        "count": "9"
+      }
+    ],
+    "font-the-girl-next-door": [
+      {
+        "cask": "font-the-girl-next-door",
+        "count": "3"
+      }
+    ],
+    "font-thesansuhh": [
+      {
+        "cask": "font-thesansuhh",
+        "count": "1"
+      }
+    ],
+    "font-times-new-roman": [
+      {
+        "cask": "font-times-new-roman",
+        "count": "2"
+      }
+    ],
+    "font-tinos-nerd-font": [
+      {
+        "cask": "font-tinos-nerd-font",
+        "count": "33"
+      }
+    ],
+    "font-tinos-nerd-font-mono": [
+      {
+        "cask": "font-tinos-nerd-font-mono",
+        "count": "2"
+      }
+    ],
+    "font-titillium": [
+      {
+        "cask": "font-titillium",
+        "count": "7"
+      }
+    ],
+    "font-trebuchet-ms": [
+      {
+        "cask": "font-trebuchet-ms",
+        "count": "4"
+      }
+    ],
+    "font-tulpen-one": [
+      {
+        "cask": "font-tulpen-one",
+        "count": "2"
+      }
+    ],
+    "font-twitter-color-emoji": [
+      {
+        "cask": "font-twitter-color-emoji",
+        "count": "13"
+      }
+    ],
+    "font-ubuntu": [
+      {
+        "cask": "font-ubuntu",
+        "count": "81"
+      }
+    ],
+    "font-ubuntu-mono-derivative-powerline": [
+      {
+        "cask": "font-ubuntu-mono-derivative-powerline",
+        "count": "43"
+      }
+    ],
+    "font-ubuntu-nerd-font": [
+      {
+        "cask": "font-ubuntu-nerd-font",
+        "count": "80"
+      }
+    ],
+    "font-ubuntu-nerd-font-mono": [
+      {
+        "cask": "font-ubuntu-nerd-font-mono",
+        "count": "6"
+      }
+    ],
+    "font-ubuntumono-nerd-font": [
+      {
+        "cask": "font-ubuntumono-nerd-font",
+        "count": "104"
+      }
+    ],
+    "font-ubuntumono-nerd-font-mono": [
+      {
+        "cask": "font-ubuntumono-nerd-font-mono",
+        "count": "3"
+      }
+    ],
+    "font-urw-base35": [
+      {
+        "cask": "font-urw-base35",
+        "count": "2"
+      }
+    ],
+    "font-varela-round": [
+      {
+        "cask": "font-varela-round",
+        "count": "3"
+      }
+    ],
+    "font-verdana": [
+      {
+        "cask": "font-verdana",
+        "count": "3"
+      }
+    ],
+    "font-victor-mono": [
+      {
+        "cask": "font-victor-mono",
+        "count": "169"
+      }
+    ],
+    "font-victormono-nerd-font": [
+      {
+        "cask": "font-victormono-nerd-font",
+        "count": "49"
+      }
+    ],
+    "font-vidaloka": [
+      {
+        "cask": "font-vidaloka",
+        "count": "2"
+      }
+    ],
+    "font-vlgothic": [
+      {
+        "cask": "font-vlgothic",
+        "count": "1"
+      }
+    ],
+    "font-volkhov": [
+      {
+        "cask": "font-volkhov",
+        "count": "1"
+      }
+    ],
+    "font-vollkorn": [
+      {
+        "cask": "font-vollkorn",
+        "count": "10"
+      }
+    ],
+    "font-vt323": [
+      {
+        "cask": "font-vt323",
+        "count": "5"
+      }
+    ],
+    "font-wire-one": [
+      {
+        "cask": "font-wire-one",
+        "count": "1"
+      }
+    ],
+    "font-work-sans": [
+      {
+        "cask": "font-work-sans",
+        "count": "22"
+      }
+    ],
+    "font-xits": [
+      {
+        "cask": "font-xits",
+        "count": "5"
+      }
+    ],
+    "font-xkcd": [
+      {
+        "cask": "font-xkcd",
+        "count": "14"
+      }
+    ],
+    "font-xkcd-script": [
+      {
+        "cask": "font-xkcd-script",
+        "count": "10"
+      }
+    ],
+    "font-yellowtail": [
+      {
+        "cask": "font-yellowtail",
+        "count": "1"
+      }
+    ],
+    "font-yorkten": [
+      {
+        "cask": "font-yorkten",
+        "count": "4"
+      }
+    ],
+    "font-ysabeau": [
+      {
+        "cask": "font-ysabeau",
+        "count": "2"
+      }
+    ],
+    "font-zilla-slab": [
+      {
+        "cask": "font-zilla-slab",
+        "count": "6"
+      }
+    ],
+    "fontbase": [
+      {
+        "cask": "fontbase",
+        "count": "86"
+      }
+    ],
+    "fontexplorer-x-pro": [
+      {
+        "cask": "fontexplorer-x-pro",
+        "count": "7"
+      }
+    ],
+    "fontforge": [
+      {
+        "cask": "fontforge",
+        "count": "343"
+      }
+    ],
+    "fontgoggles": [
+      {
+        "cask": "fontgoggles",
+        "count": "19"
+      }
+    ],
+    "fontlab": [
+      {
+        "cask": "fontlab",
+        "count": "7"
+      }
+    ],
+    "fontplop": [
+      {
+        "cask": "fontplop",
+        "count": "28"
+      }
+    ],
+    "fontstand": [
+      {
+        "cask": "fontstand",
+        "count": "1"
+      }
+    ],
+    "force-paste": [
+      {
+        "cask": "force-paste",
+        "count": "21"
+      }
+    ],
+    "forecast": [
+      {
+        "cask": "forecast",
+        "count": "8"
+      }
+    ],
+    "foreman": [
+      {
+        "cask": "foreman",
+        "count": "65"
+      }
+    ],
+    "fork": [
+      {
+        "cask": "fork",
+        "count": "788"
+      }
+    ],
+    "forklift": [
+      {
+        "cask": "forklift",
+        "count": "273"
+      }
+    ],
+    "forklift2": [
+      {
+        "cask": "forklift2",
+        "count": "3"
+      }
+    ],
+    "forticlient": [
+      {
+        "cask": "forticlient",
+        "count": "258"
+      }
+    ],
+    "foxitreader": [
+      {
+        "cask": "foxitreader",
+        "count": "102"
+      }
+    ],
+    "foxmail": [
+      {
+        "cask": "foxmail",
+        "count": "37"
+      }
+    ],
+    "fpcsrc": [
+      {
+        "cask": "fpcsrc",
+        "count": "89"
+      }
+    ],
+    "fractal-bot": [
+      {
+        "cask": "fractal-bot",
+        "count": "3"
+      }
+    ],
+    "framer": [
+      {
+        "cask": "framer",
+        "count": "3"
+      }
+    ],
+    "framer-x": [
+      {
+        "cask": "framer-x",
+        "count": "11"
+      }
+    ],
+    "franz": [
+      {
+        "cask": "franz",
+        "count": "333"
+      }
+    ],
+    "freac": [
+      {
+        "cask": "freac",
+        "count": "58"
+      }
+    ],
+    "free-download-manager": [
+      {
+        "cask": "free-download-manager",
+        "count": "211"
+      }
+    ],
+    "free-ruler": [
+      {
+        "cask": "free-ruler",
+        "count": "35"
+      }
+    ],
+    "freecad": [
+      {
+        "cask": "freecad",
+        "count": "488"
+      }
+    ],
+    "freecad-nightly": [
+      {
+        "cask": "freecad-nightly",
+        "count": "3"
+      }
+    ],
+    "freeclip": [
+      {
+        "cask": "freeclip",
+        "count": "1"
+      }
+    ],
+    "freecol": [
+      {
+        "cask": "freecol",
+        "count": "7"
+      }
+    ],
+    "freedom": [
+      {
+        "cask": "freedom",
+        "count": "38"
+      }
+    ],
+    "freedome": [
+      {
+        "cask": "freedome",
+        "count": "4"
+      }
+    ],
+    "freefilesync": [
+      {
+        "cask": "freefilesync",
+        "count": "1"
+      }
+    ],
+    "freemind": [
+      {
+        "cask": "freemind",
+        "count": "148"
+      }
+    ],
+    "freenettray": [
+      {
+        "cask": "freenettray",
+        "count": "7"
+      }
+    ],
+    "freeorion": [
+      {
+        "cask": "freeorion",
+        "count": "5"
+      }
+    ],
+    "freeplane": [
+      {
+        "cask": "freeplane",
+        "count": "98"
+      }
+    ],
+    "freesmug-chromium": [
+      {
+        "cask": "freesmug-chromium",
+        "count": "69"
+      }
+    ],
+    "freeter": [
+      {
+        "cask": "freeter",
+        "count": "7"
+      }
+    ],
+    "freeyourmusic": [
+      {
+        "cask": "freeyourmusic",
+        "count": "32"
+      }
+    ],
+    "freeze": [
+      {
+        "cask": "freeze",
+        "count": "16"
+      }
+    ],
+    "frescobaldi": [
+      {
+        "cask": "frescobaldi",
+        "count": "61"
+      }
+    ],
+    "frhelper": [
+      {
+        "cask": "frhelper",
+        "count": "3"
+      }
+    ],
+    "fritzing": [
+      {
+        "cask": "fritzing",
+        "count": "214"
+      }
+    ],
+    "fromscratch": [
+      {
+        "cask": "fromscratch",
+        "count": "14"
+      }
+    ],
+    "front": [
+      {
+        "cask": "front",
+        "count": "13"
+      }
+    ],
+    "fruit": [
+      {
+        "cask": "fruit",
+        "count": "2"
+      }
+    ],
+    "fs-uae": [
+      {
+        "cask": "fs-uae",
+        "count": "15"
+      }
+    ],
+    "fsmonitor": [
+      {
+        "cask": "fsmonitor",
+        "count": "8"
+      }
+    ],
+    "fsnotes": [
+      {
+        "cask": "fsnotes",
+        "count": "408"
+      }
+    ],
+    "fstream": [
+      {
+        "cask": "fstream",
+        "count": "1"
+      }
+    ],
+    "ftdi-vcp-driver": [
+      {
+        "cask": "ftdi-vcp-driver",
+        "count": "12"
+      }
+    ],
+    "fugu": [
+      {
+        "cask": "fugu",
+        "count": "117"
+      }
+    ],
+    "fujifilm-x-raw-studio": [
+      {
+        "cask": "fujifilm-x-raw-studio",
+        "count": "7"
+      }
+    ],
+    "fujitsu-scansnap-home": [
+      {
+        "cask": "fujitsu-scansnap-home",
+        "count": "20"
+      }
+    ],
+    "fujitsu-scansnap-manager": [
+      {
+        "cask": "fujitsu-scansnap-manager",
+        "count": "7"
+      }
+    ],
+    "fujitsu-scansnap-manager-ix500": [
+      {
+        "cask": "fujitsu-scansnap-manager-ix500",
+        "count": "9"
+      }
+    ],
+    "fujitsu-scansnap-manager-s1300": [
+      {
+        "cask": "fujitsu-scansnap-manager-s1300",
+        "count": "3"
+      }
+    ],
+    "functionflip": [
+      {
+        "cask": "functionflip",
+        "count": "6"
+      }
+    ],
+    "funter": [
+      {
+        "cask": "funter",
+        "count": "35"
+      }
+    ],
+    "fuse": [
+      {
+        "cask": "fuse",
+        "count": "198"
+      }
+    ],
+    "futuniuniu": [
+      {
+        "cask": "futuniuniu",
+        "count": "22"
+      }
+    ],
+    "fuwari": [
+      {
+        "cask": "fuwari",
+        "count": "3"
+      }
+    ],
+    "fuzzyclock": [
+      {
+        "cask": "fuzzyclock",
+        "count": "8"
+      }
+    ],
+    "gameranger": [
+      {
+        "cask": "gameranger",
+        "count": "5"
+      }
+    ],
+    "gameshow": [
+      {
+        "cask": "gameshow",
+        "count": "2"
+      }
+    ],
+    "ganache": [
+      {
+        "cask": "ganache",
+        "count": "72"
+      }
+    ],
+    "ganttproject": [
+      {
+        "cask": "ganttproject",
+        "count": "101"
+      }
+    ],
+    "garagebuy": [
+      {
+        "cask": "garagebuy",
+        "count": "1"
+      }
+    ],
+    "garagesale": [
+      {
+        "cask": "garagesale",
+        "count": "1"
+      }
+    ],
+    "gargoyle": [
+      {
+        "cask": "gargoyle",
+        "count": "10"
+      }
+    ],
+    "garmin-basecamp": [
+      {
+        "cask": "garmin-basecamp",
+        "count": "17"
+      }
+    ],
+    "garmin-express": [
+      {
+        "cask": "garmin-express",
+        "count": "57"
+      }
+    ],
+    "gas-mask": [
+      {
+        "cask": "gas-mask",
+        "count": "156"
+      }
+    ],
+    "gb-studio": [
+      {
+        "cask": "gb-studio",
+        "count": "2"
+      }
+    ],
+    "gcc-arm-embedded": [
+      {
+        "cask": "gcc-arm-embedded",
+        "count": "355"
+      }
+    ],
+    "gcc-arm-embedded-2017q2": [
+      {
+        "cask": "gcc-arm-embedded-2017q2",
+        "count": "2"
+      }
+    ],
+    "gcc-arm-embedded-2017q4": [
+      {
+        "cask": "gcc-arm-embedded-2017q4",
+        "count": "1"
+      }
+    ],
+    "gcc-arm-embedded-2019q4": [
+      {
+        "cask": "gcc-arm-embedded-2019q4",
+        "count": "2"
+      }
+    ],
+    "gcollazo-mongodb": [
+      {
+        "cask": "gcollazo-mongodb",
+        "count": "27"
+      }
+    ],
+    "gdisk": [
+      {
+        "cask": "gdisk",
+        "count": "174"
+      }
+    ],
+    "gdlauncher": [
+      {
+        "cask": "gdlauncher",
+        "count": "3"
+      }
+    ],
+    "geany": [
+      {
+        "cask": "geany",
+        "count": "207"
+      }
+    ],
+    "gearboy": [
+      {
+        "cask": "gearboy",
+        "count": "22"
+      }
+    ],
+    "gearsystem": [
+      {
+        "cask": "gearsystem",
+        "count": "6"
+      }
+    ],
+    "geburtstagschecker": [
+      {
+        "cask": "geburtstagschecker",
+        "count": "1"
+      }
+    ],
+    "geekbench": [
+      {
+        "cask": "geekbench",
+        "count": "343"
+      }
+    ],
+    "geektool": [
+      {
+        "cask": "geektool",
+        "count": "72"
+      }
+    ],
+    "gemini": [
+      {
+        "cask": "gemini",
+        "count": "94"
+      }
+    ],
+    "genymotion": [
+      {
+        "cask": "genymotion",
+        "count": "160"
+      }
+    ],
+    "geogebra": [
+      {
+        "cask": "geogebra",
+        "count": "92"
+      }
+    ],
+    "geomap": [
+      {
+        "cask": "geomap",
+        "count": "4"
+      }
+    ],
+    "geotag": [
+      {
+        "cask": "geotag",
+        "count": "7"
+      }
+    ],
+    "geotag-photos-pro": [
+      {
+        "cask": "geotag-photos-pro",
+        "count": "1"
+      }
+    ],
+    "geph": [
+      {
+        "cask": "geph",
+        "count": "10"
+      }
+    ],
+    "gephi": [
+      {
+        "cask": "gephi",
+        "count": "72"
+      }
+    ],
+    "get-backup-pro": [
+      {
+        "cask": "get-backup-pro",
+        "count": "3"
+      }
+    ],
+    "get-iplayer-automator": [
+      {
+        "cask": "get-iplayer-automator",
+        "count": "8"
+      }
+    ],
+    "get-lyrical": [
+      {
+        "cask": "get-lyrical",
+        "count": "1"
+      }
+    ],
+    "getrasplex": [
+      {
+        "cask": "getrasplex",
+        "count": "1"
+      }
+    ],
+    "gfortran": [
+      {
+        "cask": "gfortran",
+        "count": "792"
+      }
+    ],
+    "gfxcardstatus": [
+      {
+        "cask": "gfxcardstatus",
+        "count": "125"
+      }
+    ],
+    "ghdl": [
+      {
+        "cask": "ghdl",
+        "count": "56"
+      }
+    ],
+    "ghidra": [
+      {
+        "cask": "ghidra",
+        "count": "243"
+      }
+    ],
+    "ghidra-beta": [
+      {
+        "cask": "ghidra-beta",
+        "count": "3"
+      }
+    ],
+    "ghost": [
+      {
+        "cask": "ghost",
+        "count": "19"
+      }
+    ],
+    "ghost-browser": [
+      {
+        "cask": "ghost-browser",
+        "count": "14"
+      }
+    ],
+    "ghosttile": [
+      {
+        "cask": "ghosttile",
+        "count": "9"
+      }
+    ],
+    "gifcapture": [
+      {
+        "cask": "gifcapture",
+        "count": "79"
+      }
+    ],
+    "gifox": [
+      {
+        "cask": "gifox",
+        "count": "73"
+      }
+    ],
+    "gifrocket": [
+      {
+        "cask": "gifrocket",
+        "count": "21"
+      }
+    ],
+    "gifs": [
+      {
+        "cask": "gifs",
+        "count": "4"
+      }
+    ],
+    "gimp": [
+      {
+        "cask": "gimp",
+        "count": "3,621"
+      }
+    ],
+    "gingko": [
+      {
+        "cask": "gingko",
+        "count": "4"
+      }
+    ],
+    "gisto": [
+      {
+        "cask": "gisto",
+        "count": "22"
+      }
+    ],
+    "git-it": [
+      {
+        "cask": "git-it",
+        "count": "28"
+      }
+    ],
+    "gitahead": [
+      {
+        "cask": "gitahead",
+        "count": "57"
+      }
+    ],
+    "gitblade": [
+      {
+        "cask": "gitblade",
+        "count": "16"
+      }
+    ],
+    "gitbook": [
+      {
+        "cask": "gitbook",
+        "count": "98"
+      }
+    ],
+    "gitbox": [
+      {
+        "cask": "gitbox",
+        "count": "5"
+      }
+    ],
+    "gitee": [
+      {
+        "cask": "gitee",
+        "count": "3"
+      }
+    ],
+    "giteye": [
+      {
+        "cask": "giteye",
+        "count": "11"
+      }
+    ],
+    "gitfiend": [
+      {
+        "cask": "gitfiend",
+        "count": "5"
+      }
+    ],
+    "gitfinder": [
+      {
+        "cask": "gitfinder",
+        "count": "7"
+      }
+    ],
+    "gitfox": [
+      {
+        "cask": "gitfox",
+        "count": "12"
+      }
+    ],
+    "github": [
+      {
+        "cask": "github",
+        "count": "2,316"
+      }
+    ],
+    "github-beta": [
+      {
+        "cask": "github-beta",
+        "count": "11"
+      }
+    ],
+    "githubpulse": [
+      {
+        "cask": "githubpulse",
+        "count": "6"
+      }
+    ],
+    "gitify": [
+      {
+        "cask": "gitify",
+        "count": "104"
+      }
+    ],
+    "gitkraken": [
+      {
+        "cask": "gitkraken",
+        "count": "720"
+      }
+    ],
+    "gitnote": [
+      {
+        "cask": "gitnote",
+        "count": "10"
+      }
+    ],
+    "gitscout": [
+      {
+        "cask": "gitscout",
+        "count": "7"
+      }
+    ],
+    "gitter": [
+      {
+        "cask": "gitter",
+        "count": "91"
+      }
+    ],
+    "gitup": [
+      {
+        "cask": "gitup",
+        "count": "309"
+      }
+    ],
+    "gitx": [
+      {
+        "cask": "gitx",
+        "count": "101"
+      }
+    ],
+    "glimmerblocker": [
+      {
+        "cask": "glimmerblocker",
+        "count": "1"
+      }
+    ],
+    "glip": [
+      {
+        "cask": "glip",
+        "count": "7"
+      }
+    ],
+    "globalmeet": [
+      {
+        "cask": "globalmeet",
+        "count": "3"
+      }
+    ],
+    "globalprotect": [
+      {
+        "cask": "globalprotect",
+        "count": "1"
+      }
+    ],
+    "gloomhaven-helper": [
+      {
+        "cask": "gloomhaven-helper",
+        "count": "90"
+      }
+    ],
+    "gltfquicklook": [
+      {
+        "cask": "gltfquicklook",
+        "count": "49"
+      }
+    ],
+    "glyphfinder": [
+      {
+        "cask": "glyphfinder",
+        "count": "3"
+      }
+    ],
+    "glyphs": [
+      {
+        "cask": "glyphs",
+        "count": "20"
+      }
+    ],
+    "gmail-notifier": [
+      {
+        "cask": "gmail-notifier",
+        "count": "9"
+      }
+    ],
+    "gmvault": [
+      {
+        "cask": "gmvault",
+        "count": "11"
+      }
+    ],
+    "gns3": [
+      {
+        "cask": "gns3",
+        "count": "88"
+      }
+    ],
+    "gnucash": [
+      {
+        "cask": "gnucash",
+        "count": "210"
+      }
+    ],
+    "go-agent": [
+      {
+        "cask": "go-agent",
+        "count": "5"
+      }
+    ],
+    "go-server": [
+      {
+        "cask": "go-server",
+        "count": "5"
+      }
+    ],
+    "go2shell": [
+      {
+        "cask": "go2shell",
+        "count": "110"
+      }
+    ],
+    "go64": [
+      {
+        "cask": "go64",
+        "count": "18"
+      }
+    ],
+    "godot": [
+      {
+        "cask": "godot",
+        "count": "1,016"
+      }
+    ],
+    "godot-mono": [
+      {
+        "cask": "godot-mono",
+        "count": "43"
+      }
+    ],
+    "godot-nightly": [
+      {
+        "cask": "godot-nightly",
+        "count": "6"
+      }
+    ],
+    "gog-downloader": [
+      {
+        "cask": "gog-downloader",
+        "count": "1"
+      }
+    ],
+    "gog-galaxy": [
+      {
+        "cask": "gog-galaxy",
+        "count": "163"
+      }
+    ],
+    "gogs": [
+      {
+        "cask": "gogs",
+        "count": "7"
+      }
+    ],
+    "goland": [
+      {
+        "cask": "goland",
+        "count": "627"
+      }
+    ],
+    "goldencheetah": [
+      {
+        "cask": "goldencheetah",
+        "count": "12"
+      }
+    ],
+    "goldendict": [
+      {
+        "cask": "goldendict",
+        "count": "23"
+      }
+    ],
+    "golem": [
+      {
+        "cask": "golem",
+        "count": "79"
+      }
+    ],
+    "golem-mainnet-launcher": [
+      {
+        "cask": "golem-mainnet-launcher",
+        "count": "71"
+      }
+    ],
+    "golly": [
+      {
+        "cask": "golly",
+        "count": "26"
+      }
+    ],
+    "gom-player": [
+      {
+        "cask": "gom-player",
+        "count": "1"
+      }
+    ],
+    "goodsync": [
+      {
+        "cask": "goodsync",
+        "count": "39"
+      }
+    ],
+    "goofy": [
+      {
+        "cask": "goofy",
+        "count": "34"
+      }
+    ],
+    "google-ads-editor": [
+      {
+        "cask": "google-ads-editor",
+        "count": "54"
+      }
+    ],
+    "google-backup-and-sync": [
+      {
+        "cask": "google-backup-and-sync",
+        "count": "966"
+      }
+    ],
+    "google-chat": [
+      {
+        "cask": "google-chat",
+        "count": "183"
+      }
+    ],
+    "google-chrome": [
+      {
+        "cask": "google-chrome",
+        "count": "17,436"
+      }
+    ],
+    "google-chrome-beta": [
+      {
+        "cask": "google-chrome-beta",
+        "count": "73"
+      }
+    ],
+    "google-chrome-canary": [
+      {
+        "cask": "google-chrome-canary",
+        "count": "409"
+      }
+    ],
+    "google-chrome-dev": [
+      {
+        "cask": "google-chrome-dev",
+        "count": "101"
+      }
+    ],
+    "google-cloud-sdk": [
+      {
+        "cask": "google-cloud-sdk",
+        "count": "4,481"
+      }
+    ],
+    "google-drive-file-stream": [
+      {
+        "cask": "google-drive-file-stream",
+        "count": "1,464"
+      }
+    ],
+    "google-earth-pro": [
+      {
+        "cask": "google-earth-pro",
+        "count": "587"
+      }
+    ],
+    "google-featured-photos": [
+      {
+        "cask": "google-featured-photos",
+        "count": "10"
+      }
+    ],
+    "google-hangouts": [
+      {
+        "cask": "google-hangouts",
+        "count": "414"
+      }
+    ],
+    "google-japanese-ime": [
+      {
+        "cask": "google-japanese-ime",
+        "count": "533"
+      }
+    ],
+    "google-japanese-ime-dev": [
+      {
+        "cask": "google-japanese-ime-dev",
+        "count": "1"
+      }
+    ],
+    "google-nik-collection": [
+      {
+        "cask": "google-nik-collection",
+        "count": "1"
+      }
+    ],
+    "google-photos-backup-and-sync": [
+      {
+        "cask": "google-photos-backup-and-sync",
+        "count": "88"
+      }
+    ],
+    "google-trends": [
+      {
+        "cask": "google-trends",
+        "count": "48"
+      }
+    ],
+    "google-web-designer": [
+      {
+        "cask": "google-web-designer",
+        "count": "77"
+      }
+    ],
+    "googleappengine": [
+      {
+        "cask": "googleappengine",
+        "count": "14"
+      }
+    ],
+    "gopanda": [
+      {
+        "cask": "gopanda",
+        "count": "7"
+      }
+    ],
+    "gopass-ui": [
+      {
+        "cask": "gopass-ui",
+        "count": "21"
+      }
+    ],
+    "gotiengviet": [
+      {
+        "cask": "gotiengviet",
+        "count": "11"
+      }
+    ],
+    "gpg-suite": [
+      {
+        "cask": "gpg-suite",
+        "count": "1,120"
+      }
+    ],
+    "gpg-suite-nightly": [
+      {
+        "cask": "gpg-suite-nightly",
+        "count": "4"
+      }
+    ],
+    "gpg-suite-no-mail": [
+      {
+        "cask": "gpg-suite-no-mail",
+        "count": "154"
+      }
+    ],
+    "gpg-suite-pinentry": [
+      {
+        "cask": "gpg-suite-pinentry",
+        "count": "31"
+      }
+    ],
+    "gpg-sync": [
+      {
+        "cask": "gpg-sync",
+        "count": "7"
+      }
+    ],
+    "gplates": [
+      {
+        "cask": "gplates",
+        "count": "3"
+      }
+    ],
+    "gpodder": [
+      {
+        "cask": "gpodder",
+        "count": "27"
+      }
+    ],
+    "gpower": [
+      {
+        "cask": "gpower",
+        "count": "4"
+      }
+    ],
+    "gpsdump": [
+      {
+        "cask": "gpsdump",
+        "count": "1"
+      }
+    ],
+    "gpxsee": [
+      {
+        "cask": "gpxsee",
+        "count": "37"
+      }
+    ],
+    "gqrx": [
+      {
+        "cask": "gqrx",
+        "count": "232"
+      }
+    ],
+    "graalvm-ce-java11": [
+      {
+        "cask": "graalvm-ce-java11",
+        "count": "261"
+      }
+    ],
+    "graalvm-ce-java8": [
+      {
+        "cask": "graalvm-ce-java8",
+        "count": "131"
+      }
+    ],
+    "grads": [
+      {
+        "cask": "grads",
+        "count": "46"
+      }
+    ],
+    "grafx": [
+      {
+        "cask": "grafx",
+        "count": "8"
+      }
+    ],
+    "grakn-workbase": [
+      {
+        "cask": "grakn-workbase",
+        "count": "50"
+      }
+    ],
+    "grammarly": [
+      {
+        "cask": "grammarly",
+        "count": "338"
+      }
+    ],
+    "gramps": [
+      {
+        "cask": "gramps",
+        "count": "22"
+      }
+    ],
+    "grandperspective": [
+      {
+        "cask": "grandperspective",
+        "count": "378"
+      }
+    ],
+    "grandtotal": [
+      {
+        "cask": "grandtotal",
+        "count": "2"
+      }
+    ],
+    "graphicconverter": [
+      {
+        "cask": "graphicconverter",
+        "count": "40"
+      }
+    ],
+    "graphiql": [
+      {
+        "cask": "graphiql",
+        "count": "1,236"
+      }
+    ],
+    "graphql-ide": [
+      {
+        "cask": "graphql-ide",
+        "count": "19"
+      }
+    ],
+    "graphql-playground": [
+      {
+        "cask": "graphql-playground",
+        "count": "824"
+      }
+    ],
+    "graphsketcher": [
+      {
+        "cask": "graphsketcher",
+        "count": "3"
+      }
+    ],
+    "gray": [
+      {
+        "cask": "gray",
+        "count": "39"
+      }
+    ],
+    "greenfoot": [
+      {
+        "cask": "greenfoot",
+        "count": "3"
+      }
+    ],
+    "gretl": [
+      {
+        "cask": "gretl",
+        "count": "15"
+      }
+    ],
+    "gridea": [
+      {
+        "cask": "gridea",
+        "count": "16"
+      }
+    ],
+    "grids": [
+      {
+        "cask": "grids",
+        "count": "5"
+      }
+    ],
+    "grisbi": [
+      {
+        "cask": "grisbi",
+        "count": "2"
+      }
+    ],
+    "growlnotify": [
+      {
+        "cask": "growlnotify",
+        "count": "40"
+      }
+    ],
+    "gswitch": [
+      {
+        "cask": "gswitch",
+        "count": "522"
+      }
+    ],
+    "gtkwave": [
+      {
+        "cask": "gtkwave",
+        "count": "302"
+      }
+    ],
+    "gtt-taskbar": [
+      {
+        "cask": "gtt-taskbar",
+        "count": "3"
+      }
+    ],
+    "gu-base": [
+      {
+        "cask": "gu-base",
+        "count": "4"
+      }
+    ],
+    "gu-scala": [
+      {
+        "cask": "gu-scala",
+        "count": "6"
+      }
+    ],
+    "guijs": [
+      {
+        "cask": "guijs",
+        "count": "6"
+      }
+    ],
+    "guild-wars2": [
+      {
+        "cask": "guild-wars2",
+        "count": "12"
+      }
+    ],
+    "guitar-pro": [
+      {
+        "cask": "guitar-pro",
+        "count": "28"
+      }
+    ],
+    "gulp": [
+      {
+        "cask": "gulp",
+        "count": "270"
+      }
+    ],
+    "guppy": [
+      {
+        "cask": "guppy",
+        "count": "2"
+      }
+    ],
+    "gureumkim": [
+      {
+        "cask": "gureumkim",
+        "count": "53"
+      }
+    ],
+    "gutenprint": [
+      {
+        "cask": "gutenprint",
+        "count": "26"
+      }
+    ],
+    "gyazmail": [
+      {
+        "cask": "gyazmail",
+        "count": "2"
+      }
+    ],
+    "gyazo": [
+      {
+        "cask": "gyazo",
+        "count": "54"
+      }
+    ],
+    "gzdoom": [
+      {
+        "cask": "gzdoom",
+        "count": "43"
+      }
+    ],
+    "ha-menu": [
+      {
+        "cask": "ha-menu",
+        "count": "24"
+      }
+    ],
+    "hab": [
+      {
+        "cask": "hab",
+        "count": "3"
+      }
+    ],
+    "hackaru": [
+      {
+        "cask": "hackaru",
+        "count": "1"
+      }
+    ],
+    "hacker-menu": [
+      {
+        "cask": "hacker-menu",
+        "count": "19"
+      }
+    ],
+    "hackhands": [
+      {
+        "cask": "hackhands",
+        "count": "3"
+      }
+    ],
+    "hackintool": [
+      {
+        "cask": "hackintool",
+        "count": "145"
+      }
+    ],
+    "hackmd": [
+      {
+        "cask": "hackmd",
+        "count": "6"
+      }
+    ],
+    "hakuneko": [
+      {
+        "cask": "hakuneko",
+        "count": "8"
+      }
+    ],
+    "hammerspoon": [
+      {
+        "cask": "hammerspoon",
+        "count": "535"
+      }
+    ],
+    "hamsket-nightly": [
+      {
+        "cask": "hamsket-nightly",
+        "count": "5"
+      }
+    ],
+    "hand-mirror": [
+      {
+        "cask": "hand-mirror",
+        "count": "14"
+      }
+    ],
+    "handbrake": [
+      {
+        "cask": "handbrake",
+        "count": "1,607"
+      }
+    ],
+    "handbrake-nightly": [
+      {
+        "cask": "handbrake-nightly",
+        "count": "18"
+      }
+    ],
+    "handbrakebatch": [
+      {
+        "cask": "handbrakebatch",
+        "count": "12"
+      }
+    ],
+    "hands-off": [
+      {
+        "cask": "hands-off",
+        "count": "10"
+      }
+    ],
+    "handshaker": [
+      {
+        "cask": "handshaker",
+        "count": "22"
+      }
+    ],
+    "happygrep": [
+      {
+        "cask": "happygrep",
+        "count": "2"
+      }
+    ],
+    "haptic-touch-bar": [
+      {
+        "cask": "haptic-touch-bar",
+        "count": "39"
+      }
+    ],
+    "haptickey": [
+      {
+        "cask": "haptickey",
+        "count": "49"
+      }
+    ],
+    "harbor": [
+      {
+        "cask": "harbor",
+        "count": "1"
+      }
+    ],
+    "harmony": [
+      {
+        "cask": "harmony",
+        "count": "8"
+      }
+    ],
+    "haroopad": [
+      {
+        "cask": "haroopad",
+        "count": "13"
+      }
+    ],
+    "harvest": [
+      {
+        "cask": "harvest",
+        "count": "86"
+      }
+    ],
+    "hashbackup": [
+      {
+        "cask": "hashbackup",
+        "count": "5"
+      }
+    ],
+    "haskell-for-mac": [
+      {
+        "cask": "haskell-for-mac",
+        "count": "28"
+      }
+    ],
+    "hazel": [
+      {
+        "cask": "hazel",
+        "count": "150"
+      }
+    ],
+    "hazeover": [
+      {
+        "cask": "hazeover",
+        "count": "42"
+      }
+    ],
+    "hbuilder": [
+      {
+        "cask": "hbuilder",
+        "count": "14"
+      }
+    ],
+    "hbuilderx": [
+      {
+        "cask": "hbuilderx",
+        "count": "44"
+      }
+    ],
+    "hdhomerun": [
+      {
+        "cask": "hdhomerun",
+        "count": "3"
+      }
+    ],
+    "hdrmerge": [
+      {
+        "cask": "hdrmerge",
+        "count": "4"
+      }
+    ],
+    "headset": [
+      {
+        "cask": "headset",
+        "count": "15"
+      }
+    ],
+    "heaven": [
+      {
+        "cask": "heaven",
+        "count": "24"
+      }
+    ],
+    "hedgewars": [
+      {
+        "cask": "hedgewars",
+        "count": "18"
+      }
+    ],
+    "heimdall-suite": [
+      {
+        "cask": "heimdall-suite",
+        "count": "19"
+      }
+    ],
+    "helium": [
+      {
+        "cask": "helium",
+        "count": "104"
+      }
+    ],
+    "helo": [
+      {
+        "cask": "helo",
+        "count": "2"
+      }
+    ],
+    "hermes": [
+      {
+        "cask": "hermes",
+        "count": "18"
+      }
+    ],
+    "hex": [
+      {
+        "cask": "hex",
+        "count": "10"
+      }
+    ],
+    "hex-fiend": [
+      {
+        "cask": "hex-fiend",
+        "count": "316"
+      }
+    ],
+    "hex-fiend-beta": [
+      {
+        "cask": "hex-fiend-beta",
+        "count": "6"
+      }
+    ],
+    "hfsleuth": [
+      {
+        "cask": "hfsleuth",
+        "count": "8"
+      }
+    ],
+    "hiarcs-chess-explorer": [
+      {
+        "cask": "hiarcs-chess-explorer",
+        "count": "5"
+      }
+    ],
+    "hiddenbar": [
+      {
+        "cask": "hiddenbar",
+        "count": "238"
+      }
+    ],
+    "hider": [
+      {
+        "cask": "hider",
+        "count": "2"
+      }
+    ],
+    "hipchat": [
+      {
+        "cask": "hipchat",
+        "count": "24"
+      }
+    ],
+    "historyhound": [
+      {
+        "cask": "historyhound",
+        "count": "2"
+      }
+    ],
+    "hma-pro-vpn": [
+      {
+        "cask": "hma-pro-vpn",
+        "count": "19"
+      }
+    ],
+    "hockey": [
+      {
+        "cask": "hockey",
+        "count": "4"
+      }
+    ],
+    "hocus-focus": [
+      {
+        "cask": "hocus-focus",
+        "count": "34"
+      }
+    ],
+    "holavpn": [
+      {
+        "cask": "holavpn",
+        "count": "8"
+      }
+    ],
+    "home-inventory": [
+      {
+        "cask": "home-inventory",
+        "count": "2"
+      }
+    ],
+    "honer": [
+      {
+        "cask": "honer",
+        "count": "9"
+      }
+    ],
+    "honto": [
+      {
+        "cask": "honto",
+        "count": "5"
+      }
+    ],
+    "hook": [
+      {
+        "cask": "hook",
+        "count": "2"
+      }
+    ],
+    "hopper-debugger-server": [
+      {
+        "cask": "hopper-debugger-server",
+        "count": "7"
+      }
+    ],
+    "hopper-disassembler": [
+      {
+        "cask": "hopper-disassembler",
+        "count": "9"
+      }
+    ],
+    "horndis": [
+      {
+        "cask": "horndis",
+        "count": "119"
+      }
+    ],
+    "horos": [
+      {
+        "cask": "horos",
+        "count": "38"
+      }
+    ],
+    "hosty": [
+      {
+        "cask": "hosty",
+        "count": "1"
+      }
+    ],
+    "hotswitch": [
+      {
+        "cask": "hotswitch",
+        "count": "5"
+      }
+    ],
+    "houdahspot": [
+      {
+        "cask": "houdahspot",
+        "count": "20"
+      }
+    ],
+    "houseparty": [
+      {
+        "cask": "houseparty",
+        "count": "155"
+      }
+    ],
+    "hp-connectivity-kit": [
+      {
+        "cask": "hp-connectivity-kit",
+        "count": "13"
+      }
+    ],
+    "hp-easy-start": [
+      {
+        "cask": "hp-easy-start",
+        "count": "32"
+      }
+    ],
+    "hp-eprint": [
+      {
+        "cask": "hp-eprint",
+        "count": "4"
+      }
+    ],
+    "hp-prime": [
+      {
+        "cask": "hp-prime",
+        "count": "13"
+      }
+    ],
+    "hstracker": [
+      {
+        "cask": "hstracker",
+        "count": "31"
+      }
+    ],
+    "http-toolkit": [
+      {
+        "cask": "http-toolkit",
+        "count": "44"
+      }
+    ],
+    "hubic": [
+      {
+        "cask": "hubic",
+        "count": "1"
+      }
+    ],
+    "hubstaff": [
+      {
+        "cask": "hubstaff",
+        "count": "9"
+      }
+    ],
+    "hue-topia": [
+      {
+        "cask": "hue-topia",
+        "count": "5"
+      }
+    ],
+    "hugin": [
+      {
+        "cask": "hugin",
+        "count": "57"
+      }
+    ],
+    "huion-tablet-driver": [
+      {
+        "cask": "huion-tablet-driver",
+        "count": "1"
+      }
+    ],
+    "hummingbird": [
+      {
+        "cask": "hummingbird",
+        "count": "16"
+      }
+    ],
+    "hwsensors": [
+      {
+        "cask": "hwsensors",
+        "count": "80"
+      }
+    ],
+    "hydrogen": [
+      {
+        "cask": "hydrogen",
+        "count": "12"
+      }
+    ],
+    "hype": [
+      {
+        "cask": "hype",
+        "count": "6"
+      }
+    ],
+    "hyper": [
+      {
+        "cask": "hyper",
+        "count": "1,307"
+      }
+    ],
+    "hyper-canary": [
+      {
+        "cask": "hyper-canary",
+        "count": "5"
+      }
+    ],
+    "hyperbackupexplorer": [
+      {
+        "cask": "hyperbackupexplorer",
+        "count": "6"
+      }
+    ],
+    "hyperdock": [
+      {
+        "cask": "hyperdock",
+        "count": "91"
+      }
+    ],
+    "hyperion-download-manager": [
+      {
+        "cask": "hyperion-download-manager",
+        "count": "2"
+      }
+    ],
+    "hyperswitch": [
+      {
+        "cask": "hyperswitch",
+        "count": "287"
+      }
+    ],
+    "i1profiler": [
+      {
+        "cask": "i1profiler",
+        "count": "16"
+      }
+    ],
+    "ibabel": [
+      {
+        "cask": "ibabel",
+        "count": "2"
+      }
+    ],
+    "ibackup": [
+      {
+        "cask": "ibackup",
+        "count": "2"
+      }
+    ],
+    "ibackup-viewer": [
+      {
+        "cask": "ibackup-viewer",
+        "count": "8"
+      }
+    ],
+    "ibackupbot": [
+      {
+        "cask": "ibackupbot",
+        "count": "6"
+      }
+    ],
+    "ibettercharge": [
+      {
+        "cask": "ibettercharge",
+        "count": "5"
+      }
+    ],
+    "ibm-cloud-cli": [
+      {
+        "cask": "ibm-cloud-cli",
+        "count": "42"
+      }
+    ],
+    "ibored": [
+      {
+        "cask": "ibored",
+        "count": "3"
+      }
+    ],
+    "icab": [
+      {
+        "cask": "icab",
+        "count": "12"
+      }
+    ],
+    "icamsource": [
+      {
+        "cask": "icamsource",
+        "count": "1"
+      }
+    ],
+    "icanhazshortcut": [
+      {
+        "cask": "icanhazshortcut",
+        "count": "13"
+      }
+    ],
+    "icc": [
+      {
+        "cask": "icc",
+        "count": "6"
+      }
+    ],
+    "iceberg": [
+      {
+        "cask": "iceberg",
+        "count": "2"
+      }
+    ],
+    "icefloor": [
+      {
+        "cask": "icefloor",
+        "count": "4"
+      }
+    ],
+    "icegridgui36": [
+      {
+        "cask": "icegridgui36",
+        "count": "1"
+      }
+    ],
+    "ichm": [
+      {
+        "cask": "ichm",
+        "count": "1"
+      }
+    ],
+    "icloud-control": [
+      {
+        "cask": "icloud-control",
+        "count": "10"
+      }
+    ],
+    "icm-browser": [
+      {
+        "cask": "icm-browser",
+        "count": "1"
+      }
+    ],
+    "iconizer": [
+      {
+        "cask": "iconizer",
+        "count": "18"
+      }
+    ],
+    "iconjar": [
+      {
+        "cask": "iconjar",
+        "count": "20"
+      }
+    ],
+    "iconping": [
+      {
+        "cask": "iconping",
+        "count": "6"
+      }
+    ],
+    "icons": [
+      {
+        "cask": "icons",
+        "count": "4"
+      }
+    ],
+    "icons8": [
+      {
+        "cask": "icons8",
+        "count": "26"
+      }
+    ],
+    "icq": [
+      {
+        "cask": "icq",
+        "count": "23"
+      }
+    ],
+    "id3-editor": [
+      {
+        "cask": "id3-editor",
+        "count": "19"
+      }
+    ],
+    "idafree": [
+      {
+        "cask": "idafree",
+        "count": "15"
+      }
+    ],
+    "idagio": [
+      {
+        "cask": "idagio",
+        "count": "6"
+      }
+    ],
+    "idefrag": [
+      {
+        "cask": "idefrag",
+        "count": "3"
+      }
+    ],
+    "idisplay": [
+      {
+        "cask": "idisplay",
+        "count": "5"
+      }
+    ],
+    "idrive": [
+      {
+        "cask": "idrive",
+        "count": "11"
+      }
+    ],
+    "ieasemusic": [
+      {
+        "cask": "ieasemusic",
+        "count": "62"
+      }
+    ],
+    "iexplorer": [
+      {
+        "cask": "iexplorer",
+        "count": "33"
+      }
+    ],
+    "ifunbox": [
+      {
+        "cask": "ifunbox",
+        "count": "29"
+      }
+    ],
+    "igdm": [
+      {
+        "cask": "igdm",
+        "count": "13"
+      }
+    ],
+    "igetter": [
+      {
+        "cask": "igetter",
+        "count": "24"
+      }
+    ],
+    "iglance": [
+      {
+        "cask": "iglance",
+        "count": "445"
+      }
+    ],
+    "iguanatexmac": [
+      {
+        "cask": "iguanatexmac",
+        "count": "4"
+      }
+    ],
+    "igv": [
+      {
+        "cask": "igv",
+        "count": "21"
+      }
+    ],
+    "iina": [
+      {
+        "cask": "iina",
+        "count": "2,137"
+      }
+    ],
+    "iina-plus": [
+      {
+        "cask": "iina-plus",
+        "count": "56"
+      }
+    ],
+    "ilok-license-manager": [
+      {
+        "cask": "ilok-license-manager",
+        "count": "22"
+      }
+    ],
+    "ilya-birman-typography-layout": [
+      {
+        "cask": "ilya-birman-typography-layout",
+        "count": "8"
+      }
+    ],
+    "image-tool": [
+      {
+        "cask": "image-tool",
+        "count": "10"
+      }
+    ],
+    "image2icon": [
+      {
+        "cask": "image2icon",
+        "count": "24"
+      }
+    ],
+    "imagealpha": [
+      {
+        "cask": "imagealpha",
+        "count": "62"
+      }
+    ],
+    "imagej": [
+      {
+        "cask": "imagej",
+        "count": "53"
+      }
+    ],
+    "imagemin": [
+      {
+        "cask": "imagemin",
+        "count": "6"
+      }
+    ],
+    "imageoptim": [
+      {
+        "cask": "imageoptim",
+        "count": "682"
+      }
+    ],
+    "imaging-edge": [
+      {
+        "cask": "imaging-edge",
+        "count": "12"
+      }
+    ],
+    "imazing": [
+      {
+        "cask": "imazing",
+        "count": "197"
+      }
+    ],
+    "imazing-mini": [
+      {
+        "cask": "imazing-mini",
+        "count": "8"
+      }
+    ],
+    "imgbrd-grabber-nightly": [
+      {
+        "cask": "imgbrd-grabber-nightly",
+        "count": "1"
+      }
+    ],
+    "imgotv": [
+      {
+        "cask": "imgotv",
+        "count": "11"
+      }
+    ],
+    "imgur": [
+      {
+        "cask": "imgur",
+        "count": "12"
+      }
+    ],
+    "imitone": [
+      {
+        "cask": "imitone",
+        "count": "1"
+      }
+    ],
+    "imo": [
+      {
+        "cask": "imo",
+        "count": "4"
+      }
+    ],
+    "impactor": [
+      {
+        "cask": "impactor",
+        "count": "34"
+      }
+    ],
+    "inav-configurator": [
+      {
+        "cask": "inav-configurator",
+        "count": "4"
+      }
+    ],
+    "inboard": [
+      {
+        "cask": "inboard",
+        "count": "2"
+      }
+    ],
+    "indigo": [
+      {
+        "cask": "indigo",
+        "count": "2"
+      }
+    ],
+    "inform": [
+      {
+        "cask": "inform",
+        "count": "3"
+      }
+    ],
+    "inkdrop": [
+      {
+        "cask": "inkdrop",
+        "count": "26"
+      }
+    ],
+    "inkscape": [
+      {
+        "cask": "inkscape",
+        "count": "3,260"
+      }
+    ],
+    "inky": [
+      {
+        "cask": "inky",
+        "count": "4"
+      }
+    ],
+    "inloop-qlplayground": [
+      {
+        "cask": "inloop-qlplayground",
+        "count": "4"
+      }
+    ],
+    "insomnia": [
+      {
+        "cask": "insomnia",
+        "count": "3,225"
+      }
+    ],
+    "insomnia-designer": [
+      {
+        "cask": "insomnia-designer",
+        "count": "51"
+      }
+    ],
+    "inspec": [
+      {
+        "cask": "inspec",
+        "count": "211"
+      }
+    ],
+    "inssider": [
+      {
+        "cask": "inssider",
+        "count": "27"
+      }
+    ],
+    "install-disk-creator": [
+      {
+        "cask": "install-disk-creator",
+        "count": "23"
+      }
+    ],
+    "install-unity": [
+      {
+        "cask": "install-unity",
+        "count": "3"
+      }
+    ],
+    "install_mono_mdk": [
+      {
+        "cask": "install_mono_mdk",
+        "count": "1"
+      }
+    ],
+    "install_xamarin_ios": [
+      {
+        "cask": "install_xamarin_ios",
+        "count": "1"
+      }
+    ],
+    "install_xamarin_mac": [
+      {
+        "cask": "install_xamarin_mac",
+        "count": "1"
+      }
+    ],
+    "instant-articles-builder": [
+      {
+        "cask": "instant-articles-builder",
+        "count": "1"
+      }
+    ],
+    "insync": [
+      {
+        "cask": "insync",
+        "count": "49"
+      }
+    ],
+    "integrity": [
+      {
+        "cask": "integrity",
+        "count": "17"
+      }
+    ],
+    "intel-haxm": [
+      {
+        "cask": "intel-haxm",
+        "count": "287"
+      }
+    ],
+    "intel-power-gadget": [
+      {
+        "cask": "intel-power-gadget",
+        "count": "496"
+      }
+    ],
+    "intel-psxe-ce-c-plus-plus": [
+      {
+        "cask": "intel-psxe-ce-c-plus-plus",
+        "count": "2"
+      }
+    ],
+    "intellij-idea": [
+      {
+        "cask": "intellij-idea",
+        "count": "2,790"
+      }
+    ],
+    "intellij-idea-ce": [
+      {
+        "cask": "intellij-idea-ce",
+        "count": "2,053"
+      }
+    ],
+    "intelliscape-caffeine": [
+      {
+        "cask": "intelliscape-caffeine",
+        "count": "22"
+      }
+    ],
+    "interarchy": [
+      {
+        "cask": "interarchy",
+        "count": "1"
+      }
+    ],
+    "invesalius": [
+      {
+        "cask": "invesalius",
+        "count": "1"
+      }
+    ],
+    "invisiblix": [
+      {
+        "cask": "invisiblix",
+        "count": "1"
+      }
+    ],
+    "invisionsync": [
+      {
+        "cask": "invisionsync",
+        "count": "5"
+      }
+    ],
+    "invisor-lite": [
+      {
+        "cask": "invisor-lite",
+        "count": "3"
+      }
+    ],
+    "ionic-lab": [
+      {
+        "cask": "ionic-lab",
+        "count": "6"
+      }
+    ],
+    "ionic-machina-cli": [
+      {
+        "cask": "ionic-machina-cli",
+        "count": "8"
+      }
+    ],
+    "ioninja": [
+      {
+        "cask": "ioninja",
+        "count": "13"
+      }
+    ],
+    "ioquake3": [
+      {
+        "cask": "ioquake3",
+        "count": "49"
+      }
+    ],
+    "ios-app-signer": [
+      {
+        "cask": "ios-app-signer",
+        "count": "33"
+      }
+    ],
+    "ios-console": [
+      {
+        "cask": "ios-console",
+        "count": "14"
+      }
+    ],
+    "ios-saver": [
+      {
+        "cask": "ios-saver",
+        "count": "3"
+      }
+    ],
+    "iota-wallet": [
+      {
+        "cask": "iota-wallet",
+        "count": "1"
+      }
+    ],
+    "ip-in-menu-bar": [
+      {
+        "cask": "ip-in-menu-bar",
+        "count": "15"
+      }
+    ],
+    "ipa-manager": [
+      {
+        "cask": "ipa-manager",
+        "count": "4"
+      }
+    ],
+    "ipartition": [
+      {
+        "cask": "ipartition",
+        "count": "12"
+      }
+    ],
+    "ipe": [
+      {
+        "cask": "ipe",
+        "count": "42"
+      }
+    ],
+    "ipepresenter": [
+      {
+        "cask": "ipepresenter",
+        "count": "9"
+      }
+    ],
+    "ipfs": [
+      {
+        "cask": "ipfs",
+        "count": "230"
+      }
+    ],
+    "iphoney": [
+      {
+        "cask": "iphoney",
+        "count": "3"
+      }
+    ],
+    "iphoto-library-manager": [
+      {
+        "cask": "iphoto-library-manager",
+        "count": "3"
+      }
+    ],
+    "ipremoteutility": [
+      {
+        "cask": "ipremoteutility",
+        "count": "1"
+      }
+    ],
+    "ipsecuritas": [
+      {
+        "cask": "ipsecuritas",
+        "count": "5"
+      }
+    ],
+    "ipvanish-vpn": [
+      {
+        "cask": "ipvanish-vpn",
+        "count": "17"
+      }
+    ],
+    "ipynb-quicklook": [
+      {
+        "cask": "ipynb-quicklook",
+        "count": "24"
+      }
+    ],
+    "irccloud": [
+      {
+        "cask": "irccloud",
+        "count": "19"
+      }
+    ],
+    "ireadfast": [
+      {
+        "cask": "ireadfast",
+        "count": "3"
+      }
+    ],
+    "iridient-developer": [
+      {
+        "cask": "iridient-developer",
+        "count": "3"
+      }
+    ],
+    "iridium": [
+      {
+        "cask": "iridium",
+        "count": "31"
+      }
+    ],
+    "iris": [
+      {
+        "cask": "iris",
+        "count": "5"
+      }
+    ],
+    "isabelle": [
+      {
+        "cask": "isabelle",
+        "count": "20"
+      }
+    ],
+    "ishowu": [
+      {
+        "cask": "ishowu",
+        "count": "62"
+      }
+    ],
+    "ishowu-instant": [
+      {
+        "cask": "ishowu-instant",
+        "count": "14"
+      }
+    ],
+    "isimulator": [
+      {
+        "cask": "isimulator",
+        "count": "4"
+      }
+    ],
+    "islide": [
+      {
+        "cask": "islide",
+        "count": "14"
+      }
+    ],
+    "isolator": [
+      {
+        "cask": "isolator",
+        "count": "7"
+      }
+    ],
+    "istat-menus": [
+      {
+        "cask": "istat-menus",
+        "count": "865"
+      }
+    ],
+    "istat-menus5": [
+      {
+        "cask": "istat-menus5",
+        "count": "16"
+      }
+    ],
+    "istat-server": [
+      {
+        "cask": "istat-server",
+        "count": "22"
+      }
+    ],
+    "isteg": [
+      {
+        "cask": "isteg",
+        "count": "13"
+      }
+    ],
+    "istumbler": [
+      {
+        "cask": "istumbler",
+        "count": "34"
+      }
+    ],
+    "isubtitle": [
+      {
+        "cask": "isubtitle",
+        "count": "4"
+      }
+    ],
+    "iswiff": [
+      {
+        "cask": "iswiff",
+        "count": "3"
+      }
+    ],
+    "isyncr": [
+      {
+        "cask": "isyncr",
+        "count": "7"
+      }
+    ],
+    "itau": [
+      {
+        "cask": "itau",
+        "count": "7"
+      }
+    ],
+    "itch": [
+      {
+        "cask": "itch",
+        "count": "19"
+      }
+    ],
+    "iterm2": [
+      {
+        "cask": "iterm2",
+        "count": "17,774"
+      }
+    ],
+    "iterm2-beta": [
+      {
+        "cask": "iterm2-beta",
+        "count": "116"
+      }
+    ],
+    "iterm2-legacy": [
+      {
+        "cask": "iterm2-legacy",
+        "count": "6"
+      }
+    ],
+    "iterm2-nightly": [
+      {
+        "cask": "iterm2-nightly",
+        "count": "78"
+      }
+    ],
+    "ithoughtsx": [
+      {
+        "cask": "ithoughtsx",
+        "count": "3"
+      }
+    ],
+    "itk-snap": [
+      {
+        "cask": "itk-snap",
+        "count": "5"
+      }
+    ],
+    "itools": [
+      {
+        "cask": "itools",
+        "count": "26"
+      }
+    ],
+    "itrash": [
+      {
+        "cask": "itrash",
+        "count": "3"
+      }
+    ],
+    "itsycal": [
+      {
+        "cask": "itsycal",
+        "count": "602"
+      }
+    ],
+    "itubedownloader": [
+      {
+        "cask": "itubedownloader",
+        "count": "14"
+      }
+    ],
+    "itunes-producer": [
+      {
+        "cask": "itunes-producer",
+        "count": "2"
+      }
+    ],
+    "itunes-volume-control": [
+      {
+        "cask": "itunes-volume-control",
+        "count": "5"
+      }
+    ],
+    "ivideonclient": [
+      {
+        "cask": "ivideonclient",
+        "count": "2"
+      }
+    ],
+    "ivideonserver": [
+      {
+        "cask": "ivideonserver",
+        "count": "2"
+      }
+    ],
+    "ivolume": [
+      {
+        "cask": "ivolume",
+        "count": "3"
+      }
+    ],
+    "ivpn": [
+      {
+        "cask": "ivpn",
+        "count": "16"
+      }
+    ],
+    "izip": [
+      {
+        "cask": "izip",
+        "count": "24"
+      }
+    ],
+    "j": [
+      {
+        "cask": "j",
+        "count": "11"
+      }
+    ],
+    "jabra-direct": [
+      {
+        "cask": "jabra-direct",
+        "count": "37"
+      }
+    ],
+    "jabref": [
+      {
+        "cask": "jabref",
+        "count": "96"
+      }
+    ],
+    "jad": [
+      {
+        "cask": "jad",
+        "count": "92"
+      }
+    ],
+    "jaikoz": [
+      {
+        "cask": "jaikoz",
+        "count": "3"
+      }
+    ],
+    "jaksta-media-recorder": [
+      {
+        "cask": "jaksta-media-recorder",
+        "count": "1"
+      }
+    ],
+    "jalbum": [
+      {
+        "cask": "jalbum",
+        "count": "3"
+      }
+    ],
+    "jalview": [
+      {
+        "cask": "jalview",
+        "count": "9"
+      }
+    ],
+    "jameica": [
+      {
+        "cask": "jameica",
+        "count": "3"
+      }
+    ],
+    "james": [
+      {
+        "cask": "james",
+        "count": "6"
+      }
+    ],
+    "jamf-migrator": [
+      {
+        "cask": "jamf-migrator",
+        "count": "4"
+      }
+    ],
+    "jami": [
+      {
+        "cask": "jami",
+        "count": "94"
+      }
+    ],
+    "jamovi": [
+      {
+        "cask": "jamovi",
+        "count": "8"
+      }
+    ],
+    "jandi": [
+      {
+        "cask": "jandi",
+        "count": "1"
+      }
+    ],
+    "jasp": [
+      {
+        "cask": "jasp",
+        "count": "16"
+      }
+    ],
+    "jasper": [
+      {
+        "cask": "jasper",
+        "count": "12"
+      }
+    ],
+    "java": [
+      {
+        "cask": "java",
+        "count": "20,462"
+      }
+    ],
+    "java11": [
+      {
+        "cask": "java11",
+        "count": "4,466"
+      }
+    ],
+    "java6": [
+      {
+        "cask": "java6",
+        "count": "559"
+      }
+    ],
+    "java7": [
+      {
+        "cask": "java7",
+        "count": "2"
+      }
+    ],
+    "java8": [
+      {
+        "cask": "java8",
+        "count": "6"
+      }
+    ],
+    "java8u181": [
+      {
+        "cask": "java8u181",
+        "count": "1"
+      }
+    ],
+    "java9": [
+      {
+        "cask": "java9",
+        "count": "15"
+      }
+    ],
+    "java_11_0_2": [
+      {
+        "cask": "java_11_0_2",
+        "count": "1"
+      }
+    ],
+    "jaxx-liberty": [
+      {
+        "cask": "jaxx-liberty",
+        "count": "15"
+      }
+    ],
+    "jazzup": [
+      {
+        "cask": "jazzup",
+        "count": "2"
+      }
+    ],
+    "jbidwatcher": [
+      {
+        "cask": "jbidwatcher",
+        "count": "3"
+      }
+    ],
+    "jbrowse": [
+      {
+        "cask": "jbrowse",
+        "count": "10"
+      }
+    ],
+    "jclasslib-bytecode-viewer": [
+      {
+        "cask": "jclasslib-bytecode-viewer",
+        "count": "5"
+      }
+    ],
+    "jcryptool": [
+      {
+        "cask": "jcryptool",
+        "count": "7"
+      }
+    ],
+    "jd-gui": [
+      {
+        "cask": "jd-gui",
+        "count": "428"
+      }
+    ],
+    "jdiskreport": [
+      {
+        "cask": "jdiskreport",
+        "count": "12"
+      }
+    ],
+    "jdk-mission-control": [
+      {
+        "cask": "jdk-mission-control",
+        "count": "35"
+      }
+    ],
+    "jdk-mission-control-snapshot": [
+      {
+        "cask": "jdk-mission-control-snapshot",
+        "count": "2"
+      }
+    ],
+    "jdownloader": [
+      {
+        "cask": "jdownloader",
+        "count": "308"
+      }
+    ],
+    "jedit": [
+      {
+        "cask": "jedit",
+        "count": "23"
+      }
+    ],
+    "jedit-omega": [
+      {
+        "cask": "jedit-omega",
+        "count": "7"
+      }
+    ],
+    "jenkins-menu": [
+      {
+        "cask": "jenkins-menu",
+        "count": "8"
+      }
+    ],
+    "jeromelebel-mongohub": [
+      {
+        "cask": "jeromelebel-mongohub",
+        "count": "25"
+      }
+    ],
+    "jet": [
+      {
+        "cask": "jet",
+        "count": "305"
+      }
+    ],
+    "jetbrains-toolbox": [
+      {
+        "cask": "jetbrains-toolbox",
+        "count": "1,624"
+      }
+    ],
+    "jettison": [
+      {
+        "cask": "jettison",
+        "count": "10"
+      }
+    ],
+    "jewelrybox": [
+      {
+        "cask": "jewelrybox",
+        "count": "2"
+      }
+    ],
+    "jgrasp": [
+      {
+        "cask": "jgrasp",
+        "count": "7"
+      }
+    ],
+    "jietu": [
+      {
+        "cask": "jietu",
+        "count": "32"
+      }
+    ],
+    "jiggler": [
+      {
+        "cask": "jiggler",
+        "count": "57"
+      }
+    ],
+    "jing": [
+      {
+        "cask": "jing",
+        "count": "22"
+      }
+    ],
+    "jira-client": [
+      {
+        "cask": "jira-client",
+        "count": "128"
+      }
+    ],
+    "jitouch": [
+      {
+        "cask": "jitouch",
+        "count": "12"
+      }
+    ],
+    "jitsi": [
+      {
+        "cask": "jitsi",
+        "count": "369"
+      }
+    ],
+    "jitsi-meet": [
+      {
+        "cask": "jitsi-meet",
+        "count": "865"
+      }
+    ],
+    "jmc": [
+      {
+        "cask": "jmc",
+        "count": "18"
+      }
+    ],
+    "joinme": [
+      {
+        "cask": "joinme",
+        "count": "12"
+      }
+    ],
+    "joker": [
+      {
+        "cask": "joker",
+        "count": "12"
+      }
+    ],
+    "jollysfastvnc": [
+      {
+        "cask": "jollysfastvnc",
+        "count": "32"
+      }
+    ],
+    "joox": [
+      {
+        "cask": "joox",
+        "count": "2"
+      }
+    ],
+    "joplin": [
+      {
+        "cask": "joplin",
+        "count": "2,247"
+      }
+    ],
+    "joshaven-winbox": [
+      {
+        "cask": "joshaven-winbox",
+        "count": "1"
+      }
+    ],
+    "josm": [
+      {
+        "cask": "josm",
+        "count": "123"
+      }
+    ],
+    "journey": [
+      {
+        "cask": "journey",
+        "count": "15"
+      }
+    ],
+    "jprofiler": [
+      {
+        "cask": "jprofiler",
+        "count": "38"
+      }
+    ],
+    "jqbx": [
+      {
+        "cask": "jqbx",
+        "count": "25"
+      }
+    ],
+    "jsontohandyjson": [
+      {
+        "cask": "jsontohandyjson",
+        "count": "3"
+      }
+    ],
+    "jsui": [
+      {
+        "cask": "jsui",
+        "count": "4"
+      }
+    ],
+    "jtool": [
+      {
+        "cask": "jtool",
+        "count": "34"
+      }
+    ],
+    "jtool2": [
+      {
+        "cask": "jtool2",
+        "count": "26"
+      }
+    ],
+    "jubler": [
+      {
+        "cask": "jubler",
+        "count": "37"
+      }
+    ],
+    "juicebar": [
+      {
+        "cask": "juicebar",
+        "count": "2"
+      }
+    ],
+    "julia": [
+      {
+        "cask": "julia",
+        "count": "1,247"
+      }
+    ],
+    "julia-lts": [
+      {
+        "cask": "julia-lts",
+        "count": "4"
+      }
+    ],
+    "julia-nightly": [
+      {
+        "cask": "julia-nightly",
+        "count": "9"
+      }
+    ],
+    "jump": [
+      {
+        "cask": "jump",
+        "count": "21"
+      }
+    ],
+    "jump-desktop-connect": [
+      {
+        "cask": "jump-desktop-connect",
+        "count": "4"
+      }
+    ],
+    "jumpcut": [
+      {
+        "cask": "jumpcut",
+        "count": "521"
+      }
+    ],
+    "jumpshare": [
+      {
+        "cask": "jumpshare",
+        "count": "4"
+      }
+    ],
+    "jupyter-notebook-ql": [
+      {
+        "cask": "jupyter-notebook-ql",
+        "count": "68"
+      }
+    ],
+    "jupyter-notebook-viewer": [
+      {
+        "cask": "jupyter-notebook-viewer",
+        "count": "242"
+      }
+    ],
+    "kactus": [
+      {
+        "cask": "kactus",
+        "count": "6"
+      }
+    ],
+    "kafka-tool": [
+      {
+        "cask": "kafka-tool",
+        "count": "60"
+      }
+    ],
+    "kakapo": [
+      {
+        "cask": "kakapo",
+        "count": "2"
+      }
+    ],
+    "kaku": [
+      {
+        "cask": "kaku",
+        "count": "1"
+      }
+    ],
+    "kaleidoscope": [
+      {
+        "cask": "kaleidoscope",
+        "count": "197"
+      }
+    ],
+    "kanmail": [
+      {
+        "cask": "kanmail",
+        "count": "1"
+      }
+    ],
+    "kap": [
+      {
+        "cask": "kap",
+        "count": "730"
+      }
+    ],
+    "kap-beta": [
+      {
+        "cask": "kap-beta",
+        "count": "3"
+      }
+    ],
+    "kapitainsky-rclone-browser": [
+      {
+        "cask": "kapitainsky-rclone-browser",
+        "count": "10"
+      }
+    ],
+    "kapow": [
+      {
+        "cask": "kapow",
+        "count": "4"
+      }
+    ],
+    "karabiner-elements": [
+      {
+        "cask": "karabiner-elements",
+        "count": "1,851"
+      }
+    ],
+    "katalon-studio": [
+      {
+        "cask": "katalon-studio",
+        "count": "44"
+      }
+    ],
+    "katana": [
+      {
+        "cask": "katana",
+        "count": "8"
+      }
+    ],
+    "kawa": [
+      {
+        "cask": "kawa",
+        "count": "47"
+      }
+    ],
+    "kc-knockknock": [
+      {
+        "cask": "kc-knockknock",
+        "count": "1"
+      }
+    ],
+    "kde-connect": [
+      {
+        "cask": "kde-connect",
+        "count": "1"
+      }
+    ],
+    "kdiff3": [
+      {
+        "cask": "kdiff3",
+        "count": "111"
+      }
+    ],
+    "keep": [
+      {
+        "cask": "keep",
+        "count": "26"
+      }
+    ],
+    "keep-it": [
+      {
+        "cask": "keep-it",
+        "count": "4"
+      }
+    ],
+    "keepassx": [
+      {
+        "cask": "keepassx",
+        "count": "420"
+      }
+    ],
+    "keepassxc": [
+      {
+        "cask": "keepassxc",
+        "count": "3,782"
+      }
+    ],
+    "keepassxc-beta": [
+      {
+        "cask": "keepassxc-beta",
+        "count": "3"
+      }
+    ],
+    "keepassxc-snapshot": [
+      {
+        "cask": "keepassxc-snapshot",
+        "count": "5"
+      }
+    ],
+    "keeper-password-manager": [
+      {
+        "cask": "keeper-password-manager",
+        "count": "20"
+      }
+    ],
+    "keepingyouawake": [
+      {
+        "cask": "keepingyouawake",
+        "count": "779"
+      }
+    ],
+    "keeweb": [
+      {
+        "cask": "keeweb",
+        "count": "200"
+      }
+    ],
+    "keka": [
+      {
+        "cask": "keka",
+        "count": "1,964"
+      }
+    ],
+    "keka-beta": [
+      {
+        "cask": "keka-beta",
+        "count": "17"
+      }
+    ],
+    "kekadefaultapp": [
+      {
+        "cask": "kekadefaultapp",
+        "count": "82"
+      }
+    ],
+    "kellerkinder-time-machine-status": [
+      {
+        "cask": "kellerkinder-time-machine-status",
+        "count": "1"
+      }
+    ],
+    "kensington-trackball-works": [
+      {
+        "cask": "kensington-trackball-works",
+        "count": "10"
+      }
+    ],
+    "kext-updater": [
+      {
+        "cask": "kext-updater",
+        "count": "57"
+      }
+    ],
+    "kext-utility": [
+      {
+        "cask": "kext-utility",
+        "count": "42"
+      }
+    ],
+    "kextviewr": [
+      {
+        "cask": "kextviewr",
+        "count": "31"
+      }
+    ],
+    "key-codes": [
+      {
+        "cask": "key-codes",
+        "count": "25"
+      }
+    ],
+    "keybase": [
+      {
+        "cask": "keybase",
+        "count": "1,142"
+      }
+    ],
+    "keyboard": [
+      {
+        "cask": "keyboard",
+        "count": "1"
+      }
+    ],
+    "keyboard-cleaner": [
+      {
+        "cask": "keyboard-cleaner",
+        "count": "48"
+      }
+    ],
+    "keyboard-lock": [
+      {
+        "cask": "keyboard-lock",
+        "count": "10"
+      }
+    ],
+    "keyboard-maestro": [
+      {
+        "cask": "keyboard-maestro",
+        "count": "140"
+      }
+    ],
+    "keyboardcleantool": [
+      {
+        "cask": "keyboardcleantool",
+        "count": "100"
+      }
+    ],
+    "keycast": [
+      {
+        "cask": "keycast",
+        "count": "5"
+      }
+    ],
+    "keycastr": [
+      {
+        "cask": "keycastr",
+        "count": "943"
+      }
+    ],
+    "keychain-pkcs11": [
+      {
+        "cask": "keychain-pkcs11",
+        "count": "10"
+      }
+    ],
+    "keychaincheck2": [
+      {
+        "cask": "keychaincheck2",
+        "count": "1"
+      }
+    ],
+    "keycue": [
+      {
+        "cask": "keycue",
+        "count": "13"
+      }
+    ],
+    "keyfinder": [
+      {
+        "cask": "keyfinder",
+        "count": "2"
+      }
+    ],
+    "keymanager": [
+      {
+        "cask": "keymanager",
+        "count": "6"
+      }
+    ],
+    "keypad-layout": [
+      {
+        "cask": "keypad-layout",
+        "count": "3"
+      }
+    ],
+    "keys": [
+      {
+        "cask": "keys",
+        "count": "4"
+      }
+    ],
+    "keyshot": [
+      {
+        "cask": "keyshot",
+        "count": "2"
+      }
+    ],
+    "keystore-explorer": [
+      {
+        "cask": "keystore-explorer",
+        "count": "134"
+      }
+    ],
+    "khmer-unicode-layout": [
+      {
+        "cask": "khmer-unicode-layout",
+        "count": "2"
+      }
+    ],
+    "kicad": [
+      {
+        "cask": "kicad",
+        "count": "131"
+      }
+    ],
+    "kid3": [
+      {
+        "cask": "kid3",
+        "count": "135"
+      }
+    ],
+    "kiibohd-configurator": [
+      {
+        "cask": "kiibohd-configurator",
+        "count": "5"
+      }
+    ],
+    "kindle": [
+      {
+        "cask": "kindle",
+        "count": "652"
+      }
+    ],
+    "kindle-50131": [
+      {
+        "cask": "kindle-50131",
+        "count": "2"
+      }
+    ],
+    "kindle-comic-converter": [
+      {
+        "cask": "kindle-comic-converter",
+        "count": "16"
+      }
+    ],
+    "kindle-comic-creator": [
+      {
+        "cask": "kindle-comic-creator",
+        "count": "179"
+      }
+    ],
+    "kindle-previewer": [
+      {
+        "cask": "kindle-previewer",
+        "count": "49"
+      }
+    ],
+    "kindlegen": [
+      {
+        "cask": "kindlegen",
+        "count": "198"
+      }
+    ],
+    "kinesis-smart-set": [
+      {
+        "cask": "kinesis-smart-set",
+        "count": "1"
+      }
+    ],
+    "kinza": [
+      {
+        "cask": "kinza",
+        "count": "2"
+      }
+    ],
+    "kite": [
+      {
+        "cask": "kite",
+        "count": "230"
+      }
+    ],
+    "kitematic": [
+      {
+        "cask": "kitematic",
+        "count": "558"
+      }
+    ],
+    "kitematic0176": [
+      {
+        "cask": "kitematic0176",
+        "count": "1"
+      }
+    ],
+    "kitt": [
+      {
+        "cask": "kitt",
+        "count": "6"
+      }
+    ],
+    "kitty": [
+      {
+        "cask": "kitty",
+        "count": "1,131"
+      }
+    ],
+    "kiwi-for-g-suite": [
+      {
+        "cask": "kiwi-for-g-suite",
+        "count": "18"
+      }
+    ],
+    "kiwix": [
+      {
+        "cask": "kiwix",
+        "count": "21"
+      }
+    ],
+    "kk7ds-python-runtime": [
+      {
+        "cask": "kk7ds-python-runtime",
+        "count": "12"
+      }
+    ],
+    "kkbox": [
+      {
+        "cask": "kkbox",
+        "count": "17"
+      }
+    ],
+    "klatexformula": [
+      {
+        "cask": "klatexformula",
+        "count": "37"
+      }
+    ],
+    "klayout": [
+      {
+        "cask": "klayout",
+        "count": "7"
+      }
+    ],
+    "klokki": [
+      {
+        "cask": "klokki",
+        "count": "5"
+      }
+    ],
+    "kmbmpdc": [
+      {
+        "cask": "kmbmpdc",
+        "count": "8"
+      }
+    ],
+    "kmplayer": [
+      {
+        "cask": "kmplayer",
+        "count": "33"
+      }
+    ],
+    "knime": [
+      {
+        "cask": "knime",
+        "count": "23"
+      }
+    ],
+    "knock": [
+      {
+        "cask": "knock",
+        "count": "4"
+      }
+    ],
+    "knockknock": [
+      {
+        "cask": "knockknock",
+        "count": "108"
+      }
+    ],
+    "knotes": [
+      {
+        "cask": "knotes",
+        "count": "3"
+      }
+    ],
+    "knox": [
+      {
+        "cask": "knox",
+        "count": "6"
+      }
+    ],
+    "knuff": [
+      {
+        "cask": "knuff",
+        "count": "2"
+      }
+    ],
+    "koa11y": [
+      {
+        "cask": "koa11y",
+        "count": "2"
+      }
+    ],
+    "koala": [
+      {
+        "cask": "koala",
+        "count": "12"
+      }
+    ],
+    "kobo": [
+      {
+        "cask": "kobo",
+        "count": "46"
+      }
+    ],
+    "kode54-cog": [
+      {
+        "cask": "kode54-cog",
+        "count": "48"
+      }
+    ],
+    "kodelife": [
+      {
+        "cask": "kodelife",
+        "count": "2"
+      }
+    ],
+    "kodi": [
+      {
+        "cask": "kodi",
+        "count": "299"
+      }
+    ],
+    "komodo-edit": [
+      {
+        "cask": "komodo-edit",
+        "count": "16"
+      }
+    ],
+    "komodo-ide": [
+      {
+        "cask": "komodo-ide",
+        "count": "11"
+      }
+    ],
+    "kompozer": [
+      {
+        "cask": "kompozer",
+        "count": "1"
+      }
+    ],
+    "konica-minolta-bizhub-c650i-c360i-c4050i-c4000i-c3320i-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c650i-c360i-c4050i-c4000i-c3320i-driver",
+        "count": "4"
+      }
+    ],
+    "kotlin-native": [
+      {
+        "cask": "kotlin-native",
+        "count": "41"
+      }
+    ],
+    "krew": [
+      {
+        "cask": "krew",
+        "count": "1"
+      }
+    ],
+    "krisp": [
+      {
+        "cask": "krisp",
+        "count": "233"
+      }
+    ],
+    "krita": [
+      {
+        "cask": "krita",
+        "count": "314"
+      }
+    ],
+    "kroger-ascii": [
+      {
+        "cask": "kroger-ascii",
+        "count": "1"
+      }
+    ],
+    "ksdiff": [
+      {
+        "cask": "ksdiff",
+        "count": "35"
+      }
+    ],
+    "kstars": [
+      {
+        "cask": "kstars",
+        "count": "14"
+      }
+    ],
+    "kubar": [
+      {
+        "cask": "kubar",
+        "count": "1"
+      }
+    ],
+    "kube-cluster": [
+      {
+        "cask": "kube-cluster",
+        "count": "2"
+      }
+    ],
+    "kube-forwarder": [
+      {
+        "cask": "kube-forwarder",
+        "count": "86"
+      }
+    ],
+    "kubecontext": [
+      {
+        "cask": "kubecontext",
+        "count": "36"
+      }
+    ],
+    "kubedog": [
+      {
+        "cask": "kubedog",
+        "count": "1"
+      }
+    ],
+    "kubenav": [
+      {
+        "cask": "kubenav",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.11.3": [
+      {
+        "cask": "kubernetes-cli-1.11.3",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.6": [
+      {
+        "cask": "kubernetes-cli-1.13.6",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.15.11": [
+      {
+        "cask": "kubernetes-cli-1.15.11",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.16.8": [
+      {
+        "cask": "kubernetes-cli-1.16.8",
+        "count": "1"
+      }
+    ],
+    "kubernetic": [
+      {
+        "cask": "kubernetic",
+        "count": "75"
+      }
+    ],
+    "kugoumusic": [
+      {
+        "cask": "kugoumusic",
+        "count": "21"
+      }
+    ],
+    "kvirc": [
+      {
+        "cask": "kvirc",
+        "count": "9"
+      }
+    ],
+    "kyocera-printer-drivers": [
+      {
+        "cask": "kyocera-printer-drivers",
+        "count": "1"
+      }
+    ],
+    "lab": [
+      {
+        "cask": "lab",
+        "count": "3"
+      }
+    ],
+    "labelme": [
+      {
+        "cask": "labelme",
+        "count": "60"
+      }
+    ],
+    "lacie-network-assistant": [
+      {
+        "cask": "lacie-network-assistant",
+        "count": "1"
+      }
+    ],
+    "lacona": [
+      {
+        "cask": "lacona",
+        "count": "13"
+      }
+    ],
+    "lando": [
+      {
+        "cask": "lando",
+        "count": "191"
+      }
+    ],
+    "lantern": [
+      {
+        "cask": "lantern",
+        "count": "42"
+      }
+    ],
+    "laravel-kit": [
+      {
+        "cask": "laravel-kit",
+        "count": "15"
+      }
+    ],
+    "lark": [
+      {
+        "cask": "lark",
+        "count": "25"
+      }
+    ],
+    "lastfm": [
+      {
+        "cask": "lastfm",
+        "count": "32"
+      }
+    ],
+    "lastpass": [
+      {
+        "cask": "lastpass",
+        "count": "721"
+      }
+    ],
+    "latest": [
+      {
+        "cask": "latest",
+        "count": "58"
+      }
+    ],
+    "latexdraw": [
+      {
+        "cask": "latexdraw",
+        "count": "24"
+      }
+    ],
+    "latexit": [
+      {
+        "cask": "latexit",
+        "count": "361"
+      }
+    ],
+    "launchbar": [
+      {
+        "cask": "launchbar",
+        "count": "97"
+      }
+    ],
+    "launchcontrol": [
+      {
+        "cask": "launchcontrol",
+        "count": "299"
+      }
+    ],
+    "launchpad-manager": [
+      {
+        "cask": "launchpad-manager",
+        "count": "33"
+      }
+    ],
+    "launchrocket": [
+      {
+        "cask": "launchrocket",
+        "count": "296"
+      }
+    ],
+    "launchy": [
+      {
+        "cask": "launchy",
+        "count": "2"
+      }
+    ],
+    "laverna": [
+      {
+        "cask": "laverna",
+        "count": "5"
+      }
+    ],
+    "lazarus": [
+      {
+        "cask": "lazarus",
+        "count": "91"
+      }
+    ],
+    "lazpaint": [
+      {
+        "cask": "lazpaint",
+        "count": "15"
+      }
+    ],
+    "lazy": [
+      {
+        "cask": "lazy",
+        "count": "7"
+      }
+    ],
+    "lbry": [
+      {
+        "cask": "lbry",
+        "count": "22"
+      }
+    ],
+    "league-displays": [
+      {
+        "cask": "league-displays",
+        "count": "2"
+      }
+    ],
+    "league-of-legends": [
+      {
+        "cask": "league-of-legends",
+        "count": "191"
+      }
+    ],
+    "leanote": [
+      {
+        "cask": "leanote",
+        "count": "4"
+      }
+    ],
+    "leap-motion": [
+      {
+        "cask": "leap-motion",
+        "count": "4"
+      }
+    ],
+    "ledger-live": [
+      {
+        "cask": "ledger-live",
+        "count": "96"
+      }
+    ],
+    "leech": [
+      {
+        "cask": "leech",
+        "count": "5"
+      }
+    ],
+    "lego-digital-designer": [
+      {
+        "cask": "lego-digital-designer",
+        "count": "5"
+      }
+    ],
+    "lego-mindstorms-ev3": [
+      {
+        "cask": "lego-mindstorms-ev3",
+        "count": "29"
+      }
+    ],
+    "lehreroffice": [
+      {
+        "cask": "lehreroffice",
+        "count": "1"
+      }
+    ],
+    "leksah": [
+      {
+        "cask": "leksah",
+        "count": "4"
+      }
+    ],
+    "lektor": [
+      {
+        "cask": "lektor",
+        "count": "3"
+      }
+    ],
+    "lens": [
+      {
+        "cask": "lens",
+        "count": "353"
+      }
+    ],
+    "leocad": [
+      {
+        "cask": "leocad",
+        "count": "8"
+      }
+    ],
+    "lepton": [
+      {
+        "cask": "lepton",
+        "count": "176"
+      }
+    ],
+    "lets-view": [
+      {
+        "cask": "lets-view",
+        "count": "1"
+      }
+    ],
+    "letsview": [
+      {
+        "cask": "letsview",
+        "count": "4"
+      }
+    ],
+    "levelator": [
+      {
+        "cask": "levelator",
+        "count": "2"
+      }
+    ],
+    "lg-onscreen-control": [
+      {
+        "cask": "lg-onscreen-control",
+        "count": "24"
+      }
+    ],
+    "liberica-jdk11": [
+      {
+        "cask": "liberica-jdk11",
+        "count": "10"
+      }
+    ],
+    "liberica-jdk11-full": [
+      {
+        "cask": "liberica-jdk11-full",
+        "count": "11"
+      }
+    ],
+    "liberica-jdk11-lite": [
+      {
+        "cask": "liberica-jdk11-lite",
+        "count": "2"
+      }
+    ],
+    "liberica-jdk12": [
+      {
+        "cask": "liberica-jdk12",
+        "count": "1"
+      }
+    ],
+    "liberica-jdk13": [
+      {
+        "cask": "liberica-jdk13",
+        "count": "4"
+      }
+    ],
+    "liberica-jdk13-full": [
+      {
+        "cask": "liberica-jdk13-full",
+        "count": "2"
+      }
+    ],
+    "liberica-jdk13-lite": [
+      {
+        "cask": "liberica-jdk13-lite",
+        "count": "1"
+      }
+    ],
+    "liberica-jdk14": [
+      {
+        "cask": "liberica-jdk14",
+        "count": "12"
+      }
+    ],
+    "liberica-jdk14-full": [
+      {
+        "cask": "liberica-jdk14-full",
+        "count": "12"
+      }
+    ],
+    "liberica-jdk14-lite": [
+      {
+        "cask": "liberica-jdk14-lite",
+        "count": "2"
+      }
+    ],
+    "liberica-jdk8": [
+      {
+        "cask": "liberica-jdk8",
+        "count": "555"
+      }
+    ],
+    "liberica-jdk8-full": [
+      {
+        "cask": "liberica-jdk8-full",
+        "count": "423"
+      }
+    ],
+    "liberica-jre11": [
+      {
+        "cask": "liberica-jre11",
+        "count": "2"
+      }
+    ],
+    "liberica-jre11-full": [
+      {
+        "cask": "liberica-jre11-full",
+        "count": "2"
+      }
+    ],
+    "liberica-jre13": [
+      {
+        "cask": "liberica-jre13",
+        "count": "1"
+      }
+    ],
+    "liberica-jre14": [
+      {
+        "cask": "liberica-jre14",
+        "count": "2"
+      }
+    ],
+    "liberica-jre14-full": [
+      {
+        "cask": "liberica-jre14-full",
+        "count": "2"
+      }
+    ],
+    "liberica-jre8": [
+      {
+        "cask": "liberica-jre8",
+        "count": "3"
+      }
+    ],
+    "liberica-jre8-full": [
+      {
+        "cask": "liberica-jre8-full",
+        "count": "6"
+      }
+    ],
+    "librecad": [
+      {
+        "cask": "librecad",
+        "count": "101"
+      }
+    ],
+    "libreelec-usb-sd-creator": [
+      {
+        "cask": "libreelec-usb-sd-creator",
+        "count": "9"
+      }
+    ],
+    "libreoffice": [
+      {
+        "cask": "libreoffice",
+        "count": "3,930"
+      }
+    ],
+    "libreoffice-language-pack": [
+      {
+        "cask": "libreoffice-language-pack",
+        "count": "444"
+      }
+    ],
+    "libreoffice-still": [
+      {
+        "cask": "libreoffice-still",
+        "count": "13"
+      }
+    ],
+    "libreofficeja": [
+      {
+        "cask": "libreofficeja",
+        "count": "1"
+      }
+    ],
+    "librepcb": [
+      {
+        "cask": "librepcb",
+        "count": "9"
+      }
+    ],
+    "licecap": [
+      {
+        "cask": "licecap",
+        "count": "497"
+      }
+    ],
+    "license-control-center": [
+      {
+        "cask": "license-control-center",
+        "count": "1"
+      }
+    ],
+    "licensed": [
+      {
+        "cask": "licensed",
+        "count": "2"
+      }
+    ],
+    "liclipse": [
+      {
+        "cask": "liclipse",
+        "count": "3"
+      }
+    ],
+    "lidarr": [
+      {
+        "cask": "lidarr",
+        "count": "7"
+      }
+    ],
+    "lifesize": [
+      {
+        "cask": "lifesize",
+        "count": "24"
+      }
+    ],
+    "lightgallery": [
+      {
+        "cask": "lightgallery",
+        "count": "6"
+      }
+    ],
+    "lighting": [
+      {
+        "cask": "lighting",
+        "count": "5"
+      }
+    ],
+    "lightpaper": [
+      {
+        "cask": "lightpaper",
+        "count": "2"
+      }
+    ],
+    "lightproxy": [
+      {
+        "cask": "lightproxy",
+        "count": "14"
+      }
+    ],
+    "lighttable": [
+      {
+        "cask": "lighttable",
+        "count": "52"
+      }
+    ],
+    "lightworks": [
+      {
+        "cask": "lightworks",
+        "count": "34"
+      }
+    ],
+    "lilypond": [
+      {
+        "cask": "lilypond",
+        "count": "43"
+      }
+    ],
+    "lilypond-dev": [
+      {
+        "cask": "lilypond-dev",
+        "count": "7"
+      }
+    ],
+    "lilypond-unofficial": [
+      {
+        "cask": "lilypond-unofficial",
+        "count": "3"
+      }
+    ],
+    "lilypond64": [
+      {
+        "cask": "lilypond64",
+        "count": "1"
+      }
+    ],
+    "lincastor": [
+      {
+        "cask": "lincastor",
+        "count": "2"
+      }
+    ],
+    "linear": [
+      {
+        "cask": "linear",
+        "count": "14"
+      }
+    ],
+    "linein": [
+      {
+        "cask": "linein",
+        "count": "28"
+      }
+    ],
+    "lingo": [
+      {
+        "cask": "lingo",
+        "count": "4"
+      }
+    ],
+    "lingon-x": [
+      {
+        "cask": "lingon-x",
+        "count": "59"
+      }
+    ],
+    "lingon-x5": [
+      {
+        "cask": "lingon-x5",
+        "count": "1"
+      }
+    ],
+    "linkliar": [
+      {
+        "cask": "linkliar",
+        "count": "35"
+      }
+    ],
+    "linphone": [
+      {
+        "cask": "linphone",
+        "count": "57"
+      }
+    ],
+    "listen1": [
+      {
+        "cask": "listen1",
+        "count": "45"
+      }
+    ],
+    "litecoin": [
+      {
+        "cask": "litecoin",
+        "count": "4"
+      }
+    ],
+    "liteicon": [
+      {
+        "cask": "liteicon",
+        "count": "31"
+      }
+    ],
+    "liteide": [
+      {
+        "cask": "liteide",
+        "count": "53"
+      }
+    ],
+    "little-snitch": [
+      {
+        "cask": "little-snitch",
+        "count": "471"
+      }
+    ],
+    "littlesecrets": [
+      {
+        "cask": "littlesecrets",
+        "count": "1"
+      }
+    ],
+    "livereload": [
+      {
+        "cask": "livereload",
+        "count": "13"
+      }
+    ],
+    "livetail": [
+      {
+        "cask": "livetail",
+        "count": "3"
+      }
+    ],
+    "liya": [
+      {
+        "cask": "liya",
+        "count": "5"
+      }
+    ],
+    "lmms": [
+      {
+        "cask": "lmms",
+        "count": "50"
+      }
+    ],
+    "lmsclients-squeezeplay": [
+      {
+        "cask": "lmsclients-squeezeplay",
+        "count": "2"
+      }
+    ],
+    "lnkd-ads-cli": [
+      {
+        "cask": "lnkd-ads-cli",
+        "count": "22,188"
+      }
+    ],
+    "lnkd-amf-cli": [
+      {
+        "cask": "lnkd-amf-cli",
+        "count": "10,414"
+      }
+    ],
+    "lnkd-amf-qualys": [
+      {
+        "cask": "lnkd-amf-qualys",
+        "count": "25,329"
+      }
+    ],
+    "lnkd-argos-tracert-cli": [
+      {
+        "cask": "lnkd-argos-tracert-cli",
+        "count": "22,370"
+      }
+    ],
+    "lnkd-arrow": [
+      {
+        "cask": "lnkd-arrow",
+        "count": "37,367"
+      }
+    ],
+    "lnkd-artifact-tools": [
+      {
+        "cask": "lnkd-artifact-tools",
+        "count": "22,558"
+      }
+    ],
+    "lnkd-ask-project-tools": [
+      {
+        "cask": "lnkd-ask-project-tools",
+        "count": "30,768"
+      }
+    ],
+    "lnkd-assembler-cli": [
+      {
+        "cask": "lnkd-assembler-cli",
+        "count": "26,506"
+      }
+    ],
+    "lnkd-assembler-rollback-cli": [
+      {
+        "cask": "lnkd-assembler-rollback-cli",
+        "count": "21,638"
+      }
+    ],
+    "lnkd-ats-admin-cli": [
+      {
+        "cask": "lnkd-ats-admin-cli",
+        "count": "22,788"
+      }
+    ],
+    "lnkd-ats-tools": [
+      {
+        "cask": "lnkd-ats-tools",
+        "count": "77,654"
+      }
+    ],
+    "lnkd-auto2to4": [
+      {
+        "cask": "lnkd-auto2to4",
+        "count": "22,455"
+      }
+    ],
+    "lnkd-autoalerts-cli": [
+      {
+        "cask": "lnkd-autoalerts-cli",
+        "count": "9,685"
+      }
+    ],
+    "lnkd-autoalerts-cli-go": [
+      {
+        "cask": "lnkd-autoalerts-cli-go",
+        "count": "21,912"
+      }
+    ],
+    "lnkd-autochangelog": [
+      {
+        "cask": "lnkd-autochangelog",
+        "count": "19,095"
+      }
+    ],
+    "lnkd-autometrics-index-cli": [
+      {
+        "cask": "lnkd-autometrics-index-cli",
+        "count": "30,962"
+      }
+    ],
+    "lnkd-autopilot": [
+      {
+        "cask": "lnkd-autopilot",
+        "count": "10,242"
+      }
+    ],
+    "lnkd-aws-tools": [
+      {
+        "cask": "lnkd-aws-tools",
+        "count": "10,286"
+      }
+    ],
+    "lnkd-az-imds-control": [
+      {
+        "cask": "lnkd-az-imds-control",
+        "count": "25,536"
+      }
+    ],
+    "lnkd-base": [
+      {
+        "cask": "lnkd-base",
+        "count": "51,715"
+      }
+    ],
+    "lnkd-bastion": [
+      {
+        "cask": "lnkd-bastion",
+        "count": "10,219"
+      }
+    ],
+    "lnkd-batman": [
+      {
+        "cask": "lnkd-batman",
+        "count": "10,210"
+      }
+    ],
+    "lnkd-bazel-wrapper": [
+      {
+        "cask": "lnkd-bazel-wrapper",
+        "count": "26,180"
+      }
+    ],
+    "lnkd-binary-cache": [
+      {
+        "cask": "lnkd-binary-cache",
+        "count": "22,637"
+      }
+    ],
+    "lnkd-bloodhound": [
+      {
+        "cask": "lnkd-bloodhound",
+        "count": "27,407"
+      }
+    ],
+    "lnkd-blueshift-grid-migration-cli": [
+      {
+        "cask": "lnkd-blueshift-grid-migration-cli",
+        "count": "32,487"
+      }
+    ],
+    "lnkd-brannigan": [
+      {
+        "cask": "lnkd-brannigan",
+        "count": "22,510"
+      }
+    ],
+    "lnkd-brooklin-tool": [
+      {
+        "cask": "lnkd-brooklin-tool",
+        "count": "56,627"
+      }
+    ],
+    "lnkd-caas-fleet": [
+      {
+        "cask": "lnkd-caas-fleet",
+        "count": "22,564"
+      }
+    ],
+    "lnkd-caas-tools": [
+      {
+        "cask": "lnkd-caas-tools",
+        "count": "47,584"
+      }
+    ],
+    "lnkd-cablein": [
+      {
+        "cask": "lnkd-cablein",
+        "count": "22,036"
+      }
+    ],
+    "lnkd-cachemanager-cli": [
+      {
+        "cask": "lnkd-cachemanager-cli",
+        "count": "19,907"
+      }
+    ],
+    "lnkd-cam-cli": [
+      {
+        "cask": "lnkd-cam-cli",
+        "count": "16,956"
+      }
+    ],
+    "lnkd-camels": [
+      {
+        "cask": "lnkd-camels",
+        "count": "10,401"
+      }
+    ],
+    "lnkd-ccdo": [
+      {
+        "cask": "lnkd-ccdo",
+        "count": "19,327"
+      }
+    ],
+    "lnkd-cfg2-commands": [
+      {
+        "cask": "lnkd-cfg2-commands",
+        "count": "38,106"
+      }
+    ],
+    "lnkd-chimp-cli": [
+      {
+        "cask": "lnkd-chimp-cli",
+        "count": "25,171"
+      }
+    ],
+    "lnkd-cia-utilities": [
+      {
+        "cask": "lnkd-cia-utilities",
+        "count": "10,092"
+      }
+    ],
+    "lnkd-cit": [
+      {
+        "cask": "lnkd-cit",
+        "count": "22,174"
+      }
+    ],
+    "lnkd-clean-staging": [
+      {
+        "cask": "lnkd-clean-staging",
+        "count": "13,131"
+      }
+    ],
+    "lnkd-cleanpython27": [
+      {
+        "cask": "lnkd-cleanpython27",
+        "count": "346"
+      }
+    ],
+    "lnkd-cleanpython35": [
+      {
+        "cask": "lnkd-cleanpython35",
+        "count": "330"
+      }
+    ],
+    "lnkd-cleanpython36": [
+      {
+        "cask": "lnkd-cleanpython36",
+        "count": "342"
+      }
+    ],
+    "lnkd-cleanpython37": [
+      {
+        "cask": "lnkd-cleanpython37",
+        "count": "416"
+      }
+    ],
+    "lnkd-cleanpython38": [
+      {
+        "cask": "lnkd-cleanpython38",
+        "count": "439"
+      }
+    ],
+    "lnkd-cli-bench": [
+      {
+        "cask": "lnkd-cli-bench",
+        "count": "21,811"
+      }
+    ],
+    "lnkd-clusterator-cli": [
+      {
+        "cask": "lnkd-clusterator-cli",
+        "count": "10,026"
+      }
+    ],
+    "lnkd-code-search-cli": [
+      {
+        "cask": "lnkd-code-search-cli",
+        "count": "31,122"
+      }
+    ],
+    "lnkd-codecoverage-tools": [
+      {
+        "cask": "lnkd-codecoverage-tools",
+        "count": "10,372"
+      }
+    ],
+    "lnkd-commerce-workflow-tool": [
+      {
+        "cask": "lnkd-commerce-workflow-tool",
+        "count": "10,366"
+      }
+    ],
+    "lnkd-compatibility-test-tool": [
+      {
+        "cask": "lnkd-compatibility-test-tool",
+        "count": "22,005"
+      }
+    ],
+    "lnkd-configure-app-runtime": [
+      {
+        "cask": "lnkd-configure-app-runtime",
+        "count": "10,313"
+      }
+    ],
+    "lnkd-content-sre-iris-dashboard-autogen": [
+      {
+        "cask": "lnkd-content-sre-iris-dashboard-autogen",
+        "count": "10,867"
+      }
+    ],
+    "lnkd-couch-tracker-cli": [
+      {
+        "cask": "lnkd-couch-tracker-cli",
+        "count": "10,611"
+      }
+    ],
+    "lnkd-couchbase-tools": [
+      {
+        "cask": "lnkd-couchbase-tools",
+        "count": "31,396"
+      }
+    ],
+    "lnkd-craem": [
+      {
+        "cask": "lnkd-craem",
+        "count": "22,945"
+      }
+    ],
+    "lnkd-crt-clis": [
+      {
+        "cask": "lnkd-crt-clis",
+        "count": "12,515"
+      }
+    ],
+    "lnkd-csm-pycli-test": [
+      {
+        "cask": "lnkd-csm-pycli-test",
+        "count": "15,096"
+      }
+    ],
+    "lnkd-curli": [
+      {
+        "cask": "lnkd-curli",
+        "count": "17,552"
+      }
+    ],
+    "lnkd-d2-config-cli": [
+      {
+        "cask": "lnkd-d2-config-cli",
+        "count": "23,798"
+      }
+    ],
+    "lnkd-d2-staging-cli": [
+      {
+        "cask": "lnkd-d2-staging-cli",
+        "count": "13,122"
+      }
+    ],
+    "lnkd-d2autotuner": [
+      {
+        "cask": "lnkd-d2autotuner",
+        "count": "20,168"
+      }
+    ],
+    "lnkd-dali-cli": [
+      {
+        "cask": "lnkd-dali-cli",
+        "count": "10,265"
+      }
+    ],
+    "lnkd-dash": [
+      {
+        "cask": "lnkd-dash",
+        "count": "10,169"
+      }
+    ],
+    "lnkd-dasre-tableau-insights-cli": [
+      {
+        "cask": "lnkd-dasre-tableau-insights-cli",
+        "count": "22,263"
+      }
+    ],
+    "lnkd-dasre-tools": [
+      {
+        "cask": "lnkd-dasre-tools",
+        "count": "24,844"
+      }
+    ],
+    "lnkd-data-derived": [
+      {
+        "cask": "lnkd-data-derived",
+        "count": "10"
+      }
+    ],
+    "lnkd-deadpool": [
+      {
+        "cask": "lnkd-deadpool",
+        "count": "10,574"
+      }
+    ],
+    "lnkd-debug-ssh": [
+      {
+        "cask": "lnkd-debug-ssh",
+        "count": "26,247"
+      }
+    ],
+    "lnkd-delta": [
+      {
+        "cask": "lnkd-delta",
+        "count": "10,620"
+      }
+    ],
+    "lnkd-dependency-test-cli": [
+      {
+        "cask": "lnkd-dependency-test-cli",
+        "count": "18,448"
+      }
+    ],
+    "lnkd-deployment-tools": [
+      {
+        "cask": "lnkd-deployment-tools",
+        "count": "39,131"
+      }
+    ],
+    "lnkd-diffoscope-cli": [
+      {
+        "cask": "lnkd-diffoscope-cli",
+        "count": "22,056"
+      }
+    ],
+    "lnkd-disre-cli-tools": [
+      {
+        "cask": "lnkd-disre-cli-tools",
+        "count": "22,295"
+      }
+    ],
+    "lnkd-docin-cli": [
+      {
+        "cask": "lnkd-docin-cli",
+        "count": "12,006"
+      }
+    ],
+    "lnkd-dss-cli": [
+      {
+        "cask": "lnkd-dss-cli",
+        "count": "10,450"
+      }
+    ],
+    "lnkd-dynamic-acl-tool": [
+      {
+        "cask": "lnkd-dynamic-acl-tool",
+        "count": "14,626"
+      }
+    ],
+    "lnkd-e2d": [
+      {
+        "cask": "lnkd-e2d",
+        "count": "22,605"
+      }
+    ],
+    "lnkd-e8-cli": [
+      {
+        "cask": "lnkd-e8-cli",
+        "count": "21,805"
+      }
+    ],
+    "lnkd-ecl": [
+      {
+        "cask": "lnkd-ecl",
+        "count": "331,140"
+      }
+    ],
+    "lnkd-eh": [
+      {
+        "cask": "lnkd-eh",
+        "count": "21,731"
+      }
+    ],
+    "lnkd-ehssh": [
+      {
+        "cask": "lnkd-ehssh",
+        "count": "22,336"
+      }
+    ],
+    "lnkd-ekg-cli": [
+      {
+        "cask": "lnkd-ekg-cli",
+        "count": "22,570"
+      }
+    ],
+    "lnkd-elkb-tools": [
+      {
+        "cask": "lnkd-elkb-tools",
+        "count": "10,274"
+      }
+    ],
+    "lnkd-encryption-tools": [
+      {
+        "cask": "lnkd-encryption-tools",
+        "count": "10,212"
+      }
+    ],
+    "lnkd-epsilon-cli": [
+      {
+        "cask": "lnkd-epsilon-cli",
+        "count": "10,743"
+      }
+    ],
+    "lnkd-ergo": [
+      {
+        "cask": "lnkd-ergo",
+        "count": "22,153"
+      }
+    ],
+    "lnkd-ers-new": [
+      {
+        "cask": "lnkd-ers-new",
+        "count": "10,268"
+      }
+    ],
+    "lnkd-espresso-storage-node-hooks": [
+      {
+        "cask": "lnkd-espresso-storage-node-hooks",
+        "count": "59,673"
+      }
+    ],
+    "lnkd-espresso-utilities": [
+      {
+        "cask": "lnkd-espresso-utilities",
+        "count": "41,728"
+      }
+    ],
+    "lnkd-et": [
+      {
+        "cask": "lnkd-et",
+        "count": "20,772"
+      }
+    ],
+    "lnkd-filtercall": [
+      {
+        "cask": "lnkd-filtercall",
+        "count": "46,991"
+      }
+    ],
+    "lnkd-flagship-bundle": [
+      {
+        "cask": "lnkd-flagship-bundle",
+        "count": "43,860"
+      }
+    ],
+    "lnkd-flashdisag-amf": [
+      {
+        "cask": "lnkd-flashdisag-amf",
+        "count": "22,708"
+      }
+    ],
+    "lnkd-flatc": [
+      {
+        "cask": "lnkd-flatc",
+        "count": "10,350"
+      }
+    ],
+    "lnkd-flood": [
+      {
+        "cask": "lnkd-flood",
+        "count": "17,028"
+      }
+    ],
+    "lnkd-fossor-li": [
+      {
+        "cask": "lnkd-fossor-li",
+        "count": "22,398"
+      }
+    ],
+    "lnkd-fua-cli": [
+      {
+        "cask": "lnkd-fua-cli",
+        "count": "9,932"
+      }
+    ],
+    "lnkd-gaas-client": [
+      {
+        "cask": "lnkd-gaas-client",
+        "count": "35,266"
+      }
+    ],
+    "lnkd-galene-index-cli": [
+      {
+        "cask": "lnkd-galene-index-cli",
+        "count": "24,659"
+      }
+    ],
+    "lnkd-get-oncall": [
+      {
+        "cask": "lnkd-get-oncall",
+        "count": "22,723"
+      }
+    ],
+    "lnkd-git-commands": [
+      {
+        "cask": "lnkd-git-commands",
+        "count": "47,608"
+      }
+    ],
+    "lnkd-git-submit": [
+      {
+        "cask": "lnkd-git-submit",
+        "count": "56,883"
+      }
+    ],
+    "lnkd-gnsops-tools": [
+      {
+        "cask": "lnkd-gnsops-tools",
+        "count": "24,616"
+      }
+    ],
+    "lnkd-go-log-replay": [
+      {
+        "cask": "lnkd-go-log-replay",
+        "count": "22,971"
+      }
+    ],
+    "lnkd-go-map": [
+      {
+        "cask": "lnkd-go-map",
+        "count": "10,371"
+      }
+    ],
+    "lnkd-go-redliner": [
+      {
+        "cask": "lnkd-go-redliner",
+        "count": "25,216"
+      }
+    ],
+    "lnkd-go-status": [
+      {
+        "cask": "lnkd-go-status",
+        "count": "31,087"
+      }
+    ],
+    "lnkd-gobblin-hooks": [
+      {
+        "cask": "lnkd-gobblin-hooks",
+        "count": "32,656"
+      }
+    ],
+    "lnkd-gobroke": [
+      {
+        "cask": "lnkd-gobroke",
+        "count": "19,864"
+      }
+    ],
+    "lnkd-gogo": [
+      {
+        "cask": "lnkd-gogo",
+        "count": "9,853"
+      }
+    ],
+    "lnkd-gradle-abtest-cli": [
+      {
+        "cask": "lnkd-gradle-abtest-cli",
+        "count": "13,320"
+      }
+    ],
+    "lnkd-hac-ai-tool": [
+      {
+        "cask": "lnkd-hac-ai-tool",
+        "count": "22,888"
+      }
+    ],
+    "lnkd-hadoop-cli": [
+      {
+        "cask": "lnkd-hadoop-cli",
+        "count": "12,043"
+      }
+    ],
+    "lnkd-harbor": [
+      {
+        "cask": "lnkd-harbor",
+        "count": "10,096"
+      }
+    ],
+    "lnkd-hardware-info": [
+      {
+        "cask": "lnkd-hardware-info",
+        "count": "22,590"
+      }
+    ],
+    "lnkd-hbfgradle": [
+      {
+        "cask": "lnkd-hbfgradle",
+        "count": "31,469"
+      }
+    ],
+    "lnkd-helios-cli": [
+      {
+        "cask": "lnkd-helios-cli",
+        "count": "22,184"
+      }
+    ],
+    "lnkd-helix-sre-tools": [
+      {
+        "cask": "lnkd-helix-sre-tools",
+        "count": "10,104"
+      }
+    ],
+    "lnkd-histogram": [
+      {
+        "cask": "lnkd-histogram",
+        "count": "10,214"
+      }
+    ],
+    "lnkd-hodor": [
+      {
+        "cask": "lnkd-hodor",
+        "count": "22,740"
+      }
+    ],
+    "lnkd-hong-kong": [
+      {
+        "cask": "lnkd-hong-kong",
+        "count": "22,927"
+      }
+    ],
+    "lnkd-host-information-tool-cli": [
+      {
+        "cask": "lnkd-host-information-tool-cli",
+        "count": "21,573"
+      }
+    ],
+    "lnkd-hosted-search-cli": [
+      {
+        "cask": "lnkd-hosted-search-cli",
+        "count": "37,161"
+      }
+    ],
+    "lnkd-hostli": [
+      {
+        "cask": "lnkd-hostli",
+        "count": "19,838"
+      }
+    ],
+    "lnkd-i18n-orphan": [
+      {
+        "cask": "lnkd-i18n-orphan",
+        "count": "9,820"
+      }
+    ],
+    "lnkd-id-tools": [
+      {
+        "cask": "lnkd-id-tools",
+        "count": "33,805"
+      }
+    ],
+    "lnkd-image-tool": [
+      {
+        "cask": "lnkd-image-tool",
+        "count": "60,536"
+      }
+    ],
+    "lnkd-informed-cli": [
+      {
+        "cask": "lnkd-informed-cli",
+        "count": "10,535"
+      }
+    ],
+    "lnkd-informed2-cli": [
+      {
+        "cask": "lnkd-informed2-cli",
+        "count": "25,850"
+      }
+    ],
+    "lnkd-ingraphs-cli": [
+      {
+        "cask": "lnkd-ingraphs-cli",
+        "count": "22,462"
+      }
+    ],
+    "lnkd-ingraphs-jinja": [
+      {
+        "cask": "lnkd-ingraphs-jinja",
+        "count": "22,563"
+      }
+    ],
+    "lnkd-inlogs-cli": [
+      {
+        "cask": "lnkd-inlogs-cli",
+        "count": "41,935"
+      }
+    ],
+    "lnkd-inmon-cli": [
+      {
+        "cask": "lnkd-inmon-cli",
+        "count": "9,957"
+      }
+    ],
+    "lnkd-inphone": [
+      {
+        "cask": "lnkd-inphone",
+        "count": "19,033"
+      }
+    ],
+    "lnkd-insearch-cli": [
+      {
+        "cask": "lnkd-insearch-cli",
+        "count": "22,478"
+      }
+    ],
+    "lnkd-inuse-cli": [
+      {
+        "cask": "lnkd-inuse-cli",
+        "count": "32,886"
+      }
+    ],
+    "lnkd-invincible-runner": [
+      {
+        "cask": "lnkd-invincible-runner",
+        "count": "22,978"
+      }
+    ],
+    "lnkd-invips-cli": [
+      {
+        "cask": "lnkd-invips-cli",
+        "count": "10,345"
+      }
+    ],
+    "lnkd-irresistible-force-cli": [
+      {
+        "cask": "lnkd-irresistible-force-cli",
+        "count": "20,012"
+      }
+    ],
+    "lnkd-java-11-zulu": [
+      {
+        "cask": "lnkd-java-11-zulu",
+        "count": "436"
+      }
+    ],
+    "lnkd-java-7u51": [
+      {
+        "cask": "lnkd-java-7u51",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-8u121": [
+      {
+        "cask": "lnkd-java-8u121",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-8u172": [
+      {
+        "cask": "lnkd-java-8u172",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-8u172-zulu": [
+      {
+        "cask": "lnkd-java-8u172-zulu",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-8u40": [
+      {
+        "cask": "lnkd-java-8u40",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-8u5": [
+      {
+        "cask": "lnkd-java-8u5",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-8u72": [
+      {
+        "cask": "lnkd-java-8u72",
+        "count": "5"
+      }
+    ],
+    "lnkd-java-cli-example": [
+      {
+        "cask": "lnkd-java-cli-example",
+        "count": "9,961"
+      }
+    ],
+    "lnkd-java-launcher": [
+      {
+        "cask": "lnkd-java-launcher",
+        "count": "12,605"
+      }
+    ],
+    "lnkd-java-sre-cli": [
+      {
+        "cask": "lnkd-java-sre-cli",
+        "count": "18,428"
+      }
+    ],
+    "lnkd-java-version-check": [
+      {
+        "cask": "lnkd-java-version-check",
+        "count": "10,055"
+      }
+    ],
+    "lnkd-jeeves-cli": [
+      {
+        "cask": "lnkd-jeeves-cli",
+        "count": "29,488"
+      }
+    ],
+    "lnkd-jet-unminify-cli": [
+      {
+        "cask": "lnkd-jet-unminify-cli",
+        "count": "22,315"
+      }
+    ],
+    "lnkd-jit-acl-cli": [
+      {
+        "cask": "lnkd-jit-acl-cli",
+        "count": "22,301"
+      }
+    ],
+    "lnkd-jobs-tool": [
+      {
+        "cask": "lnkd-jobs-tool",
+        "count": "21,296"
+      }
+    ],
+    "lnkd-jpulse": [
+      {
+        "cask": "lnkd-jpulse",
+        "count": "22,938"
+      }
+    ],
+    "lnkd-jqtop": [
+      {
+        "cask": "lnkd-jqtop",
+        "count": "21,869"
+      }
+    ],
+    "lnkd-jstf": [
+      {
+        "cask": "lnkd-jstf",
+        "count": "28,672"
+      }
+    ],
+    "lnkd-just": [
+      {
+        "cask": "lnkd-just",
+        "count": "22,799"
+      }
+    ],
+    "lnkd-jvmtop-cli": [
+      {
+        "cask": "lnkd-jvmtop-cli",
+        "count": "10,350"
+      }
+    ],
+    "lnkd-kafka-tool": [
+      {
+        "cask": "lnkd-kafka-tool",
+        "count": "11,453"
+      }
+    ],
+    "lnkd-kcap": [
+      {
+        "cask": "lnkd-kcap",
+        "count": "9,927"
+      }
+    ],
+    "lnkd-keep-running": [
+      {
+        "cask": "lnkd-keep-running",
+        "count": "9,972"
+      }
+    ],
+    "lnkd-kevin-cli": [
+      {
+        "cask": "lnkd-kevin-cli",
+        "count": "10,081"
+      }
+    ],
+    "lnkd-kms-cli": [
+      {
+        "cask": "lnkd-kms-cli",
+        "count": "44,068"
+      }
+    ],
+    "lnkd-ksre-tool": [
+      {
+        "cask": "lnkd-ksre-tool",
+        "count": "10,065"
+      }
+    ],
+    "lnkd-ktool": [
+      {
+        "cask": "lnkd-ktool",
+        "count": "24,365"
+      }
+    ],
+    "lnkd-labservice-tools": [
+      {
+        "cask": "lnkd-labservice-tools",
+        "count": "61,306"
+      }
+    ],
+    "lnkd-learning-sre-tools": [
+      {
+        "cask": "lnkd-learning-sre-tools",
+        "count": "15,752"
+      }
+    ],
+    "lnkd-li-idea": [
+      {
+        "cask": "lnkd-li-idea",
+        "count": "824"
+      }
+    ],
+    "lnkd-lid-host-history": [
+      {
+        "cask": "lnkd-lid-host-history",
+        "count": "22,843"
+      }
+    ],
+    "lnkd-lid-image-runner": [
+      {
+        "cask": "lnkd-lid-image-runner",
+        "count": "18,256"
+      }
+    ],
+    "lnkd-lid-runner": [
+      {
+        "cask": "lnkd-lid-runner",
+        "count": "21,693"
+      }
+    ],
+    "lnkd-lid-server-cli": [
+      {
+        "cask": "lnkd-lid-server-cli",
+        "count": "18,226"
+      }
+    ],
+    "lnkd-ligradle": [
+      {
+        "cask": "lnkd-ligradle",
+        "count": "22,889"
+      }
+    ],
+    "lnkd-lintellijps-cli": [
+      {
+        "cask": "lnkd-lintellijps-cli",
+        "count": "22,127"
+      }
+    ],
+    "lnkd-lintli-cli": [
+      {
+        "cask": "lnkd-lintli-cli",
+        "count": "45,077"
+      }
+    ],
+    "lnkd-lipy-followfeed": [
+      {
+        "cask": "lnkd-lipy-followfeed",
+        "count": "25,382"
+      }
+    ],
+    "lnkd-lipy-javaformat-app": [
+      {
+        "cask": "lnkd-lipy-javaformat-app",
+        "count": "9,976"
+      }
+    ],
+    "lnkd-lipy-kubectl": [
+      {
+        "cask": "lnkd-lipy-kubectl",
+        "count": "29,543"
+      }
+    ],
+    "lnkd-lipy-mdc": [
+      {
+        "cask": "lnkd-lipy-mdc",
+        "count": "32,646"
+      }
+    ],
+    "lnkd-lipy-pd-aggregator-app": [
+      {
+        "cask": "lnkd-lipy-pd-aggregator-app",
+        "count": "13,296"
+      }
+    ],
+    "lnkd-lipy-ranking-benchmark": [
+      {
+        "cask": "lnkd-lipy-ranking-benchmark",
+        "count": "10,360"
+      }
+    ],
+    "lnkd-lipy-security-scanner-app": [
+      {
+        "cask": "lnkd-lipy-security-scanner-app",
+        "count": "10,315"
+      }
+    ],
+    "lnkd-lipy-sourcecount-app": [
+      {
+        "cask": "lnkd-lipy-sourcecount-app",
+        "count": "9,863"
+      }
+    ],
+    "lnkd-lipy-uberlint": [
+      {
+        "cask": "lnkd-lipy-uberlint",
+        "count": "22,838"
+      }
+    ],
+    "lnkd-lipy-whatami-cli": [
+      {
+        "cask": "lnkd-lipy-whatami-cli",
+        "count": "10,580"
+      }
+    ],
+    "lnkd-lix-cli": [
+      {
+        "cask": "lnkd-lix-cli",
+        "count": "21,964"
+      }
+    ],
+    "lnkd-lls-cp-cli": [
+      {
+        "cask": "lnkd-lls-cp-cli",
+        "count": "25,179"
+      }
+    ],
+    "lnkd-lms-productivity-analysis-tools": [
+      {
+        "cask": "lnkd-lms-productivity-analysis-tools",
+        "count": "23,059"
+      }
+    ],
+    "lnkd-locker-cli": [
+      {
+        "cask": "lnkd-locker-cli",
+        "count": "30,287"
+      }
+    ],
+    "lnkd-lodgeit-cli": [
+      {
+        "cask": "lnkd-lodgeit-cli",
+        "count": "10,171"
+      }
+    ],
+    "lnkd-log-analyze": [
+      {
+        "cask": "lnkd-log-analyze",
+        "count": "22,364"
+      }
+    ],
+    "lnkd-logli": [
+      {
+        "cask": "lnkd-logli",
+        "count": "27,563"
+      }
+    ],
+    "lnkd-lps-cli": [
+      {
+        "cask": "lnkd-lps-cli",
+        "count": "42,660"
+      }
+    ],
+    "lnkd-luigi-cli": [
+      {
+        "cask": "lnkd-luigi-cli",
+        "count": "22,388"
+      }
+    ],
+    "lnkd-maestro-cli": [
+      {
+        "cask": "lnkd-maestro-cli",
+        "count": "37,076"
+      }
+    ],
+    "lnkd-manage-ssh": [
+      {
+        "cask": "lnkd-manage-ssh",
+        "count": "42,695"
+      }
+    ],
+    "lnkd-manifold": [
+      {
+        "cask": "lnkd-manifold",
+        "count": "23,045"
+      }
+    ],
+    "lnkd-media-tools": [
+      {
+        "cask": "lnkd-media-tools",
+        "count": "45,961"
+      }
+    ],
+    "lnkd-member-id-obftable-gen": [
+      {
+        "cask": "lnkd-member-id-obftable-gen",
+        "count": "22,092"
+      }
+    ],
+    "lnkd-member-restriction-benchmark": [
+      {
+        "cask": "lnkd-member-restriction-benchmark",
+        "count": "10,693"
+      }
+    ],
+    "lnkd-messaging-dev-tools": [
+      {
+        "cask": "lnkd-messaging-dev-tools",
+        "count": "10,211"
+      }
+    ],
+    "lnkd-metal-cli": [
+      {
+        "cask": "lnkd-metal-cli",
+        "count": "19,237"
+      }
+    ],
+    "lnkd-metget": [
+      {
+        "cask": "lnkd-metget",
+        "count": "10,059"
+      }
+    ],
+    "lnkd-metrics-client": [
+      {
+        "cask": "lnkd-metrics-client",
+        "count": "13,171"
+      }
+    ],
+    "lnkd-metrics-validator": [
+      {
+        "cask": "lnkd-metrics-validator",
+        "count": "36,281"
+      }
+    ],
+    "lnkd-midgard-utils": [
+      {
+        "cask": "lnkd-midgard-utils",
+        "count": "12,941"
+      }
+    ],
+    "lnkd-min": [
+      {
+        "cask": "lnkd-min",
+        "count": "22,806"
+      }
+    ],
+    "lnkd-mint": [
+      {
+        "cask": "lnkd-mint",
+        "count": "37,562"
+      }
+    ],
+    "lnkd-mint-integration": [
+      {
+        "cask": "lnkd-mint-integration",
+        "count": "10,723"
+      }
+    ],
+    "lnkd-model-creation-tool": [
+      {
+        "cask": "lnkd-model-creation-tool",
+        "count": "37,877"
+      }
+    ],
+    "lnkd-mp-maker": [
+      {
+        "cask": "lnkd-mp-maker",
+        "count": "24,299"
+      }
+    ],
+    "lnkd-mri": [
+      {
+        "cask": "lnkd-mri",
+        "count": "22,600"
+      }
+    ],
+    "lnkd-mysql-backup": [
+      {
+        "cask": "lnkd-mysql-backup",
+        "count": "10,541"
+      }
+    ],
+    "lnkd-mysqlmon-control": [
+      {
+        "cask": "lnkd-mysqlmon-control",
+        "count": "32,427"
+      }
+    ],
+    "lnkd-neo-builder": [
+      {
+        "cask": "lnkd-neo-builder",
+        "count": "31,952"
+      }
+    ],
+    "lnkd-neo-decom": [
+      {
+        "cask": "lnkd-neo-decom",
+        "count": "22,335"
+      }
+    ],
+    "lnkd-neo-silencer": [
+      {
+        "cask": "lnkd-neo-silencer",
+        "count": "10,138"
+      }
+    ],
+    "lnkd-norbert-cli": [
+      {
+        "cask": "lnkd-norbert-cli",
+        "count": "22,697"
+      }
+    ],
+    "lnkd-notgot": [
+      {
+        "cask": "lnkd-notgot",
+        "count": "19,570"
+      }
+    ],
+    "lnkd-nuage-auto-tools": [
+      {
+        "cask": "lnkd-nuage-auto-tools",
+        "count": "10,129"
+      }
+    ],
+    "lnkd-nurse-cli": [
+      {
+        "cask": "lnkd-nurse-cli",
+        "count": "10,467"
+      }
+    ],
+    "lnkd-odp": [
+      {
+        "cask": "lnkd-odp",
+        "count": "18,617"
+      }
+    ],
+    "lnkd-oncall-cli": [
+      {
+        "cask": "lnkd-oncall-cli",
+        "count": "10,324"
+      }
+    ],
+    "lnkd-oncall-custom-shifts": [
+      {
+        "cask": "lnkd-oncall-custom-shifts",
+        "count": "10,506"
+      }
+    ],
+    "lnkd-ondemand-sflow": [
+      {
+        "cask": "lnkd-ondemand-sflow",
+        "count": "10,520"
+      }
+    ],
+    "lnkd-oops": [
+      {
+        "cask": "lnkd-oops",
+        "count": "22,496"
+      }
+    ],
+    "lnkd-oracle-compliance-check": [
+      {
+        "cask": "lnkd-oracle-compliance-check",
+        "count": "17,707"
+      }
+    ],
+    "lnkd-orca-cli": [
+      {
+        "cask": "lnkd-orca-cli",
+        "count": "31,894"
+      }
+    ],
+    "lnkd-p4p-espresso": [
+      {
+        "cask": "lnkd-p4p-espresso",
+        "count": "12,900"
+      }
+    ],
+    "lnkd-p4p-jmx": [
+      {
+        "cask": "lnkd-p4p-jmx",
+        "count": "42,712"
+      }
+    ],
+    "lnkd-p4p-logrep": [
+      {
+        "cask": "lnkd-p4p-logrep",
+        "count": "25,412"
+      }
+    ],
+    "lnkd-p4p-oncall": [
+      {
+        "cask": "lnkd-p4p-oncall",
+        "count": "14,297"
+      }
+    ],
+    "lnkd-p4p-restli": [
+      {
+        "cask": "lnkd-p4p-restli",
+        "count": "25,409"
+      }
+    ],
+    "lnkd-parsein": [
+      {
+        "cask": "lnkd-parsein",
+        "count": "22,225"
+      }
+    ],
+    "lnkd-pem-cli": [
+      {
+        "cask": "lnkd-pem-cli",
+        "count": "13,117"
+      }
+    ],
+    "lnkd-perf-runner": [
+      {
+        "cask": "lnkd-perf-runner",
+        "count": "10,191"
+      }
+    ],
+    "lnkd-perseustool": [
+      {
+        "cask": "lnkd-perseustool",
+        "count": "42,742"
+      }
+    ],
+    "lnkd-pexcacheclean": [
+      {
+        "cask": "lnkd-pexcacheclean",
+        "count": "22,468"
+      }
+    ],
+    "lnkd-pillar-review-tool": [
+      {
+        "cask": "lnkd-pillar-review-tool",
+        "count": "47,568"
+      }
+    ],
+    "lnkd-pinot-utils": [
+      {
+        "cask": "lnkd-pinot-utils",
+        "count": "23,289"
+      }
+    ],
+    "lnkd-platform-sre-tools": [
+      {
+        "cask": "lnkd-platform-sre-tools",
+        "count": "12,103"
+      }
+    ],
+    "lnkd-pmu-cli": [
+      {
+        "cask": "lnkd-pmu-cli",
+        "count": "17,551"
+      }
+    ],
+    "lnkd-pop-buildout-tools": [
+      {
+        "cask": "lnkd-pop-buildout-tools",
+        "count": "22,994"
+      }
+    ],
+    "lnkd-pq-batch-cli": [
+      {
+        "cask": "lnkd-pq-batch-cli",
+        "count": "12,720"
+      }
+    ],
+    "lnkd-production-cli": [
+      {
+        "cask": "lnkd-production-cli",
+        "count": "18,826"
+      }
+    ],
+    "lnkd-prom-devices": [
+      {
+        "cask": "lnkd-prom-devices",
+        "count": "10,604"
+      }
+    ],
+    "lnkd-pylene-cli": [
+      {
+        "cask": "lnkd-pylene-cli",
+        "count": "71,526"
+      }
+    ],
+    "lnkd-python-dependency-inspector": [
+      {
+        "cask": "lnkd-python-dependency-inspector",
+        "count": "9,905"
+      }
+    ],
+    "lnkd-pyusage": [
+      {
+        "cask": "lnkd-pyusage",
+        "count": "21,787"
+      }
+    ],
+    "lnkd-qdt-cli": [
+      {
+        "cask": "lnkd-qdt-cli",
+        "count": "22,244"
+      }
+    ],
+    "lnkd-qei-cli": [
+      {
+        "cask": "lnkd-qei-cli",
+        "count": "9,980"
+      }
+    ],
+    "lnkd-querylog-parser": [
+      {
+        "cask": "lnkd-querylog-parser",
+        "count": "11,271"
+      }
+    ],
+    "lnkd-quotas": [
+      {
+        "cask": "lnkd-quotas",
+        "count": "22,907"
+      }
+    ],
+    "lnkd-race-cli": [
+      {
+        "cask": "lnkd-race-cli",
+        "count": "10,322"
+      }
+    ],
+    "lnkd-race-marshal-cli": [
+      {
+        "cask": "lnkd-race-marshal-cli",
+        "count": "10,337"
+      }
+    ],
+    "lnkd-rack-check-cli": [
+      {
+        "cask": "lnkd-rack-check-cli",
+        "count": "22,016"
+      }
+    ],
+    "lnkd-rain-adoption-utils": [
+      {
+        "cask": "lnkd-rain-adoption-utils",
+        "count": "10,303"
+      }
+    ],
+    "lnkd-rain-agent": [
+      {
+        "cask": "lnkd-rain-agent",
+        "count": "22,312"
+      }
+    ],
+    "lnkd-rain-cli": [
+      {
+        "cask": "lnkd-rain-cli",
+        "count": "43,021"
+      }
+    ],
+    "lnkd-rain-free": [
+      {
+        "cask": "lnkd-rain-free",
+        "count": "31,533"
+      }
+    ],
+    "lnkd-rainicorn": [
+      {
+        "cask": "lnkd-rainicorn",
+        "count": "10,825"
+      }
+    ],
+    "lnkd-rate-my-build": [
+      {
+        "cask": "lnkd-rate-my-build",
+        "count": "25,651"
+      }
+    ],
+    "lnkd-rb-cli": [
+      {
+        "cask": "lnkd-rb-cli",
+        "count": "13,545"
+      }
+    ],
+    "lnkd-rb-status": [
+      {
+        "cask": "lnkd-rb-status",
+        "count": "9,568"
+      }
+    ],
+    "lnkd-rdev-cli": [
+      {
+        "cask": "lnkd-rdev-cli",
+        "count": "78,725"
+      }
+    ],
+    "lnkd-rdt": [
+      {
+        "cask": "lnkd-rdt",
+        "count": "22,484"
+      }
+    ],
+    "lnkd-redliner-checks": [
+      {
+        "cask": "lnkd-redliner-checks",
+        "count": "36,998"
+      }
+    ],
+    "lnkd-redliner-cli": [
+      {
+        "cask": "lnkd-redliner-cli",
+        "count": "24,813"
+      }
+    ],
+    "lnkd-roomcheck": [
+      {
+        "cask": "lnkd-roomcheck",
+        "count": "13,038"
+      }
+    ],
+    "lnkd-rover-cli": [
+      {
+        "cask": "lnkd-rover-cli",
+        "count": "22,108"
+      }
+    ],
+    "lnkd-samples": [
+      {
+        "cask": "lnkd-samples",
+        "count": "22,975"
+      }
+    ],
+    "lnkd-samza-build-cli": [
+      {
+        "cask": "lnkd-samza-build-cli",
+        "count": "18,411"
+      }
+    ],
+    "lnkd-samza-hacks-cli": [
+      {
+        "cask": "lnkd-samza-hacks-cli",
+        "count": "10,184"
+      }
+    ],
+    "lnkd-samza-nurse-cli": [
+      {
+        "cask": "lnkd-samza-nurse-cli",
+        "count": "22,737"
+      }
+    ],
+    "lnkd-samza-sql-shell": [
+      {
+        "cask": "lnkd-samza-sql-shell",
+        "count": "12,121"
+      }
+    ],
+    "lnkd-samza-tool": [
+      {
+        "cask": "lnkd-samza-tool",
+        "count": "19,130"
+      }
+    ],
+    "lnkd-samza-tools": [
+      {
+        "cask": "lnkd-samza-tools",
+        "count": "37,525"
+      }
+    ],
+    "lnkd-sar-collector": [
+      {
+        "cask": "lnkd-sar-collector",
+        "count": "22,352"
+      }
+    ],
+    "lnkd-search-cloud-cli": [
+      {
+        "cask": "lnkd-search-cloud-cli",
+        "count": "31,607"
+      }
+    ],
+    "lnkd-search-sre-tools": [
+      {
+        "cask": "lnkd-search-sre-tools",
+        "count": "10,313"
+      }
+    ],
+    "lnkd-seas-logfilter": [
+      {
+        "cask": "lnkd-seas-logfilter",
+        "count": "29,912"
+      }
+    ],
+    "lnkd-secsre-tools": [
+      {
+        "cask": "lnkd-secsre-tools",
+        "count": "9,958"
+      }
+    ],
+    "lnkd-shrimp-cli": [
+      {
+        "cask": "lnkd-shrimp-cli",
+        "count": "22,526"
+      }
+    ],
+    "lnkd-shuffle-cli": [
+      {
+        "cask": "lnkd-shuffle-cli",
+        "count": "10,372"
+      }
+    ],
+    "lnkd-si-ops-tools": [
+      {
+        "cask": "lnkd-si-ops-tools",
+        "count": "18,764"
+      }
+    ],
+    "lnkd-sideload-cli": [
+      {
+        "cask": "lnkd-sideload-cli",
+        "count": "14,298"
+      }
+    ],
+    "lnkd-simple-ingraphs": [
+      {
+        "cask": "lnkd-simple-ingraphs",
+        "count": "53,639"
+      }
+    ],
+    "lnkd-singlemaster": [
+      {
+        "cask": "lnkd-singlemaster",
+        "count": "10,280"
+      }
+    ],
+    "lnkd-snapdragon": [
+      {
+        "cask": "lnkd-snapdragon",
+        "count": "22,997"
+      }
+    ],
+    "lnkd-snapshot-service-worker-hooks": [
+      {
+        "cask": "lnkd-snapshot-service-worker-hooks",
+        "count": "34,524"
+      }
+    ],
+    "lnkd-sos-cli": [
+      {
+        "cask": "lnkd-sos-cli",
+        "count": "23,089"
+      }
+    ],
+    "lnkd-spark-notebook": [
+      {
+        "cask": "lnkd-spark-notebook",
+        "count": "22,711"
+      }
+    ],
+    "lnkd-sparkjoy-cli": [
+      {
+        "cask": "lnkd-sparkjoy-cli",
+        "count": "21,390"
+      }
+    ],
+    "lnkd-srd-cli": [
+      {
+        "cask": "lnkd-srd-cli",
+        "count": "17,022"
+      }
+    ],
+    "lnkd-sre-cli": [
+      {
+        "cask": "lnkd-sre-cli",
+        "count": "33,380"
+      }
+    ],
+    "lnkd-sre-decom": [
+      {
+        "cask": "lnkd-sre-decom",
+        "count": "22,229"
+      }
+    ],
+    "lnkd-sre-gc-report": [
+      {
+        "cask": "lnkd-sre-gc-report",
+        "count": "10,130"
+      }
+    ],
+    "lnkd-ssh-ca-cli": [
+      {
+        "cask": "lnkd-ssh-ca-cli",
+        "count": "66,928"
+      }
+    ],
+    "lnkd-ssh-range": [
+      {
+        "cask": "lnkd-ssh-range",
+        "count": "33,373"
+      }
+    ],
+    "lnkd-st-dashboard-cli": [
+      {
+        "cask": "lnkd-st-dashboard-cli",
+        "count": "23,021"
+      }
+    ],
+    "lnkd-stickyrouting-ops": [
+      {
+        "cask": "lnkd-stickyrouting-ops",
+        "count": "13,943"
+      }
+    ],
+    "lnkd-svin": [
+      {
+        "cask": "lnkd-svin",
+        "count": "27,920"
+      }
+    ],
+    "lnkd-svn2git": [
+      {
+        "cask": "lnkd-svn2git",
+        "count": "30,960"
+      }
+    ],
+    "lnkd-tabby-mctabface": [
+      {
+        "cask": "lnkd-tabby-mctabface",
+        "count": "9,585"
+      }
+    ],
+    "lnkd-tail-metrics": [
+      {
+        "cask": "lnkd-tail-metrics",
+        "count": "10,331"
+      }
+    ],
+    "lnkd-test-cli": [
+      {
+        "cask": "lnkd-test-cli",
+        "count": "21,962"
+      }
+    ],
+    "lnkd-thin-archive": [
+      {
+        "cask": "lnkd-thin-archive",
+        "count": "10,206"
+      }
+    ],
+    "lnkd-tjacker": [
+      {
+        "cask": "lnkd-tjacker",
+        "count": "10,150"
+      }
+    ],
+    "lnkd-tm2-execution-engine": [
+      {
+        "cask": "lnkd-tm2-execution-engine",
+        "count": "32,093"
+      }
+    ],
+    "lnkd-tms-cli": [
+      {
+        "cask": "lnkd-tms-cli",
+        "count": "43,818"
+      }
+    ],
+    "lnkd-tools-slo": [
+      {
+        "cask": "lnkd-tools-slo",
+        "count": "22,103"
+      }
+    ],
+    "lnkd-tor1up-cli": [
+      {
+        "cask": "lnkd-tor1up-cli",
+        "count": "30,930"
+      }
+    ],
+    "lnkd-track-tools-cli": [
+      {
+        "cask": "lnkd-track-tools-cli",
+        "count": "15,633"
+      }
+    ],
+    "lnkd-traffic-remap-builder": [
+      {
+        "cask": "lnkd-traffic-remap-builder",
+        "count": "37,504"
+      }
+    ],
+    "lnkd-trigger-build": [
+      {
+        "cask": "lnkd-trigger-build",
+        "count": "22,242"
+      }
+    ],
+    "lnkd-trjson": [
+      {
+        "cask": "lnkd-trjson",
+        "count": "9,915"
+      }
+    ],
+    "lnkd-umbrella": [
+      {
+        "cask": "lnkd-umbrella",
+        "count": "19,224"
+      }
+    ],
+    "lnkd-ump-tool": [
+      {
+        "cask": "lnkd-ump-tool",
+        "count": "22,745"
+      }
+    ],
+    "lnkd-uss-azure-cli": [
+      {
+        "cask": "lnkd-uss-azure-cli",
+        "count": "30,419"
+      }
+    ],
+    "lnkd-validate-range-yaml-precommit": [
+      {
+        "cask": "lnkd-validate-range-yaml-precommit",
+        "count": "21,932"
+      }
+    ],
+    "lnkd-venice-tools": [
+      {
+        "cask": "lnkd-venice-tools",
+        "count": "30,537"
+      }
+    ],
+    "lnkd-venus-ull": [
+      {
+        "cask": "lnkd-venus-ull",
+        "count": "22,900"
+      }
+    ],
+    "lnkd-veritas-cli": [
+      {
+        "cask": "lnkd-veritas-cli",
+        "count": "9,995"
+      }
+    ],
+    "lnkd-video-cli": [
+      {
+        "cask": "lnkd-video-cli",
+        "count": "22,410"
+      }
+    ],
+    "lnkd-volta": [
+      {
+        "cask": "lnkd-volta",
+        "count": "28,291"
+      }
+    ],
+    "lnkd-volta-install": [
+      {
+        "cask": "lnkd-volta-install",
+        "count": "23,067"
+      }
+    ],
+    "lnkd-wastin-triage": [
+      {
+        "cask": "lnkd-wastin-triage",
+        "count": "9,999"
+      }
+    ],
+    "lnkd-waterbear-cli": [
+      {
+        "cask": "lnkd-waterbear-cli",
+        "count": "40,765"
+      }
+    ],
+    "lnkd-wk": [
+      {
+        "cask": "lnkd-wk",
+        "count": "13,870"
+      }
+    ],
+    "lnkd-wormhole-cli": [
+      {
+        "cask": "lnkd-wormhole-cli",
+        "count": "42,479"
+      }
+    ],
+    "lnkd-wrapped-python-tools": [
+      {
+        "cask": "lnkd-wrapped-python-tools",
+        "count": "21,752"
+      }
+    ],
+    "lnkd-yoda": [
+      {
+        "cask": "lnkd-yoda",
+        "count": "43,684"
+      }
+    ],
+    "lnkd-zing-tool": [
+      {
+        "cask": "lnkd-zing-tool",
+        "count": "10,404"
+      }
+    ],
+    "lnkd-zipline-cli": [
+      {
+        "cask": "lnkd-zipline-cli",
+        "count": "22,747"
+      }
+    ],
+    "lnkd-zoidberg": [
+      {
+        "cask": "lnkd-zoidberg",
+        "count": "22,732"
+      }
+    ],
+    "lnkd-zookeeper-hooks": [
+      {
+        "cask": "lnkd-zookeeper-hooks",
+        "count": "22,933"
+      }
+    ],
+    "lnkd-zookeeper-tools": [
+      {
+        "cask": "lnkd-zookeeper-tools",
+        "count": "22,377"
+      }
+    ],
+    "lnkd-zulu-jdk": [
+      {
+        "cask": "lnkd-zulu-jdk",
+        "count": "6"
+      }
+    ],
+    "lnkd-zulu-jdk-11": [
+      {
+        "cask": "lnkd-zulu-jdk-11",
+        "count": "587"
+      }
+    ],
+    "lnkd-zulu-jdk-8": [
+      {
+        "cask": "lnkd-zulu-jdk-8",
+        "count": "6"
+      }
+    ],
+    "loading": [
+      {
+        "cask": "loading",
+        "count": "16"
+      }
+    ],
+    "local": [
+      {
+        "cask": "local",
+        "count": "52"
+      }
+    ],
+    "local-by-flywheel": [
+      {
+        "cask": "local-by-flywheel",
+        "count": "5"
+      }
+    ],
+    "localdev": [
+      {
+        "cask": "localdev",
+        "count": "2"
+      }
+    ],
+    "localizationeditor": [
+      {
+        "cask": "localizationeditor",
+        "count": "27"
+      }
+    ],
+    "lockdown": [
+      {
+        "cask": "lockdown",
+        "count": "14"
+      }
+    ],
+    "lockrattler": [
+      {
+        "cask": "lockrattler",
+        "count": "6"
+      }
+    ],
+    "logdna-agent": [
+      {
+        "cask": "logdna-agent",
+        "count": "14"
+      }
+    ],
+    "logdna-cli": [
+      {
+        "cask": "logdna-cli",
+        "count": "27"
+      }
+    ],
+    "logicsniffer": [
+      {
+        "cask": "logicsniffer",
+        "count": "3"
+      }
+    ],
+    "loginputmac": [
+      {
+        "cask": "loginputmac",
+        "count": "14"
+      }
+    ],
+    "logisim": [
+      {
+        "cask": "logisim",
+        "count": "59"
+      }
+    ],
+    "logisim-evolution": [
+      {
+        "cask": "logisim-evolution",
+        "count": "14"
+      }
+    ],
+    "logisim-ita": [
+      {
+        "cask": "logisim-ita",
+        "count": "2"
+      }
+    ],
+    "logitech-camera-settings": [
+      {
+        "cask": "logitech-camera-settings",
+        "count": "70"
+      }
+    ],
+    "logitech-control-center": [
+      {
+        "cask": "logitech-control-center",
+        "count": "57"
+      }
+    ],
+    "logitech-firmwareupdatetool": [
+      {
+        "cask": "logitech-firmwareupdatetool",
+        "count": "27"
+      }
+    ],
+    "logitech-gaming-software": [
+      {
+        "cask": "logitech-gaming-software",
+        "count": "57"
+      }
+    ],
+    "logitech-myharmony": [
+      {
+        "cask": "logitech-myharmony",
+        "count": "13"
+      }
+    ],
+    "logitech-options": [
+      {
+        "cask": "logitech-options",
+        "count": "491"
+      }
+    ],
+    "logitech-presentation": [
+      {
+        "cask": "logitech-presentation",
+        "count": "25"
+      }
+    ],
+    "logitech-unifying": [
+      {
+        "cask": "logitech-unifying",
+        "count": "58"
+      }
+    ],
+    "logmein-client": [
+      {
+        "cask": "logmein-client",
+        "count": "12"
+      }
+    ],
+    "logmein-hamachi": [
+      {
+        "cask": "logmein-hamachi",
+        "count": "56"
+      }
+    ],
+    "logoist": [
+      {
+        "cask": "logoist",
+        "count": "1"
+      }
+    ],
+    "logos": [
+      {
+        "cask": "logos",
+        "count": "7"
+      }
+    ],
+    "lookin": [
+      {
+        "cask": "lookin",
+        "count": "2"
+      }
+    ],
+    "loom": [
+      {
+        "cask": "loom",
+        "count": "132"
+      }
+    ],
+    "loopback": [
+      {
+        "cask": "loopback",
+        "count": "178"
+      }
+    ],
+    "loopback1": [
+      {
+        "cask": "loopback1",
+        "count": "1"
+      }
+    ],
+    "losslesscut": [
+      {
+        "cask": "losslesscut",
+        "count": "79"
+      }
+    ],
+    "lottie": [
+      {
+        "cask": "lottie",
+        "count": "1"
+      }
+    ],
+    "love": [
+      {
+        "cask": "love",
+        "count": "130"
+      }
+    ],
+    "lrtimelapse": [
+      {
+        "cask": "lrtimelapse",
+        "count": "5"
+      }
+    ],
+    "ltspice": [
+      {
+        "cask": "ltspice",
+        "count": "48"
+      }
+    ],
+    "lulu": [
+      {
+        "cask": "lulu",
+        "count": "319"
+      }
+    ],
+    "lumen": [
+      {
+        "cask": "lumen",
+        "count": "42"
+      }
+    ],
+    "luminance-hdr": [
+      {
+        "cask": "luminance-hdr",
+        "count": "12"
+      }
+    ],
+    "luna-display": [
+      {
+        "cask": "luna-display",
+        "count": "14"
+      }
+    ],
+    "luna-secondary": [
+      {
+        "cask": "luna-secondary",
+        "count": "4"
+      }
+    ],
+    "lunar": [
+      {
+        "cask": "lunar",
+        "count": "167"
+      }
+    ],
+    "lunastudio": [
+      {
+        "cask": "lunastudio",
+        "count": "6"
+      }
+    ],
+    "lunchy": [
+      {
+        "cask": "lunchy",
+        "count": "27"
+      }
+    ],
+    "luxmark": [
+      {
+        "cask": "luxmark",
+        "count": "12"
+      }
+    ],
+    "luyten": [
+      {
+        "cask": "luyten",
+        "count": "19"
+      }
+    ],
+    "lyn": [
+      {
+        "cask": "lyn",
+        "count": "5"
+      }
+    ],
+    "lynkeos": [
+      {
+        "cask": "lynkeos",
+        "count": "6"
+      }
+    ],
+    "lynx": [
+      {
+        "cask": "lynx",
+        "count": "27"
+      }
+    ],
+    "lynxlet": [
+      {
+        "cask": "lynxlet",
+        "count": "9"
+      }
+    ],
+    "lyrics-master": [
+      {
+        "cask": "lyrics-master",
+        "count": "7"
+      }
+    ],
+    "lyricsx": [
+      {
+        "cask": "lyricsx",
+        "count": "79"
+      }
+    ],
+    "lyx": [
+      {
+        "cask": "lyx",
+        "count": "171"
+      }
+    ],
+    "m-iina": [
+      {
+        "cask": "m-iina",
+        "count": "1"
+      }
+    ],
+    "m3unify": [
+      {
+        "cask": "m3unify",
+        "count": "5"
+      }
+    ],
+    "mac-chromium": [
+      {
+        "cask": "mac-chromium",
+        "count": "14"
+      }
+    ],
+    "mac2imgur": [
+      {
+        "cask": "mac2imgur",
+        "count": "8"
+      }
+    ],
+    "macbreakz": [
+      {
+        "cask": "macbreakz",
+        "count": "3"
+      }
+    ],
+    "macclean": [
+      {
+        "cask": "macclean",
+        "count": "11"
+      }
+    ],
+    "maccpuid": [
+      {
+        "cask": "maccpuid",
+        "count": "27"
+      }
+    ],
+    "maccy": [
+      {
+        "cask": "maccy",
+        "count": "335"
+      }
+    ],
+    "macdependency": [
+      {
+        "cask": "macdependency",
+        "count": "3"
+      }
+    ],
+    "macdive": [
+      {
+        "cask": "macdive",
+        "count": "3"
+      }
+    ],
+    "macdjview": [
+      {
+        "cask": "macdjview",
+        "count": "9"
+      }
+    ],
+    "macdown": [
+      {
+        "cask": "macdown",
+        "count": "1,296"
+      }
+    ],
+    "macdropany": [
+      {
+        "cask": "macdropany",
+        "count": "5"
+      }
+    ],
+    "macfeh": [
+      {
+        "cask": "macfeh",
+        "count": "2"
+      }
+    ],
+    "macforge": [
+      {
+        "cask": "macforge",
+        "count": "1"
+      }
+    ],
+    "macfusion": [
+      {
+        "cask": "macfusion",
+        "count": "18"
+      }
+    ],
+    "macfusion-ng": [
+      {
+        "cask": "macfusion-ng",
+        "count": "16"
+      }
+    ],
+    "macgamestore": [
+      {
+        "cask": "macgamestore",
+        "count": "18"
+      }
+    ],
+    "macgdbp": [
+      {
+        "cask": "macgdbp",
+        "count": "14"
+      }
+    ],
+    "macgesture": [
+      {
+        "cask": "macgesture",
+        "count": "9"
+      }
+    ],
+    "machacha": [
+      {
+        "cask": "machacha",
+        "count": "2"
+      }
+    ],
+    "machg": [
+      {
+        "cask": "machg",
+        "count": "1"
+      }
+    ],
+    "machoexplorer": [
+      {
+        "cask": "machoexplorer",
+        "count": "7"
+      }
+    ],
+    "machoview": [
+      {
+        "cask": "machoview",
+        "count": "29"
+      }
+    ],
+    "maciasl": [
+      {
+        "cask": "maciasl",
+        "count": "48"
+      }
+    ],
+    "macintosh-explorer": [
+      {
+        "cask": "macintosh-explorer",
+        "count": "1"
+      }
+    ],
+    "macmediakeyforwarder": [
+      {
+        "cask": "macmediakeyforwarder",
+        "count": "182"
+      }
+    ],
+    "macos-catalina-patcher": [
+      {
+        "cask": "macos-catalina-patcher",
+        "count": "5"
+      }
+    ],
+    "macos-catalina-patcher@1.3.0": [
+      {
+        "cask": "macos-catalina-patcher@1.3.0",
+        "count": "6"
+      }
+    ],
+    "macpar-deluxe": [
+      {
+        "cask": "macpar-deluxe",
+        "count": "11"
+      }
+    ],
+    "macpass": [
+      {
+        "cask": "macpass",
+        "count": "368"
+      }
+    ],
+    "macpilot": [
+      {
+        "cask": "macpilot",
+        "count": "5"
+      }
+    ],
+    "macs-fan-control": [
+      {
+        "cask": "macs-fan-control",
+        "count": "614"
+      }
+    ],
+    "macspice": [
+      {
+        "cask": "macspice",
+        "count": "17"
+      }
+    ],
+    "macsvg": [
+      {
+        "cask": "macsvg",
+        "count": "64"
+      }
+    ],
+    "macterm": [
+      {
+        "cask": "macterm",
+        "count": "36"
+      }
+    ],
+    "mactex": [
+      {
+        "cask": "mactex",
+        "count": "3,725"
+      }
+    ],
+    "mactex-no-gui": [
+      {
+        "cask": "mactex-no-gui",
+        "count": "980"
+      }
+    ],
+    "mactracker": [
+      {
+        "cask": "mactracker",
+        "count": "163"
+      }
+    ],
+    "macupdate": [
+      {
+        "cask": "macupdate",
+        "count": "12"
+      }
+    ],
+    "macupdater": [
+      {
+        "cask": "macupdater",
+        "count": "80"
+      }
+    ],
+    "macvim": [
+      {
+        "cask": "macvim",
+        "count": "1,144"
+      }
+    ],
+    "macwinzipper": [
+      {
+        "cask": "macwinzipper",
+        "count": "81"
+      }
+    ],
+    "macx-dvd-ripper-mac-free-edition": [
+      {
+        "cask": "macx-dvd-ripper-mac-free-edition",
+        "count": "18"
+      }
+    ],
+    "macx-dvd-ripper-pro": [
+      {
+        "cask": "macx-dvd-ripper-pro",
+        "count": "8"
+      }
+    ],
+    "macx-video-converter-pro": [
+      {
+        "cask": "macx-video-converter-pro",
+        "count": "19"
+      }
+    ],
+    "macx-youtube-downloader": [
+      {
+        "cask": "macx-youtube-downloader",
+        "count": "99"
+      }
+    ],
+    "maczip4win": [
+      {
+        "cask": "maczip4win",
+        "count": "15"
+      }
+    ],
+    "maelstrom": [
+      {
+        "cask": "maelstrom",
+        "count": "1"
+      }
+    ],
+    "magic-launch": [
+      {
+        "cask": "magic-launch",
+        "count": "2"
+      }
+    ],
+    "magicavoxel": [
+      {
+        "cask": "magicavoxel",
+        "count": "60"
+      }
+    ],
+    "magiccap": [
+      {
+        "cask": "magiccap",
+        "count": "4"
+      }
+    ],
+    "magicplotstudent": [
+      {
+        "cask": "magicplotstudent",
+        "count": "1"
+      }
+    ],
+    "magicprefs": [
+      {
+        "cask": "magicprefs",
+        "count": "28"
+      }
+    ],
+    "mailbutler": [
+      {
+        "cask": "mailbutler",
+        "count": "37"
+      }
+    ],
+    "mailmaster": [
+      {
+        "cask": "mailmaster",
+        "count": "16"
+      }
+    ],
+    "mailmate": [
+      {
+        "cask": "mailmate",
+        "count": "46"
+      }
+    ],
+    "mailplane": [
+      {
+        "cask": "mailplane",
+        "count": "52"
+      }
+    ],
+    "mailspring": [
+      {
+        "cask": "mailspring",
+        "count": "96"
+      }
+    ],
+    "maintenance": [
+      {
+        "cask": "maintenance",
+        "count": "20"
+      }
+    ],
+    "makehuman": [
+      {
+        "cask": "makehuman",
+        "count": "18"
+      }
+    ],
+    "makemkv": [
+      {
+        "cask": "makemkv",
+        "count": "245"
+      }
+    ],
+    "maltego": [
+      {
+        "cask": "maltego",
+        "count": "86"
+      }
+    ],
+    "malus": [
+      {
+        "cask": "malus",
+        "count": "6"
+      }
+    ],
+    "malwarebytes": [
+      {
+        "cask": "malwarebytes",
+        "count": "370"
+      }
+    ],
+    "mame": [
+      {
+        "cask": "mame",
+        "count": "59"
+      }
+    ],
+    "mammon": [
+      {
+        "cask": "mammon",
+        "count": "1"
+      }
+    ],
+    "mamp": [
+      {
+        "cask": "mamp",
+        "count": "253"
+      }
+    ],
+    "manageengine-mibbrowser": [
+      {
+        "cask": "manageengine-mibbrowser",
+        "count": "12"
+      }
+    ],
+    "manico": [
+      {
+        "cask": "manico",
+        "count": "19"
+      }
+    ],
+    "manictime": [
+      {
+        "cask": "manictime",
+        "count": "6"
+      }
+    ],
+    "manta": [
+      {
+        "cask": "manta",
+        "count": "5"
+      }
+    ],
+    "manuscripts": [
+      {
+        "cask": "manuscripts",
+        "count": "9"
+      }
+    ],
+    "manuskript": [
+      {
+        "cask": "manuskript",
+        "count": "10"
+      }
+    ],
+    "mapillary-uploader": [
+      {
+        "cask": "mapillary-uploader",
+        "count": "1"
+      }
+    ],
+    "mapture": [
+      {
+        "cask": "mapture",
+        "count": "10"
+      }
+    ],
+    "marathon": [
+      {
+        "cask": "marathon",
+        "count": "6"
+      }
+    ],
+    "marble": [
+      {
+        "cask": "marble",
+        "count": "10"
+      }
+    ],
+    "marcedit": [
+      {
+        "cask": "marcedit",
+        "count": "1"
+      }
+    ],
+    "marginnote": [
+      {
+        "cask": "marginnote",
+        "count": "31"
+      }
+    ],
+    "mari0": [
+      {
+        "cask": "mari0",
+        "count": "5"
+      }
+    ],
+    "maria": [
+      {
+        "cask": "maria",
+        "count": "6"
+      }
+    ],
+    "mark-text": [
+      {
+        "cask": "mark-text",
+        "count": "233"
+      }
+    ],
+    "markdown": [
+      {
+        "cask": "markdown",
+        "count": "2"
+      }
+    ],
+    "markdown-service-tools": [
+      {
+        "cask": "markdown-service-tools",
+        "count": "15"
+      }
+    ],
+    "markdownmdimporter": [
+      {
+        "cask": "markdownmdimporter",
+        "count": "8"
+      }
+    ],
+    "marked": [
+      {
+        "cask": "marked",
+        "count": "90"
+      }
+    ],
+    "marker-import": [
+      {
+        "cask": "marker-import",
+        "count": "1"
+      }
+    ],
+    "markright": [
+      {
+        "cask": "markright",
+        "count": "1"
+      }
+    ],
+    "marmaduke-chromium": [
+      {
+        "cask": "marmaduke-chromium",
+        "count": "22"
+      }
+    ],
+    "marmaduke-chromium-nosync": [
+      {
+        "cask": "marmaduke-chromium-nosync",
+        "count": "3"
+      }
+    ],
+    "marmaduke-chromium-ungoogled": [
+      {
+        "cask": "marmaduke-chromium-ungoogled",
+        "count": "13"
+      }
+    ],
+    "mars": [
+      {
+        "cask": "mars",
+        "count": "14"
+      }
+    ],
+    "marsedit": [
+      {
+        "cask": "marsedit",
+        "count": "6"
+      }
+    ],
+    "marshallofsound-google-play-music-player": [
+      {
+        "cask": "marshallofsound-google-play-music-player",
+        "count": "56"
+      }
+    ],
+    "marta": [
+      {
+        "cask": "marta",
+        "count": "144"
+      }
+    ],
+    "marvel": [
+      {
+        "cask": "marvel",
+        "count": "13"
+      }
+    ],
+    "marvin": [
+      {
+        "cask": "marvin",
+        "count": "12"
+      }
+    ],
+    "masscode": [
+      {
+        "cask": "masscode",
+        "count": "33"
+      }
+    ],
+    "massreplaceit": [
+      {
+        "cask": "massreplaceit",
+        "count": "7"
+      }
+    ],
+    "master-password": [
+      {
+        "cask": "master-password",
+        "count": "12"
+      }
+    ],
+    "master-pdf-editor": [
+      {
+        "cask": "master-pdf-editor",
+        "count": "35"
+      }
+    ],
+    "masterway-note": [
+      {
+        "cask": "masterway-note",
+        "count": "1"
+      }
+    ],
+    "mat": [
+      {
+        "cask": "mat",
+        "count": "71"
+      }
+    ],
+    "mate-translate": [
+      {
+        "cask": "mate-translate",
+        "count": "8"
+      }
+    ],
+    "mater": [
+      {
+        "cask": "mater",
+        "count": "3"
+      }
+    ],
+    "material-colors": [
+      {
+        "cask": "material-colors",
+        "count": "3"
+      }
+    ],
+    "mathpix-snipping-tool": [
+      {
+        "cask": "mathpix-snipping-tool",
+        "count": "65"
+      }
+    ],
+    "mathtype": [
+      {
+        "cask": "mathtype",
+        "count": "28"
+      }
+    ],
+    "matterhorn": [
+      {
+        "cask": "matterhorn",
+        "count": "25"
+      }
+    ],
+    "mattermost": [
+      {
+        "cask": "mattermost",
+        "count": "491"
+      }
+    ],
+    "mattr-slate": [
+      {
+        "cask": "mattr-slate",
+        "count": "21"
+      }
+    ],
+    "mavensmate": [
+      {
+        "cask": "mavensmate",
+        "count": "4"
+      }
+    ],
+    "max": [
+      {
+        "cask": "max",
+        "count": "20"
+      }
+    ],
+    "mbed-studio": [
+      {
+        "cask": "mbed-studio",
+        "count": "7"
+      }
+    ],
+    "mblock": [
+      {
+        "cask": "mblock",
+        "count": "2"
+      }
+    ],
+    "mcbopomofo": [
+      {
+        "cask": "mcbopomofo",
+        "count": "3"
+      }
+    ],
+    "mcedit": [
+      {
+        "cask": "mcedit",
+        "count": "30"
+      }
+    ],
+    "mcgimp": [
+      {
+        "cask": "mcgimp",
+        "count": "56"
+      }
+    ],
+    "mdimagesizemdimporter": [
+      {
+        "cask": "mdimagesizemdimporter",
+        "count": "167"
+      }
+    ],
+    "mdrp": [
+      {
+        "cask": "mdrp",
+        "count": "4"
+      }
+    ],
+    "media-center": [
+      {
+        "cask": "media-center",
+        "count": "1"
+      }
+    ],
+    "media-converter": [
+      {
+        "cask": "media-converter",
+        "count": "18"
+      }
+    ],
+    "mediaelch": [
+      {
+        "cask": "mediaelch",
+        "count": "20"
+      }
+    ],
+    "mediahuman-audio-converter": [
+      {
+        "cask": "mediahuman-audio-converter",
+        "count": "48"
+      }
+    ],
+    "mediahuman-youtube-downloader": [
+      {
+        "cask": "mediahuman-youtube-downloader",
+        "count": "28"
+      }
+    ],
+    "mediainfo": [
+      {
+        "cask": "mediainfo",
+        "count": "158"
+      }
+    ],
+    "mediathekview": [
+      {
+        "cask": "mediathekview",
+        "count": "49"
+      }
+    ],
+    "mega": [
+      {
+        "cask": "mega",
+        "count": "17"
+      }
+    ],
+    "megacmd": [
+      {
+        "cask": "megacmd",
+        "count": "11"
+      }
+    ],
+    "megahertz-knotes": [
+      {
+        "cask": "megahertz-knotes",
+        "count": "1"
+      }
+    ],
+    "megasync": [
+      {
+        "cask": "megasync",
+        "count": "191"
+      }
+    ],
+    "meld": [
+      {
+        "cask": "meld",
+        "count": "2,496"
+      }
+    ],
+    "mellow": [
+      {
+        "cask": "mellow",
+        "count": "99"
+      }
+    ],
+    "mellowplayer": [
+      {
+        "cask": "mellowplayer",
+        "count": "10"
+      }
+    ],
+    "melodics": [
+      {
+        "cask": "melodics",
+        "count": "19"
+      }
+    ],
+    "memo": [
+      {
+        "cask": "memo",
+        "count": "6"
+      }
+    ],
+    "memoio": [
+      {
+        "cask": "memoio",
+        "count": "2"
+      }
+    ],
+    "memory": [
+      {
+        "cask": "memory",
+        "count": "14"
+      }
+    ],
+    "memory-map": [
+      {
+        "cask": "memory-map",
+        "count": "5"
+      }
+    ],
+    "mendeley": [
+      {
+        "cask": "mendeley",
+        "count": "247"
+      }
+    ],
+    "mendeley-desktop": [
+      {
+        "cask": "mendeley-desktop",
+        "count": "2"
+      }
+    ],
+    "mendeley-reference-manager": [
+      {
+        "cask": "mendeley-reference-manager",
+        "count": "50"
+      }
+    ],
+    "menubar-colors": [
+      {
+        "cask": "menubar-colors",
+        "count": "19"
+      }
+    ],
+    "menubar-countdown": [
+      {
+        "cask": "menubar-countdown",
+        "count": "4"
+      }
+    ],
+    "menubar-stats": [
+      {
+        "cask": "menubar-stats",
+        "count": "20"
+      }
+    ],
+    "menubargmail": [
+      {
+        "cask": "menubargmail",
+        "count": "4"
+      }
+    ],
+    "menucalendarclock-ical": [
+      {
+        "cask": "menucalendarclock-ical",
+        "count": "6"
+      }
+    ],
+    "menumeters": [
+      {
+        "cask": "menumeters",
+        "count": "314"
+      }
+    ],
+    "menutube": [
+      {
+        "cask": "menutube",
+        "count": "7"
+      }
+    ],
+    "merlin-project": [
+      {
+        "cask": "merlin-project",
+        "count": "14"
+      }
+    ],
+    "mesasqlite": [
+      {
+        "cask": "mesasqlite",
+        "count": "10"
+      }
+    ],
+    "meshcommander": [
+      {
+        "cask": "meshcommander",
+        "count": "4"
+      }
+    ],
+    "meshlab": [
+      {
+        "cask": "meshlab",
+        "count": "83"
+      }
+    ],
+    "meshmixer": [
+      {
+        "cask": "meshmixer",
+        "count": "38"
+      }
+    ],
+    "messenger": [
+      {
+        "cask": "messenger",
+        "count": "179"
+      }
+    ],
+    "messenger-native": [
+      {
+        "cask": "messenger-native",
+        "count": "12"
+      }
+    ],
+    "meta": [
+      {
+        "cask": "meta",
+        "count": "6"
+      }
+    ],
+    "metabase": [
+      {
+        "cask": "metabase",
+        "count": "55"
+      }
+    ],
+    "metasequoia": [
+      {
+        "cask": "metasequoia",
+        "count": "1"
+      }
+    ],
+    "metasploit": [
+      {
+        "cask": "metasploit",
+        "count": "326"
+      }
+    ],
+    "metaz": [
+      {
+        "cask": "metaz",
+        "count": "33"
+      }
+    ],
+    "meteorologist": [
+      {
+        "cask": "meteorologist",
+        "count": "20"
+      }
+    ],
+    "mgba": [
+      {
+        "cask": "mgba",
+        "count": "18"
+      }
+    ],
+    "mi": [
+      {
+        "cask": "mi",
+        "count": "34"
+      }
+    ],
+    "mia-for-gmail": [
+      {
+        "cask": "mia-for-gmail",
+        "count": "7"
+      }
+    ],
+    "michaelvillar-timer": [
+      {
+        "cask": "michaelvillar-timer",
+        "count": "447"
+      }
+    ],
+    "micro-snitch": [
+      {
+        "cask": "micro-snitch",
+        "count": "68"
+      }
+    ],
+    "microblog": [
+      {
+        "cask": "microblog",
+        "count": "14"
+      }
+    ],
+    "microsoft-azure-storage-explorer": [
+      {
+        "cask": "microsoft-azure-storage-explorer",
+        "count": "140"
+      }
+    ],
+    "microsoft-edge": [
+      {
+        "cask": "microsoft-edge",
+        "count": "2,345"
+      }
+    ],
+    "microsoft-edge-beta": [
+      {
+        "cask": "microsoft-edge-beta",
+        "count": "160"
+      }
+    ],
+    "microsoft-edge-dev": [
+      {
+        "cask": "microsoft-edge-dev",
+        "count": "178"
+      }
+    ],
+    "microsoft-excel": [
+      {
+        "cask": "microsoft-excel",
+        "count": "313"
+      }
+    ],
+    "microsoft-intellipoint": [
+      {
+        "cask": "microsoft-intellipoint",
+        "count": "7"
+      }
+    ],
+    "microsoft-intellitype": [
+      {
+        "cask": "microsoft-intellitype",
+        "count": "1"
+      }
+    ],
+    "microsoft-lync": [
+      {
+        "cask": "microsoft-lync",
+        "count": "39"
+      }
+    ],
+    "microsoft-office": [
+      {
+        "cask": "microsoft-office",
+        "count": "2,223"
+      }
+    ],
+    "microsoft-office-2011": [
+      {
+        "cask": "microsoft-office-2011",
+        "count": "2"
+      }
+    ],
+    "microsoft-office-2016": [
+      {
+        "cask": "microsoft-office-2016",
+        "count": "26"
+      }
+    ],
+    "microsoft-openjdk": [
+      {
+        "cask": "microsoft-openjdk",
+        "count": "2"
+      }
+    ],
+    "microsoft-outlook": [
+      {
+        "cask": "microsoft-outlook",
+        "count": "179"
+      }
+    ],
+    "microsoft-powerpoint": [
+      {
+        "cask": "microsoft-powerpoint",
+        "count": "200"
+      }
+    ],
+    "microsoft-r-open": [
+      {
+        "cask": "microsoft-r-open",
+        "count": "9"
+      }
+    ],
+    "microsoft-remote-desktop-beta": [
+      {
+        "cask": "microsoft-remote-desktop-beta",
+        "count": "214"
+      }
+    ],
+    "microsoft-teams": [
+      {
+        "cask": "microsoft-teams",
+        "count": "3,281"
+      }
+    ],
+    "microsoft-word": [
+      {
+        "cask": "microsoft-word",
+        "count": "312"
+      }
+    ],
+    "middleclick": [
+      {
+        "cask": "middleclick",
+        "count": "224"
+      }
+    ],
+    "midi-monitor": [
+      {
+        "cask": "midi-monitor",
+        "count": "20"
+      }
+    ],
+    "midikeys": [
+      {
+        "cask": "midikeys",
+        "count": "15"
+      }
+    ],
+    "midistroke": [
+      {
+        "cask": "midistroke",
+        "count": "7"
+      }
+    ],
+    "miditrail": [
+      {
+        "cask": "miditrail",
+        "count": "3"
+      }
+    ],
+    "mikogo": [
+      {
+        "cask": "mikogo",
+        "count": "2"
+      }
+    ],
+    "miktex-console": [
+      {
+        "cask": "miktex-console",
+        "count": "53"
+      }
+    ],
+    "milanote": [
+      {
+        "cask": "milanote",
+        "count": "17"
+      }
+    ],
+    "milkman": [
+      {
+        "cask": "milkman",
+        "count": "16"
+      }
+    ],
+    "milkytracker": [
+      {
+        "cask": "milkytracker",
+        "count": "9"
+      }
+    ],
+    "mimecast": [
+      {
+        "cask": "mimecast",
+        "count": "1"
+      }
+    ],
+    "mimiq": [
+      {
+        "cask": "mimiq",
+        "count": "1"
+      }
+    ],
+    "mimiq-gui": [
+      {
+        "cask": "mimiq-gui",
+        "count": "1"
+      }
+    ],
+    "min": [
+      {
+        "cask": "min",
+        "count": "48"
+      }
+    ],
+    "mindforger": [
+      {
+        "cask": "mindforger",
+        "count": "13"
+      }
+    ],
+    "mindjet-mindmanager": [
+      {
+        "cask": "mindjet-mindmanager",
+        "count": "18"
+      }
+    ],
+    "mindmaster": [
+      {
+        "cask": "mindmaster",
+        "count": "32"
+      }
+    ],
+    "minecraft": [
+      {
+        "cask": "minecraft",
+        "count": "573"
+      }
+    ],
+    "minecraft-server": [
+      {
+        "cask": "minecraft-server",
+        "count": "37"
+      }
+    ],
+    "minecraftpe": [
+      {
+        "cask": "minecraftpe",
+        "count": "23"
+      }
+    ],
+    "mini-program-studio": [
+      {
+        "cask": "mini-program-studio",
+        "count": "1"
+      }
+    ],
+    "mini-vmac": [
+      {
+        "cask": "mini-vmac",
+        "count": "12"
+      }
+    ],
+    "miniconda": [
+      {
+        "cask": "miniconda",
+        "count": "2,010"
+      }
+    ],
+    "miniconda2": [
+      {
+        "cask": "miniconda2",
+        "count": "11"
+      }
+    ],
+    "minikube": [
+      {
+        "cask": "minikube",
+        "count": "32"
+      }
+    ],
+    "minishift": [
+      {
+        "cask": "minishift",
+        "count": "1,129"
+      }
+    ],
+    "minitimer": [
+      {
+        "cask": "minitimer",
+        "count": "11"
+      }
+    ],
+    "minitube": [
+      {
+        "cask": "minitube",
+        "count": "5"
+      }
+    ],
+    "minizincide": [
+      {
+        "cask": "minizincide",
+        "count": "2"
+      }
+    ],
+    "mipony": [
+      {
+        "cask": "mipony",
+        "count": "11"
+      }
+    ],
+    "miro-formerly-realtimeboard": [
+      {
+        "cask": "miro-formerly-realtimeboard",
+        "count": "177"
+      }
+    ],
+    "mirrordisplays": [
+      {
+        "cask": "mirrordisplays",
+        "count": "2"
+      }
+    ],
+    "mirrorop": [
+      {
+        "cask": "mirrorop",
+        "count": "5"
+      }
+    ],
+    "mission-control-plus": [
+      {
+        "cask": "mission-control-plus",
+        "count": "23"
+      }
+    ],
+    "missive": [
+      {
+        "cask": "missive",
+        "count": "6"
+      }
+    ],
+    "mist": [
+      {
+        "cask": "mist",
+        "count": "2"
+      }
+    ],
+    "mitsuba": [
+      {
+        "cask": "mitsuba",
+        "count": "1"
+      }
+    ],
+    "mixxx": [
+      {
+        "cask": "mixxx",
+        "count": "33"
+      }
+    ],
+    "mjml": [
+      {
+        "cask": "mjml",
+        "count": "27"
+      }
+    ],
+    "mjolnir": [
+      {
+        "cask": "mjolnir",
+        "count": "15"
+      }
+    ],
+    "mkchromecast": [
+      {
+        "cask": "mkchromecast",
+        "count": "81"
+      }
+    ],
+    "mks": [
+      {
+        "cask": "mks",
+        "count": "9"
+      }
+    ],
+    "mkvtoolnix": [
+      {
+        "cask": "mkvtoolnix",
+        "count": "348"
+      }
+    ],
+    "mkvtools": [
+      {
+        "cask": "mkvtools",
+        "count": "39"
+      }
+    ],
+    "mmex": [
+      {
+        "cask": "mmex",
+        "count": "18"
+      }
+    ],
+    "mnemosyne": [
+      {
+        "cask": "mnemosyne",
+        "count": "7"
+      }
+    ],
+    "mob": [
+      {
+        "cask": "mob",
+        "count": "5"
+      }
+    ],
+    "mobile-cop": [
+      {
+        "cask": "mobile-cop",
+        "count": "4"
+      }
+    ],
+    "mobile-tools": [
+      {
+        "cask": "mobile-tools",
+        "count": "4"
+      }
+    ],
+    "mobirise": [
+      {
+        "cask": "mobirise",
+        "count": "9"
+      }
+    ],
+    "mobster": [
+      {
+        "cask": "mobster",
+        "count": "17"
+      }
+    ],
+    "mochi": [
+      {
+        "cask": "mochi",
+        "count": "17"
+      }
+    ],
+    "mockoon": [
+      {
+        "cask": "mockoon",
+        "count": "296"
+      }
+    ],
+    "mockplus": [
+      {
+        "cask": "mockplus",
+        "count": "4"
+      }
+    ],
+    "mockuuups-studio": [
+      {
+        "cask": "mockuuups-studio",
+        "count": "3"
+      }
+    ],
+    "modelio": [
+      {
+        "cask": "modelio",
+        "count": "26"
+      }
+    ],
+    "modmove": [
+      {
+        "cask": "modmove",
+        "count": "5"
+      }
+    ],
+    "moefe-google-translate": [
+      {
+        "cask": "moefe-google-translate",
+        "count": "10"
+      }
+    ],
+    "mojibar": [
+      {
+        "cask": "mojibar",
+        "count": "8"
+      }
+    ],
+    "molotov": [
+      {
+        "cask": "molotov",
+        "count": "36"
+      }
+    ],
+    "molsoft-browser": [
+      {
+        "cask": "molsoft-browser",
+        "count": "1"
+      }
+    ],
+    "molsoftbrowser": [
+      {
+        "cask": "molsoftbrowser",
+        "count": "1"
+      }
+    ],
+    "monal": [
+      {
+        "cask": "monal",
+        "count": "4"
+      }
+    ],
+    "monero-wallet": [
+      {
+        "cask": "monero-wallet",
+        "count": "27"
+      }
+    ],
+    "moneydance": [
+      {
+        "cask": "moneydance",
+        "count": "9"
+      }
+    ],
+    "moneymoney": [
+      {
+        "cask": "moneymoney",
+        "count": "42"
+      }
+    ],
+    "moneywiz": [
+      {
+        "cask": "moneywiz",
+        "count": "25"
+      }
+    ],
+    "mongodb": [
+      {
+        "cask": "mongodb",
+        "count": "22"
+      }
+    ],
+    "mongodb-compass": [
+      {
+        "cask": "mongodb-compass",
+        "count": "641"
+      }
+    ],
+    "mongodb-compass-beta": [
+      {
+        "cask": "mongodb-compass-beta",
+        "count": "5"
+      }
+    ],
+    "mongodb-compass-community": [
+      {
+        "cask": "mongodb-compass-community",
+        "count": "293"
+      }
+    ],
+    "mongodb-compass-isolated-edition": [
+      {
+        "cask": "mongodb-compass-isolated-edition",
+        "count": "2"
+      }
+    ],
+    "mongodb-compass-readonly": [
+      {
+        "cask": "mongodb-compass-readonly",
+        "count": "7"
+      }
+    ],
+    "mongodbpreferencepane": [
+      {
+        "cask": "mongodbpreferencepane",
+        "count": "2"
+      }
+    ],
+    "mongotron": [
+      {
+        "cask": "mongotron",
+        "count": "11"
+      }
+    ],
+    "monitorcontrol": [
+      {
+        "cask": "monitorcontrol",
+        "count": "1,257"
+      }
+    ],
+    "monitorearth": [
+      {
+        "cask": "monitorearth",
+        "count": "2"
+      }
+    ],
+    "monity-helper": [
+      {
+        "cask": "monity-helper",
+        "count": "7"
+      }
+    ],
+    "mono-mdk": [
+      {
+        "cask": "mono-mdk",
+        "count": "594"
+      }
+    ],
+    "mono-mdk-for-visual-studio": [
+      {
+        "cask": "mono-mdk-for-visual-studio",
+        "count": "512"
+      }
+    ],
+    "monodraw": [
+      {
+        "cask": "monodraw",
+        "count": "48"
+      }
+    ],
+    "monogame": [
+      {
+        "cask": "monogame",
+        "count": "17"
+      }
+    ],
+    "monolingual": [
+      {
+        "cask": "monolingual",
+        "count": "41"
+      }
+    ],
+    "moom": [
+      {
+        "cask": "moom",
+        "count": "145"
+      }
+    ],
+    "moonlight": [
+      {
+        "cask": "moonlight",
+        "count": "57"
+      }
+    ],
+    "morkro-papyrus": [
+      {
+        "cask": "morkro-papyrus",
+        "count": "2"
+      }
+    ],
+    "morpheus": [
+      {
+        "cask": "morpheus",
+        "count": "2"
+      }
+    ],
+    "mos": [
+      {
+        "cask": "mos",
+        "count": "435"
+      }
+    ],
+    "mos3": [
+      {
+        "cask": "mos3",
+        "count": "4"
+      }
+    ],
+    "mosaic": [
+      {
+        "cask": "mosaic",
+        "count": "23"
+      }
+    ],
+    "moscow-ml": [
+      {
+        "cask": "moscow-ml",
+        "count": "7"
+      }
+    ],
+    "moter": [
+      {
+        "cask": "moter",
+        "count": "1"
+      }
+    ],
+    "motion": [
+      {
+        "cask": "motion",
+        "count": "7"
+      }
+    ],
+    "motrix": [
+      {
+        "cask": "motrix",
+        "count": "347"
+      }
+    ],
+    "mount-efi": [
+      {
+        "cask": "mount-efi",
+        "count": "1"
+      }
+    ],
+    "mountain": [
+      {
+        "cask": "mountain",
+        "count": "5"
+      }
+    ],
+    "mountain-duck": [
+      {
+        "cask": "mountain-duck",
+        "count": "112"
+      }
+    ],
+    "mounty": [
+      {
+        "cask": "mounty",
+        "count": "1,890"
+      }
+    ],
+    "mouse-locator": [
+      {
+        "cask": "mouse-locator",
+        "count": "8"
+      }
+    ],
+    "mousepose": [
+      {
+        "cask": "mousepose",
+        "count": "5"
+      }
+    ],
+    "movist": [
+      {
+        "cask": "movist",
+        "count": "12"
+      }
+    ],
+    "movist-pro": [
+      {
+        "cask": "movist-pro",
+        "count": "23"
+      }
+    ],
+    "mozart": [
+      {
+        "cask": "mozart",
+        "count": "1"
+      }
+    ],
+    "mozart2": [
+      {
+        "cask": "mozart2",
+        "count": "5"
+      }
+    ],
+    "mp3gain-express": [
+      {
+        "cask": "mp3gain-express",
+        "count": "6"
+      }
+    ],
+    "mp3tag": [
+      {
+        "cask": "mp3tag",
+        "count": "18"
+      }
+    ],
+    "mp4tools": [
+      {
+        "cask": "mp4tools",
+        "count": "49"
+      }
+    ],
+    "mpeg-streamclip": [
+      {
+        "cask": "mpeg-streamclip",
+        "count": "15"
+      }
+    ],
+    "mplab-xc32": [
+      {
+        "cask": "mplab-xc32",
+        "count": "3"
+      }
+    ],
+    "mplayer-osx-extended": [
+      {
+        "cask": "mplayer-osx-extended",
+        "count": "49"
+      }
+    ],
+    "mplayerx": [
+      {
+        "cask": "mplayerx",
+        "count": "158"
+      }
+    ],
+    "mps": [
+      {
+        "cask": "mps",
+        "count": "7"
+      }
+    ],
+    "mpv": [
+      {
+        "cask": "mpv",
+        "count": "1,108"
+      }
+    ],
+    "mqtt-explorer": [
+      {
+        "cask": "mqtt-explorer",
+        "count": "59"
+      }
+    ],
+    "mqttfx": [
+      {
+        "cask": "mqttfx",
+        "count": "36"
+      }
+    ],
+    "mribeiro-timetracker": [
+      {
+        "cask": "mribeiro-timetracker",
+        "count": "1"
+      }
+    ],
+    "msoft-remote-desktop-beta": [
+      {
+        "cask": "msoft-remote-desktop-beta",
+        "count": "3"
+      }
+    ],
+    "mtmr": [
+      {
+        "cask": "mtmr",
+        "count": "252"
+      }
+    ],
+    "mu-editor": [
+      {
+        "cask": "mu-editor",
+        "count": "17"
+      }
+    ],
+    "mucommander": [
+      {
+        "cask": "mucommander",
+        "count": "106"
+      }
+    ],
+    "mudlet": [
+      {
+        "cask": "mudlet",
+        "count": "20"
+      }
+    ],
+    "mullvadvpn": [
+      {
+        "cask": "mullvadvpn",
+        "count": "90"
+      }
+    ],
+    "mullvadvpn-beta": [
+      {
+        "cask": "mullvadvpn-beta",
+        "count": "5"
+      }
+    ],
+    "multibit-hd": [
+      {
+        "cask": "multibit-hd",
+        "count": "3"
+      }
+    ],
+    "multifirefox": [
+      {
+        "cask": "multifirefox",
+        "count": "33"
+      }
+    ],
+    "multimc": [
+      {
+        "cask": "multimc",
+        "count": "48"
+      }
+    ],
+    "multipass": [
+      {
+        "cask": "multipass",
+        "count": "1,436"
+      }
+    ],
+    "multipatch": [
+      {
+        "cask": "multipatch",
+        "count": "5"
+      }
+    ],
+    "multitouch": [
+      {
+        "cask": "multitouch",
+        "count": "9"
+      }
+    ],
+    "mumble": [
+      {
+        "cask": "mumble",
+        "count": "166"
+      }
+    ],
+    "munki": [
+      {
+        "cask": "munki",
+        "count": "23"
+      }
+    ],
+    "murus": [
+      {
+        "cask": "murus",
+        "count": "23"
+      }
+    ],
+    "murus-menulet": [
+      {
+        "cask": "murus-menulet",
+        "count": "2"
+      }
+    ],
+    "muruslogsvisualizer": [
+      {
+        "cask": "muruslogsvisualizer",
+        "count": "3"
+      }
+    ],
+    "musaicfm": [
+      {
+        "cask": "musaicfm",
+        "count": "25"
+      }
+    ],
+    "muse": [
+      {
+        "cask": "muse",
+        "count": "16"
+      }
+    ],
+    "museeks": [
+      {
+        "cask": "museeks",
+        "count": "4"
+      }
+    ],
+    "musescore": [
+      {
+        "cask": "musescore",
+        "count": "160"
+      }
+    ],
+    "music-manager": [
+      {
+        "cask": "music-manager",
+        "count": "37"
+      }
+    ],
+    "musicbrainz-picard": [
+      {
+        "cask": "musicbrainz-picard",
+        "count": "155"
+      }
+    ],
+    "musictube": [
+      {
+        "cask": "musictube",
+        "count": "1"
+      }
+    ],
+    "mutespotifyads": [
+      {
+        "cask": "mutespotifyads",
+        "count": "274"
+      }
+    ],
+    "mutify": [
+      {
+        "cask": "mutify",
+        "count": "18"
+      }
+    ],
+    "muzzle": [
+      {
+        "cask": "muzzle",
+        "count": "81"
+      }
+    ],
+    "mweb": [
+      {
+        "cask": "mweb",
+        "count": "43"
+      }
+    ],
+    "my-budget": [
+      {
+        "cask": "my-budget",
+        "count": "2"
+      }
+    ],
+    "my-image-garden": [
+      {
+        "cask": "my-image-garden",
+        "count": "2"
+      }
+    ],
+    "mycloud": [
+      {
+        "cask": "mycloud",
+        "count": "3"
+      }
+    ],
+    "mycrypto": [
+      {
+        "cask": "mycrypto",
+        "count": "14"
+      }
+    ],
+    "mylio": [
+      {
+        "cask": "mylio",
+        "count": "5"
+      }
+    ],
+    "mymonero": [
+      {
+        "cask": "mymonero",
+        "count": "8"
+      }
+    ],
+    "myphone": [
+      {
+        "cask": "myphone",
+        "count": "2"
+      }
+    ],
+    "mysafaribasedbrowser": [
+      {
+        "cask": "mysafaribasedbrowser",
+        "count": "3"
+      }
+    ],
+    "mysides": [
+      {
+        "cask": "mysides",
+        "count": "21"
+      }
+    ],
+    "mysql-connector-python": [
+      {
+        "cask": "mysql-connector-python",
+        "count": "84"
+      }
+    ],
+    "mysql-shell": [
+      {
+        "cask": "mysql-shell",
+        "count": "229"
+      }
+    ],
+    "mysql-utilities": [
+      {
+        "cask": "mysql-utilities",
+        "count": "28"
+      }
+    ],
+    "mysqlworkbench": [
+      {
+        "cask": "mysqlworkbench",
+        "count": "1,725"
+      }
+    ],
+    "myworkspace": [
+      {
+        "cask": "myworkspace",
+        "count": "7"
+      }
+    ],
+    "nagbar": [
+      {
+        "cask": "nagbar",
+        "count": "2"
+      }
+    ],
+    "nagstamon": [
+      {
+        "cask": "nagstamon",
+        "count": "44"
+      }
+    ],
+    "nally": [
+      {
+        "cask": "nally",
+        "count": "5"
+      }
+    ],
+    "name-mangler": [
+      {
+        "cask": "name-mangler",
+        "count": "9"
+      }
+    ],
+    "namebench": [
+      {
+        "cask": "namebench",
+        "count": "26"
+      }
+    ],
+    "namechanger": [
+      {
+        "cask": "namechanger",
+        "count": "48"
+      }
+    ],
+    "nano": [
+      {
+        "cask": "nano",
+        "count": "27"
+      }
+    ],
+    "nanostudio": [
+      {
+        "cask": "nanostudio",
+        "count": "2"
+      }
+    ],
+    "nasas-eyes": [
+      {
+        "cask": "nasas-eyes",
+        "count": "2"
+      }
+    ],
+    "native-access": [
+      {
+        "cask": "native-access",
+        "count": "37"
+      }
+    ],
+    "nativedisplaybrightness": [
+      {
+        "cask": "nativedisplaybrightness",
+        "count": "13"
+      }
+    ],
+    "natron": [
+      {
+        "cask": "natron",
+        "count": "15"
+      }
+    ],
+    "nautilus": [
+      {
+        "cask": "nautilus",
+        "count": "18"
+      }
+    ],
+    "navicat-data-modeler": [
+      {
+        "cask": "navicat-data-modeler",
+        "count": "5"
+      }
+    ],
+    "navicat-data-modeler-essentials": [
+      {
+        "cask": "navicat-data-modeler-essentials",
+        "count": "7"
+      }
+    ],
+    "navicat-for-mariadb": [
+      {
+        "cask": "navicat-for-mariadb",
+        "count": "10"
+      }
+    ],
+    "navicat-for-mysql": [
+      {
+        "cask": "navicat-for-mysql",
+        "count": "52"
+      }
+    ],
+    "navicat-for-oracle": [
+      {
+        "cask": "navicat-for-oracle",
+        "count": "6"
+      }
+    ],
+    "navicat-for-postgresql": [
+      {
+        "cask": "navicat-for-postgresql",
+        "count": "30"
+      }
+    ],
+    "navicat-for-sql-server": [
+      {
+        "cask": "navicat-for-sql-server",
+        "count": "7"
+      }
+    ],
+    "navicat-for-sqlite": [
+      {
+        "cask": "navicat-for-sqlite",
+        "count": "8"
+      }
+    ],
+    "navicat-premium": [
+      {
+        "cask": "navicat-premium",
+        "count": "47"
+      }
+    ],
+    "navicat-premium-cn": [
+      {
+        "cask": "navicat-premium-cn",
+        "count": "1"
+      }
+    ],
+    "navicat-premium-essentials": [
+      {
+        "cask": "navicat-premium-essentials",
+        "count": "12"
+      }
+    ],
+    "nbtexplorer": [
+      {
+        "cask": "nbtexplorer",
+        "count": "7"
+      }
+    ],
+    "ncar-ncl": [
+      {
+        "cask": "ncar-ncl",
+        "count": "32"
+      }
+    ],
+    "ndm": [
+      {
+        "cask": "ndm",
+        "count": "22"
+      }
+    ],
+    "near-lock": [
+      {
+        "cask": "near-lock",
+        "count": "9"
+      }
+    ],
+    "neo4j": [
+      {
+        "cask": "neo4j",
+        "count": "68"
+      }
+    ],
+    "neofinder": [
+      {
+        "cask": "neofinder",
+        "count": "10"
+      }
+    ],
+    "neovim-nightly": [
+      {
+        "cask": "neovim-nightly",
+        "count": "4"
+      }
+    ],
+    "nestopia": [
+      {
+        "cask": "nestopia",
+        "count": "19"
+      }
+    ],
+    "netbeans": [
+      {
+        "cask": "netbeans",
+        "count": "241"
+      }
+    ],
+    "netbeans-cpp": [
+      {
+        "cask": "netbeans-cpp",
+        "count": "11"
+      }
+    ],
+    "netbeans-java-ee": [
+      {
+        "cask": "netbeans-java-ee",
+        "count": "12"
+      }
+    ],
+    "netbeans-java-se": [
+      {
+        "cask": "netbeans-java-se",
+        "count": "14"
+      }
+    ],
+    "netbeans-php": [
+      {
+        "cask": "netbeans-php",
+        "count": "46"
+      }
+    ],
+    "netdownloadhelpercoapp": [
+      {
+        "cask": "netdownloadhelpercoapp",
+        "count": "19"
+      }
+    ],
+    "neteasemusic": [
+      {
+        "cask": "neteasemusic",
+        "count": "210"
+      }
+    ],
+    "netgear-switch-discovery-tool": [
+      {
+        "cask": "netgear-switch-discovery-tool",
+        "count": "2"
+      }
+    ],
+    "nethackcocoa": [
+      {
+        "cask": "nethackcocoa",
+        "count": "11"
+      }
+    ],
+    "netiquette": [
+      {
+        "cask": "netiquette",
+        "count": "33"
+      }
+    ],
+    "netlogo": [
+      {
+        "cask": "netlogo",
+        "count": "21"
+      }
+    ],
+    "netnewswire": [
+      {
+        "cask": "netnewswire",
+        "count": "134"
+      }
+    ],
+    "netron": [
+      {
+        "cask": "netron",
+        "count": "322"
+      }
+    ],
+    "netspot": [
+      {
+        "cask": "netspot",
+        "count": "95"
+      }
+    ],
+    "netsurf": [
+      {
+        "cask": "netsurf",
+        "count": "15"
+      }
+    ],
+    "netxms-console": [
+      {
+        "cask": "netxms-console",
+        "count": "3"
+      }
+    ],
+    "next": [
+      {
+        "cask": "next",
+        "count": "34"
+      }
+    ],
+    "nextcloud": [
+      {
+        "cask": "nextcloud",
+        "count": "369"
+      }
+    ],
+    "nfov": [
+      {
+        "cask": "nfov",
+        "count": "10"
+      }
+    ],
+    "ngrok": [
+      {
+        "cask": "ngrok",
+        "count": "5,717"
+      }
+    ],
+    "nheko": [
+      {
+        "cask": "nheko",
+        "count": "20"
+      }
+    ],
+    "ni-488-2": [
+      {
+        "cask": "ni-488-2",
+        "count": "3"
+      }
+    ],
+    "night-owl": [
+      {
+        "cask": "night-owl",
+        "count": "30"
+      }
+    ],
+    "nightfall": [
+      {
+        "cask": "nightfall",
+        "count": "48"
+      }
+    ],
+    "nightowl": [
+      {
+        "cask": "nightowl",
+        "count": "169"
+      }
+    ],
+    "nimble": [
+      {
+        "cask": "nimble",
+        "count": "12"
+      }
+    ],
+    "nimble-commander": [
+      {
+        "cask": "nimble-commander",
+        "count": "10"
+      }
+    ],
+    "nimbus": [
+      {
+        "cask": "nimbus",
+        "count": "5"
+      }
+    ],
+    "ninja-download-manager-ndm": [
+      {
+        "cask": "ninja-download-manager-ndm",
+        "count": "6"
+      }
+    ],
+    "nisus-thesaurus": [
+      {
+        "cask": "nisus-thesaurus",
+        "count": "5"
+      }
+    ],
+    "nitrokey": [
+      {
+        "cask": "nitrokey",
+        "count": "5"
+      }
+    ],
+    "nitroshare": [
+      {
+        "cask": "nitroshare",
+        "count": "15"
+      }
+    ],
+    "no-ip-duc": [
+      {
+        "cask": "no-ip-duc",
+        "count": "15"
+      }
+    ],
+    "nocturnal": [
+      {
+        "cask": "nocturnal",
+        "count": "10"
+      }
+    ],
+    "nocturne": [
+      {
+        "cask": "nocturne",
+        "count": "6"
+      }
+    ],
+    "nodebox": [
+      {
+        "cask": "nodebox",
+        "count": "7"
+      }
+    ],
+    "nodeclipse": [
+      {
+        "cask": "nodeclipse",
+        "count": "1"
+      }
+    ],
+    "noisebuddy": [
+      {
+        "cask": "noisebuddy",
+        "count": "7"
+      }
+    ],
+    "noisy": [
+      {
+        "cask": "noisy",
+        "count": "2"
+      }
+    ],
+    "noisytyper": [
+      {
+        "cask": "noisytyper",
+        "count": "2"
+      }
+    ],
+    "nomachine": [
+      {
+        "cask": "nomachine",
+        "count": "181"
+      }
+    ],
+    "nomad": [
+      {
+        "cask": "nomad",
+        "count": "27"
+      }
+    ],
+    "nordic-nrf-command-line-tools": [
+      {
+        "cask": "nordic-nrf-command-line-tools",
+        "count": "28"
+      }
+    ],
+    "nordic-nrf-connect": [
+      {
+        "cask": "nordic-nrf-connect",
+        "count": "11"
+      }
+    ],
+    "nordvpn": [
+      {
+        "cask": "nordvpn",
+        "count": "656"
+      }
+    ],
+    "nosleep": [
+      {
+        "cask": "nosleep",
+        "count": "68"
+      }
+    ],
+    "nosql-workbench-for-amazon-dynamodb": [
+      {
+        "cask": "nosql-workbench-for-amazon-dynamodb",
+        "count": "70"
+      }
+    ],
+    "nosqlbooster-for-mongodb": [
+      {
+        "cask": "nosqlbooster-for-mongodb",
+        "count": "79"
+      }
+    ],
+    "nosqlclient": [
+      {
+        "cask": "nosqlclient",
+        "count": "14"
+      }
+    ],
+    "not-pacman": [
+      {
+        "cask": "not-pacman",
+        "count": "4"
+      }
+    ],
+    "not-tetris": [
+      {
+        "cask": "not-tetris",
+        "count": "10"
+      }
+    ],
+    "notable": [
+      {
+        "cask": "notable",
+        "count": "110"
+      }
+    ],
+    "notational-velocity": [
+      {
+        "cask": "notational-velocity",
+        "count": "22"
+      }
+    ],
+    "notebooks": [
+      {
+        "cask": "notebooks",
+        "count": "10"
+      }
+    ],
+    "noteplan": [
+      {
+        "cask": "noteplan",
+        "count": "7"
+      }
+    ],
+    "noti": [
+      {
+        "cask": "noti",
+        "count": "36"
+      }
+    ],
+    "notion": [
+      {
+        "cask": "notion",
+        "count": "1,137"
+      }
+    ],
+    "noto": [
+      {
+        "cask": "noto",
+        "count": "10"
+      }
+    ],
+    "noun-project": [
+      {
+        "cask": "noun-project",
+        "count": "11"
+      }
+    ],
+    "novabench": [
+      {
+        "cask": "novabench",
+        "count": "18"
+      }
+    ],
+    "now": [
+      {
+        "cask": "now",
+        "count": "64"
+      }
+    ],
+    "now-tv-player": [
+      {
+        "cask": "now-tv-player",
+        "count": "6"
+      }
+    ],
+    "nowplayingitunes": [
+      {
+        "cask": "nowplayingitunes",
+        "count": "1"
+      }
+    ],
+    "nowplayingtweet": [
+      {
+        "cask": "nowplayingtweet",
+        "count": "8"
+      }
+    ],
+    "noxappplayer": [
+      {
+        "cask": "noxappplayer",
+        "count": "110"
+      }
+    ],
+    "nozbe": [
+      {
+        "cask": "nozbe",
+        "count": "3"
+      }
+    ],
+    "nrlquaker-winbox": [
+      {
+        "cask": "nrlquaker-winbox",
+        "count": "749"
+      }
+    ],
+    "nslogger": [
+      {
+        "cask": "nslogger",
+        "count": "1"
+      }
+    ],
+    "nsregextester": [
+      {
+        "cask": "nsregextester",
+        "count": "1"
+      }
+    ],
+    "nteract": [
+      {
+        "cask": "nteract",
+        "count": "89"
+      }
+    ],
+    "nucc": [
+      {
+        "cask": "nucc",
+        "count": "20"
+      }
+    ],
+    "nuccdev": [
+      {
+        "cask": "nuccdev",
+        "count": "4"
+      }
+    ],
+    "nuclear": [
+      {
+        "cask": "nuclear",
+        "count": "11"
+      }
+    ],
+    "nucleo": [
+      {
+        "cask": "nucleo",
+        "count": "12"
+      }
+    ],
+    "nuclino": [
+      {
+        "cask": "nuclino",
+        "count": "1"
+      }
+    ],
+    "nullpomino": [
+      {
+        "cask": "nullpomino",
+        "count": "3"
+      }
+    ],
+    "numi": [
+      {
+        "cask": "numi",
+        "count": "350"
+      }
+    ],
+    "nutstore": [
+      {
+        "cask": "nutstore",
+        "count": "40"
+      }
+    ],
+    "nvalt": [
+      {
+        "cask": "nvalt",
+        "count": "114"
+      }
+    ],
+    "nvidia-cuda": [
+      {
+        "cask": "nvidia-cuda",
+        "count": "23"
+      }
+    ],
+    "nvidia-geforce-now": [
+      {
+        "cask": "nvidia-geforce-now",
+        "count": "263"
+      }
+    ],
+    "nwjs": [
+      {
+        "cask": "nwjs",
+        "count": "28"
+      }
+    ],
+    "nzbget": [
+      {
+        "cask": "nzbget",
+        "count": "26"
+      }
+    ],
+    "nzbvortex": [
+      {
+        "cask": "nzbvortex",
+        "count": "8"
+      }
+    ],
+    "obinslab-starter": [
+      {
+        "cask": "obinslab-starter",
+        "count": "13"
+      }
+    ],
+    "objectivesharpie": [
+      {
+        "cask": "objectivesharpie",
+        "count": "2"
+      }
+    ],
+    "obs": [
+      {
+        "cask": "obs",
+        "count": "1,966"
+      }
+    ],
+    "ocenaudio": [
+      {
+        "cask": "ocenaudio",
+        "count": "84"
+      }
+    ],
+    "oclint": [
+      {
+        "cask": "oclint",
+        "count": "232"
+      }
+    ],
+    "octave-app": [
+      {
+        "cask": "octave-app",
+        "count": "133"
+      }
+    ],
+    "octomouse": [
+      {
+        "cask": "octomouse",
+        "count": "7"
+      }
+    ],
+    "octoscreen": [
+      {
+        "cask": "octoscreen",
+        "count": "2"
+      }
+    ],
+    "odio": [
+      {
+        "cask": "odio",
+        "count": "10"
+      }
+    ],
+    "odrive": [
+      {
+        "cask": "odrive",
+        "count": "25"
+      }
+    ],
+    "ogdesign-eagle": [
+      {
+        "cask": "ogdesign-eagle",
+        "count": "15"
+      }
+    ],
+    "okuna-desktop": [
+      {
+        "cask": "okuna-desktop",
+        "count": "1"
+      }
+    ],
+    "olive": [
+      {
+        "cask": "olive",
+        "count": "11"
+      }
+    ],
+    "omegat": [
+      {
+        "cask": "omegat",
+        "count": "9"
+      }
+    ],
+    "omnidazzle": [
+      {
+        "cask": "omnidazzle",
+        "count": "8"
+      }
+    ],
+    "omnidb": [
+      {
+        "cask": "omnidb",
+        "count": "17"
+      }
+    ],
+    "omnidisksweeper": [
+      {
+        "cask": "omnidisksweeper",
+        "count": "229"
+      }
+    ],
+    "omnifocus": [
+      {
+        "cask": "omnifocus",
+        "count": "161"
+      }
+    ],
+    "omnigraffle": [
+      {
+        "cask": "omnigraffle",
+        "count": "288"
+      }
+    ],
+    "omnigraffle6": [
+      {
+        "cask": "omnigraffle6",
+        "count": "2"
+      }
+    ],
+    "omnioutliner": [
+      {
+        "cask": "omnioutliner",
+        "count": "54"
+      }
+    ],
+    "omniplan": [
+      {
+        "cask": "omniplan",
+        "count": "39"
+      }
+    ],
+    "omnipresence": [
+      {
+        "cask": "omnipresence",
+        "count": "8"
+      }
+    ],
+    "omniweb": [
+      {
+        "cask": "omniweb",
+        "count": "2"
+      }
+    ],
+    "ondesoft-audiobook-converter": [
+      {
+        "cask": "ondesoft-audiobook-converter",
+        "count": "4"
+      }
+    ],
+    "one-switch": [
+      {
+        "cask": "one-switch",
+        "count": "74"
+      }
+    ],
+    "onecast": [
+      {
+        "cask": "onecast",
+        "count": "7"
+      }
+    ],
+    "onedrive": [
+      {
+        "cask": "onedrive",
+        "count": "512"
+      }
+    ],
+    "onenote-importer-preview": [
+      {
+        "cask": "onenote-importer-preview",
+        "count": "5"
+      }
+    ],
+    "onepile": [
+      {
+        "cask": "onepile",
+        "count": "2"
+      }
+    ],
+    "oni": [
+      {
+        "cask": "oni",
+        "count": "72"
+      }
+    ],
+    "onionshare": [
+      {
+        "cask": "onionshare",
+        "count": "35"
+      }
+    ],
+    "onivim2": [
+      {
+        "cask": "onivim2",
+        "count": "2"
+      }
+    ],
+    "onlyoffice": [
+      {
+        "cask": "onlyoffice",
+        "count": "54"
+      }
+    ],
+    "onyx": [
+      {
+        "cask": "onyx",
+        "count": "843"
+      }
+    ],
+    "oolite": [
+      {
+        "cask": "oolite",
+        "count": "3"
+      }
+    ],
+    "open-in-code": [
+      {
+        "cask": "open-in-code",
+        "count": "80"
+      }
+    ],
+    "open-jupyter": [
+      {
+        "cask": "open-jupyter",
+        "count": "2"
+      }
+    ],
+    "openarena": [
+      {
+        "cask": "openarena",
+        "count": "37"
+      }
+    ],
+    "openaudible": [
+      {
+        "cask": "openaudible",
+        "count": "50"
+      }
+    ],
+    "openbazaar": [
+      {
+        "cask": "openbazaar",
+        "count": "9"
+      }
+    ],
+    "openboard": [
+      {
+        "cask": "openboard",
+        "count": "46"
+      }
+    ],
+    "openboardview": [
+      {
+        "cask": "openboardview",
+        "count": "7"
+      }
+    ],
+    "openconnect-gui": [
+      {
+        "cask": "openconnect-gui",
+        "count": "504"
+      }
+    ],
+    "opencore-configurator": [
+      {
+        "cask": "opencore-configurator",
+        "count": "59"
+      }
+    ],
+    "opencpn": [
+      {
+        "cask": "opencpn",
+        "count": "3"
+      }
+    ],
+    "opendnsupdater": [
+      {
+        "cask": "opendnsupdater",
+        "count": "11"
+      }
+    ],
+    "openemu": [
+      {
+        "cask": "openemu",
+        "count": "478"
+      }
+    ],
+    "openemu-experimental": [
+      {
+        "cask": "openemu-experimental",
+        "count": "34"
+      }
+    ],
+    "openfluid": [
+      {
+        "cask": "openfluid",
+        "count": "2"
+      }
+    ],
+    "openframeworks": [
+      {
+        "cask": "openframeworks",
+        "count": "9"
+      }
+    ],
+    "openineditor-lite": [
+      {
+        "cask": "openineditor-lite",
+        "count": "101"
+      }
+    ],
+    "openinterminal": [
+      {
+        "cask": "openinterminal",
+        "count": "628"
+      }
+    ],
+    "openinterminal-lite": [
+      {
+        "cask": "openinterminal-lite",
+        "count": "313"
+      }
+    ],
+    "openkey": [
+      {
+        "cask": "openkey",
+        "count": "44"
+      }
+    ],
+    "openlp": [
+      {
+        "cask": "openlp",
+        "count": "5"
+      }
+    ],
+    "openmsx": [
+      {
+        "cask": "openmsx",
+        "count": "4"
+      }
+    ],
+    "openmtp": [
+      {
+        "cask": "openmtp",
+        "count": "129"
+      }
+    ],
+    "openmw": [
+      {
+        "cask": "openmw",
+        "count": "10"
+      }
+    ],
+    "opennx": [
+      {
+        "cask": "opennx",
+        "count": "1"
+      }
+    ],
+    "openoffice": [
+      {
+        "cask": "openoffice",
+        "count": "279"
+      }
+    ],
+    "openpht": [
+      {
+        "cask": "openpht",
+        "count": "12"
+      }
+    ],
+    "openra": [
+      {
+        "cask": "openra",
+        "count": "160"
+      }
+    ],
+    "openra-playtest": [
+      {
+        "cask": "openra-playtest",
+        "count": "1"
+      }
+    ],
+    "openrct2": [
+      {
+        "cask": "openrct2",
+        "count": "15"
+      }
+    ],
+    "openrefine": [
+      {
+        "cask": "openrefine",
+        "count": "81"
+      }
+    ],
+    "opensc": [
+      {
+        "cask": "opensc",
+        "count": "87"
+      }
+    ],
+    "openscad": [
+      {
+        "cask": "openscad",
+        "count": "198"
+      }
+    ],
+    "openscad-snapshot": [
+      {
+        "cask": "openscad-snapshot",
+        "count": "3"
+      }
+    ],
+    "opensesame": [
+      {
+        "cask": "opensesame",
+        "count": "2"
+      }
+    ],
+    "openshot-video-editor": [
+      {
+        "cask": "openshot-video-editor",
+        "count": "170"
+      }
+    ],
+    "opensim": [
+      {
+        "cask": "opensim",
+        "count": "71"
+      }
+    ],
+    "opensong": [
+      {
+        "cask": "opensong",
+        "count": "2"
+      }
+    ],
+    "opentoonz": [
+      {
+        "cask": "opentoonz",
+        "count": "12"
+      }
+    ],
+    "openttd": [
+      {
+        "cask": "openttd",
+        "count": "84"
+      }
+    ],
+    "openvanilla": [
+      {
+        "cask": "openvanilla",
+        "count": "7"
+      }
+    ],
+    "openvisualtraceroute": [
+      {
+        "cask": "openvisualtraceroute",
+        "count": "29"
+      }
+    ],
+    "openvpn-connect": [
+      {
+        "cask": "openvpn-connect",
+        "count": "487"
+      }
+    ],
+    "openvpn-connect-beta": [
+      {
+        "cask": "openvpn-connect-beta",
+        "count": "30"
+      }
+    ],
+    "openwebstart": [
+      {
+        "cask": "openwebstart",
+        "count": "49"
+      }
+    ],
+    "openxcom": [
+      {
+        "cask": "openxcom",
+        "count": "8"
+      }
+    ],
+    "openzfs": [
+      {
+        "cask": "openzfs",
+        "count": "56"
+      }
+    ],
+    "opera": [
+      {
+        "cask": "opera",
+        "count": "1,050"
+      }
+    ],
+    "opera-beta": [
+      {
+        "cask": "opera-beta",
+        "count": "21"
+      }
+    ],
+    "opera-developer": [
+      {
+        "cask": "opera-developer",
+        "count": "48"
+      }
+    ],
+    "opera-mail": [
+      {
+        "cask": "opera-mail",
+        "count": "4"
+      }
+    ],
+    "opera-mobile-emulator": [
+      {
+        "cask": "opera-mobile-emulator",
+        "count": "9"
+      }
+    ],
+    "opera-neon": [
+      {
+        "cask": "opera-neon",
+        "count": "17"
+      }
+    ],
+    "operadriver": [
+      {
+        "cask": "operadriver",
+        "count": "13"
+      }
+    ],
+    "optimage": [
+      {
+        "cask": "optimage",
+        "count": "14"
+      }
+    ],
+    "optimal-layout": [
+      {
+        "cask": "optimal-layout",
+        "count": "2"
+      }
+    ],
+    "oracle-jdk": [
+      {
+        "cask": "oracle-jdk",
+        "count": "1,164"
+      }
+    ],
+    "oracle-jdk-11.0.3": [
+      {
+        "cask": "oracle-jdk-11.0.3",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-javadoc": [
+      {
+        "cask": "oracle-jdk-javadoc",
+        "count": "61"
+      }
+    ],
+    "oracle-jdk11": [
+      {
+        "cask": "oracle-jdk11",
+        "count": "1"
+      }
+    ],
+    "orange": [
+      {
+        "cask": "orange",
+        "count": "8"
+      }
+    ],
+    "origami-studio": [
+      {
+        "cask": "origami-studio",
+        "count": "13"
+      }
+    ],
+    "origin": [
+      {
+        "cask": "origin",
+        "count": "85"
+      }
+    ],
+    "orka": [
+      {
+        "cask": "orka",
+        "count": "8"
+      }
+    ],
+    "oryoki": [
+      {
+        "cask": "oryoki",
+        "count": "1"
+      }
+    ],
+    "osbuddy": [
+      {
+        "cask": "osbuddy",
+        "count": "2"
+      }
+    ],
+    "oscar": [
+      {
+        "cask": "oscar",
+        "count": "6"
+      }
+    ],
+    "oscilloscope": [
+      {
+        "cask": "oscilloscope",
+        "count": "1"
+      }
+    ],
+    "osirix-quicklook": [
+      {
+        "cask": "osirix-quicklook",
+        "count": "19"
+      }
+    ],
+    "osmc": [
+      {
+        "cask": "osmc",
+        "count": "9"
+      }
+    ],
+    "osu-development": [
+      {
+        "cask": "osu-development",
+        "count": "7"
+      }
+    ],
+    "osxfuse": [
+      {
+        "cask": "osxfuse",
+        "count": "10,753"
+      }
+    ],
+    "otp-auth": [
+      {
+        "cask": "otp-auth",
+        "count": "4"
+      }
+    ],
+    "otter-browser": [
+      {
+        "cask": "otter-browser",
+        "count": "7"
+      }
+    ],
+    "otx": [
+      {
+        "cask": "otx",
+        "count": "36"
+      }
+    ],
+    "outguess": [
+      {
+        "cask": "outguess",
+        "count": "33"
+      }
+    ],
+    "outline": [
+      {
+        "cask": "outline",
+        "count": "13"
+      }
+    ],
+    "outline-manager": [
+      {
+        "cask": "outline-manager",
+        "count": "35"
+      }
+    ],
+    "outset": [
+      {
+        "cask": "outset",
+        "count": "4"
+      }
+    ],
+    "outwit-hub": [
+      {
+        "cask": "outwit-hub",
+        "count": "1"
+      }
+    ],
+    "overdrive-media-console": [
+      {
+        "cask": "overdrive-media-console",
+        "count": "12"
+      }
+    ],
+    "overflow": [
+      {
+        "cask": "overflow",
+        "count": "4"
+      }
+    ],
+    "overkill": [
+      {
+        "cask": "overkill",
+        "count": "22"
+      }
+    ],
+    "oversight": [
+      {
+        "cask": "oversight",
+        "count": "71"
+      }
+    ],
+    "ovito": [
+      {
+        "cask": "ovito",
+        "count": "1"
+      }
+    ],
+    "owasp-zap": [
+      {
+        "cask": "owasp-zap",
+        "count": "285"
+      }
+    ],
+    "owncloud": [
+      {
+        "cask": "owncloud",
+        "count": "76"
+      }
+    ],
+    "oxygen-xml-editor": [
+      {
+        "cask": "oxygen-xml-editor",
+        "count": "23"
+      }
+    ],
+    "p4v": [
+      {
+        "cask": "p4v",
+        "count": "177"
+      }
+    ],
+    "p6sync": [
+      {
+        "cask": "p6sync",
+        "count": "4"
+      }
+    ],
+    "pablodraw": [
+      {
+        "cask": "pablodraw",
+        "count": "2"
+      }
+    ],
+    "pacifist": [
+      {
+        "cask": "pacifist",
+        "count": "37"
+      }
+    ],
+    "packages": [
+      {
+        "cask": "packages",
+        "count": "57"
+      }
+    ],
+    "packet-peeper": [
+      {
+        "cask": "packet-peeper",
+        "count": "6"
+      }
+    ],
+    "packetproxy": [
+      {
+        "cask": "packetproxy",
+        "count": "8"
+      }
+    ],
+    "packetsender": [
+      {
+        "cask": "packetsender",
+        "count": "191"
+      }
+    ],
+    "pages-data-merge": [
+      {
+        "cask": "pages-data-merge",
+        "count": "2"
+      }
+    ],
+    "pagico": [
+      {
+        "cask": "pagico",
+        "count": "5"
+      }
+    ],
+    "paintbrush": [
+      {
+        "cask": "paintbrush",
+        "count": "236"
+      }
+    ],
+    "paintcode": [
+      {
+        "cask": "paintcode",
+        "count": "11"
+      }
+    ],
+    "pallotron-yubiswitch": [
+      {
+        "cask": "pallotron-yubiswitch",
+        "count": "4"
+      }
+    ],
+    "panda": [
+      {
+        "cask": "panda",
+        "count": "5"
+      }
+    ],
+    "pandora": [
+      {
+        "cask": "pandora",
+        "count": "37"
+      }
+    ],
+    "panic-unison": [
+      {
+        "cask": "panic-unison",
+        "count": "2"
+      }
+    ],
+    "panoply": [
+      {
+        "cask": "panoply",
+        "count": "19"
+      }
+    ],
+    "paparazzi": [
+      {
+        "cask": "paparazzi",
+        "count": "12"
+      }
+    ],
+    "paper": [
+      {
+        "cask": "paper",
+        "count": "39"
+      }
+    ],
+    "papers": [
+      {
+        "cask": "papers",
+        "count": "41"
+      }
+    ],
+    "paperspace": [
+      {
+        "cask": "paperspace",
+        "count": "10"
+      }
+    ],
+    "papyrus": [
+      {
+        "cask": "papyrus",
+        "count": "13"
+      }
+    ],
+    "paragon-extfs": [
+      {
+        "cask": "paragon-extfs",
+        "count": "48"
+      }
+    ],
+    "paragon-ntfs": [
+      {
+        "cask": "paragon-ntfs",
+        "count": "149"
+      }
+    ],
+    "paragon-vmdk-mounter": [
+      {
+        "cask": "paragon-vmdk-mounter",
+        "count": "22"
+      }
+    ],
+    "parallels": [
+      {
+        "cask": "parallels",
+        "count": "850"
+      }
+    ],
+    "parallels-access": [
+      {
+        "cask": "parallels-access",
+        "count": "14"
+      }
+    ],
+    "parallels-client": [
+      {
+        "cask": "parallels-client",
+        "count": "38"
+      }
+    ],
+    "parallels-toolbox": [
+      {
+        "cask": "parallels-toolbox",
+        "count": "48"
+      }
+    ],
+    "parallels-virtualization-sdk": [
+      {
+        "cask": "parallels-virtualization-sdk",
+        "count": "39"
+      }
+    ],
+    "parallels12": [
+      {
+        "cask": "parallels12",
+        "count": "3"
+      }
+    ],
+    "parallels13": [
+      {
+        "cask": "parallels13",
+        "count": "5"
+      }
+    ],
+    "paraview": [
+      {
+        "cask": "paraview",
+        "count": "74"
+      }
+    ],
+    "parse": [
+      {
+        "cask": "parse",
+        "count": "7"
+      }
+    ],
+    "parsec": [
+      {
+        "cask": "parsec",
+        "count": "188"
+      }
+    ],
+    "parsehub": [
+      {
+        "cask": "parsehub",
+        "count": "4"
+      }
+    ],
+    "pashua": [
+      {
+        "cask": "pashua",
+        "count": "3"
+      }
+    ],
+    "passformacos": [
+      {
+        "cask": "passformacos",
+        "count": "5"
+      }
+    ],
+    "password-assistant": [
+      {
+        "cask": "password-assistant",
+        "count": "4"
+      }
+    ],
+    "password-gorilla": [
+      {
+        "cask": "password-gorilla",
+        "count": "30"
+      }
+    ],
+    "paste": [
+      {
+        "cask": "paste",
+        "count": "3"
+      }
+    ],
+    "pastebot": [
+      {
+        "cask": "pastebot",
+        "count": "35"
+      }
+    ],
+    "patchwork": [
+      {
+        "cask": "patchwork",
+        "count": "29"
+      }
+    ],
+    "path-finder": [
+      {
+        "cask": "path-finder",
+        "count": "82"
+      }
+    ],
+    "paw": [
+      {
+        "cask": "paw",
+        "count": "223"
+      }
+    ],
+    "pb-for-desktop": [
+      {
+        "cask": "pb-for-desktop",
+        "count": "1"
+      }
+    ],
+    "pcloud-drive": [
+      {
+        "cask": "pcloud-drive",
+        "count": "1"
+      }
+    ],
+    "pd": [
+      {
+        "cask": "pd",
+        "count": "17"
+      }
+    ],
+    "pd-extended": [
+      {
+        "cask": "pd-extended",
+        "count": "9"
+      }
+    ],
+    "pdf-converter-master": [
+      {
+        "cask": "pdf-converter-master",
+        "count": "9"
+      }
+    ],
+    "pdf-expert": [
+      {
+        "cask": "pdf-expert",
+        "count": "382"
+      }
+    ],
+    "pdf-expert-beta": [
+      {
+        "cask": "pdf-expert-beta",
+        "count": "8"
+      }
+    ],
+    "pdf-images": [
+      {
+        "cask": "pdf-images",
+        "count": "22"
+      }
+    ],
+    "pdf-squeezer": [
+      {
+        "cask": "pdf-squeezer",
+        "count": "16"
+      }
+    ],
+    "pdf-toolbox": [
+      {
+        "cask": "pdf-toolbox",
+        "count": "17"
+      }
+    ],
+    "pdfelement": [
+      {
+        "cask": "pdfelement",
+        "count": "70"
+      }
+    ],
+    "pdfelement-express": [
+      {
+        "cask": "pdfelement-express",
+        "count": "8"
+      }
+    ],
+    "pdfextractor": [
+      {
+        "cask": "pdfextractor",
+        "count": "5"
+      }
+    ],
+    "pdfinfo": [
+      {
+        "cask": "pdfinfo",
+        "count": "125"
+      }
+    ],
+    "pdfkey-pro": [
+      {
+        "cask": "pdfkey-pro",
+        "count": "1"
+      }
+    ],
+    "pdfpen": [
+      {
+        "cask": "pdfpen",
+        "count": "19"
+      }
+    ],
+    "pdfpenpro": [
+      {
+        "cask": "pdfpenpro",
+        "count": "42"
+      }
+    ],
+    "pdfsam-basic": [
+      {
+        "cask": "pdfsam-basic",
+        "count": "78"
+      }
+    ],
+    "pdfshaver": [
+      {
+        "cask": "pdfshaver",
+        "count": "6"
+      }
+    ],
+    "pdftk-server": [
+      {
+        "cask": "pdftk-server",
+        "count": "1"
+      }
+    ],
+    "pdftotext": [
+      {
+        "cask": "pdftotext",
+        "count": "320"
+      }
+    ],
+    "pdk": [
+      {
+        "cask": "pdk",
+        "count": "231"
+      }
+    ],
+    "pe-client-tools": [
+      {
+        "cask": "pe-client-tools",
+        "count": "24"
+      }
+    ],
+    "pe-client-tools-2018.1": [
+      {
+        "cask": "pe-client-tools-2018.1",
+        "count": "2"
+      }
+    ],
+    "pe-client-tools-2019.3": [
+      {
+        "cask": "pe-client-tools-2019.3",
+        "count": "2"
+      }
+    ],
+    "peakhour": [
+      {
+        "cask": "peakhour",
+        "count": "4"
+      }
+    ],
+    "penc": [
+      {
+        "cask": "penc",
+        "count": "13"
+      }
+    ],
+    "pencil": [
+      {
+        "cask": "pencil",
+        "count": "82"
+      }
+    ],
+    "pencil2d": [
+      {
+        "cask": "pencil2d",
+        "count": "11"
+      }
+    ],
+    "pennywise": [
+      {
+        "cask": "pennywise",
+        "count": "123"
+      }
+    ],
+    "people-plus-content-ip": [
+      {
+        "cask": "people-plus-content-ip",
+        "count": "1"
+      }
+    ],
+    "perforce": [
+      {
+        "cask": "perforce",
+        "count": "66"
+      }
+    ],
+    "periphery": [
+      {
+        "cask": "periphery",
+        "count": "359"
+      }
+    ],
+    "permissionscanner": [
+      {
+        "cask": "permissionscanner",
+        "count": "1"
+      }
+    ],
+    "permute": [
+      {
+        "cask": "permute",
+        "count": "53"
+      }
+    ],
+    "persepolis-download-manager": [
+      {
+        "cask": "persepolis-download-manager",
+        "count": "38"
+      }
+    ],
+    "perspec": [
+      {
+        "cask": "perspec",
+        "count": "2"
+      }
+    ],
+    "pester": [
+      {
+        "cask": "pester",
+        "count": "8"
+      }
+    ],
+    "pext": [
+      {
+        "cask": "pext",
+        "count": "1"
+      }
+    ],
+    "pext-nightly": [
+      {
+        "cask": "pext-nightly",
+        "count": "5"
+      }
+    ],
+    "peyton-xbox360-controller-driver-unofficial": [
+      {
+        "cask": "peyton-xbox360-controller-driver-unofficial",
+        "count": "1"
+      }
+    ],
+    "pflists": [
+      {
+        "cask": "pflists",
+        "count": "2"
+      }
+    ],
+    "pg-commander": [
+      {
+        "cask": "pg-commander",
+        "count": "8"
+      }
+    ],
+    "pgadmin3": [
+      {
+        "cask": "pgadmin3",
+        "count": "45"
+      }
+    ],
+    "pgadmin4": [
+      {
+        "cask": "pgadmin4",
+        "count": "1,767"
+      }
+    ],
+    "pgmodeler": [
+      {
+        "cask": "pgmodeler",
+        "count": "8"
+      }
+    ],
+    "phantomjs": [
+      {
+        "cask": "phantomjs",
+        "count": "1,819"
+      }
+    ],
+    "pharo-launcher": [
+      {
+        "cask": "pharo-launcher",
+        "count": "4"
+      }
+    ],
+    "phew": [
+      {
+        "cask": "phew",
+        "count": "3"
+      }
+    ],
+    "phiewer": [
+      {
+        "cask": "phiewer",
+        "count": "10"
+      }
+    ],
+    "philips-hue-sync": [
+      {
+        "cask": "philips-hue-sync",
+        "count": "35"
+      }
+    ],
+    "phocus": [
+      {
+        "cask": "phocus",
+        "count": "6"
+      }
+    ],
+    "phoenix": [
+      {
+        "cask": "phoenix",
+        "count": "40"
+      }
+    ],
+    "phoenix-slides": [
+      {
+        "cask": "phoenix-slides",
+        "count": "7"
+      }
+    ],
+    "phonebrowse": [
+      {
+        "cask": "phonebrowse",
+        "count": "2"
+      }
+    ],
+    "phoneclean": [
+      {
+        "cask": "phoneclean",
+        "count": "2"
+      }
+    ],
+    "phonegap": [
+      {
+        "cask": "phonegap",
+        "count": "19"
+      }
+    ],
+    "phonerescue": [
+      {
+        "cask": "phonerescue",
+        "count": "4"
+      }
+    ],
+    "phonetrans": [
+      {
+        "cask": "phonetrans",
+        "count": "2"
+      }
+    ],
+    "photoninja": [
+      {
+        "cask": "photoninja",
+        "count": "2"
+      }
+    ],
+    "photosweeper-x": [
+      {
+        "cask": "photosweeper-x",
+        "count": "4"
+      }
+    ],
+    "photosync": [
+      {
+        "cask": "photosync",
+        "count": "7"
+      }
+    ],
+    "photozoom-pro": [
+      {
+        "cask": "photozoom-pro",
+        "count": "2"
+      }
+    ],
+    "phpstorm": [
+      {
+        "cask": "phpstorm",
+        "count": "655"
+      }
+    ],
+    "phpstorm-perpetual": [
+      {
+        "cask": "phpstorm-perpetual",
+        "count": "3"
+      }
+    ],
+    "physicseditor": [
+      {
+        "cask": "physicseditor",
+        "count": "2"
+      }
+    ],
+    "pibakery": [
+      {
+        "cask": "pibakery",
+        "count": "19"
+      }
+    ],
+    "picgo": [
+      {
+        "cask": "picgo",
+        "count": "136"
+      }
+    ],
+    "piezo": [
+      {
+        "cask": "piezo",
+        "count": "20"
+      }
+    ],
+    "pikopixel": [
+      {
+        "cask": "pikopixel",
+        "count": "6"
+      }
+    ],
+    "pine": [
+      {
+        "cask": "pine",
+        "count": "78"
+      }
+    ],
+    "pineapple": [
+      {
+        "cask": "pineapple",
+        "count": "5"
+      }
+    ],
+    "pinegrow": [
+      {
+        "cask": "pinegrow",
+        "count": "2"
+      }
+    ],
+    "pingid": [
+      {
+        "cask": "pingid",
+        "count": "3"
+      }
+    ],
+    "pingmenu": [
+      {
+        "cask": "pingmenu",
+        "count": "3"
+      }
+    ],
+    "pingplotter": [
+      {
+        "cask": "pingplotter",
+        "count": "39"
+      }
+    ],
+    "pinta": [
+      {
+        "cask": "pinta",
+        "count": "67"
+      }
+    ],
+    "pixel-check": [
+      {
+        "cask": "pixel-check",
+        "count": "5"
+      }
+    ],
+    "pixel-picker": [
+      {
+        "cask": "pixel-picker",
+        "count": "21"
+      }
+    ],
+    "pixelpeeper": [
+      {
+        "cask": "pixelpeeper",
+        "count": "1"
+      }
+    ],
+    "pixelsnap": [
+      {
+        "cask": "pixelsnap",
+        "count": "23"
+      }
+    ],
+    "pixelstick": [
+      {
+        "cask": "pixelstick",
+        "count": "2"
+      }
+    ],
+    "pjslint": [
+      {
+        "cask": "pjslint",
+        "count": "5"
+      }
+    ],
+    "plain-clip": [
+      {
+        "cask": "plain-clip",
+        "count": "8"
+      }
+    ],
+    "plan": [
+      {
+        "cask": "plan",
+        "count": "9"
+      }
+    ],
+    "plantronics-hub": [
+      {
+        "cask": "plantronics-hub",
+        "count": "20"
+      }
+    ],
+    "platelet": [
+      {
+        "cask": "platelet",
+        "count": "4"
+      }
+    ],
+    "platypus": [
+      {
+        "cask": "platypus",
+        "count": "126"
+      }
+    ],
+    "play": [
+      {
+        "cask": "play",
+        "count": "45"
+      }
+    ],
+    "playback": [
+      {
+        "cask": "playback",
+        "count": "2"
+      }
+    ],
+    "playmemories-home": [
+      {
+        "cask": "playmemories-home",
+        "count": "8"
+      }
+    ],
+    "playnow": [
+      {
+        "cask": "playnow",
+        "count": "5"
+      }
+    ],
+    "playonmac": [
+      {
+        "cask": "playonmac",
+        "count": "341"
+      }
+    ],
+    "plecs-standalone": [
+      {
+        "cask": "plecs-standalone",
+        "count": "3"
+      }
+    ],
+    "plex": [
+      {
+        "cask": "plex",
+        "count": "587"
+      }
+    ],
+    "plex-media-player": [
+      {
+        "cask": "plex-media-player",
+        "count": "288"
+      }
+    ],
+    "plex-media-server": [
+      {
+        "cask": "plex-media-server",
+        "count": "484"
+      }
+    ],
+    "plexamp": [
+      {
+        "cask": "plexamp",
+        "count": "131"
+      }
+    ],
+    "pliim": [
+      {
+        "cask": "pliim",
+        "count": "5"
+      }
+    ],
+    "plistedit-pro": [
+      {
+        "cask": "plistedit-pro",
+        "count": "77"
+      }
+    ],
+    "plotdigitizer": [
+      {
+        "cask": "plotdigitizer",
+        "count": "6"
+      }
+    ],
+    "plover": [
+      {
+        "cask": "plover",
+        "count": "14"
+      }
+    ],
+    "plug": [
+      {
+        "cask": "plug",
+        "count": "63"
+      }
+    ],
+    "pluralsight": [
+      {
+        "cask": "pluralsight",
+        "count": "54"
+      }
+    ],
+    "plyr": [
+      {
+        "cask": "plyr",
+        "count": "1"
+      }
+    ],
+    "pngyu": [
+      {
+        "cask": "pngyu",
+        "count": "1"
+      }
+    ],
+    "pock": [
+      {
+        "cask": "pock",
+        "count": "248"
+      }
+    ],
+    "pocket-casts": [
+      {
+        "cask": "pocket-casts",
+        "count": "91"
+      }
+    ],
+    "podcastmenu": [
+      {
+        "cask": "podcastmenu",
+        "count": "9"
+      }
+    ],
+    "podman": [
+      {
+        "cask": "podman",
+        "count": "427"
+      }
+    ],
+    "poedit": [
+      {
+        "cask": "poedit",
+        "count": "76"
+      }
+    ],
+    "poi": [
+      {
+        "cask": "poi",
+        "count": "6"
+      }
+    ],
+    "pokemon-showdown": [
+      {
+        "cask": "pokemon-showdown",
+        "count": "9"
+      }
+    ],
+    "pokerstars": [
+      {
+        "cask": "pokerstars",
+        "count": "71"
+      }
+    ],
+    "pokerth": [
+      {
+        "cask": "pokerth",
+        "count": "25"
+      }
+    ],
+    "polar-bookshelf": [
+      {
+        "cask": "polar-bookshelf",
+        "count": "18"
+      }
+    ],
+    "polycom-content": [
+      {
+        "cask": "polycom-content",
+        "count": "1"
+      }
+    ],
+    "polycom-realpresence": [
+      {
+        "cask": "polycom-realpresence",
+        "count": "1"
+      }
+    ],
+    "polymail": [
+      {
+        "cask": "polymail",
+        "count": "9"
+      }
+    ],
+    "polyphone": [
+      {
+        "cask": "polyphone",
+        "count": "3"
+      }
+    ],
+    "pomello": [
+      {
+        "cask": "pomello",
+        "count": "10"
+      }
+    ],
+    "pomodone": [
+      {
+        "cask": "pomodone",
+        "count": "23"
+      }
+    ],
+    "pomolectron": [
+      {
+        "cask": "pomolectron",
+        "count": "12"
+      }
+    ],
+    "pomotodo": [
+      {
+        "cask": "pomotodo",
+        "count": "29"
+      }
+    ],
+    "pomotroid": [
+      {
+        "cask": "pomotroid",
+        "count": "96"
+      }
+    ],
+    "pongsaver": [
+      {
+        "cask": "pongsaver",
+        "count": "3"
+      }
+    ],
+    "popchar": [
+      {
+        "cask": "popchar",
+        "count": "4"
+      }
+    ],
+    "popclip": [
+      {
+        "cask": "popclip",
+        "count": "41"
+      }
+    ],
+    "popcorn-time": [
+      {
+        "cask": "popcorn-time",
+        "count": "341"
+      }
+    ],
+    "popcorn-time-beta": [
+      {
+        "cask": "popcorn-time-beta",
+        "count": "12"
+      }
+    ],
+    "popmaker": [
+      {
+        "cask": "popmaker",
+        "count": "3"
+      }
+    ],
+    "popo": [
+      {
+        "cask": "popo",
+        "count": "3"
+      }
+    ],
+    "popsql": [
+      {
+        "cask": "popsql",
+        "count": "17"
+      }
+    ],
+    "port-map": [
+      {
+        "cask": "port-map",
+        "count": "1"
+      }
+    ],
+    "portfolioperformance": [
+      {
+        "cask": "portfolioperformance",
+        "count": "41"
+      }
+    ],
+    "porting-kit": [
+      {
+        "cask": "porting-kit",
+        "count": "55"
+      }
+    ],
+    "post-haste": [
+      {
+        "cask": "post-haste",
+        "count": "1"
+      }
+    ],
+    "postbird": [
+      {
+        "cask": "postbird",
+        "count": "31"
+      }
+    ],
+    "postbox": [
+      {
+        "cask": "postbox",
+        "count": "66"
+      }
+    ],
+    "posterazor": [
+      {
+        "cask": "posterazor",
+        "count": "6"
+      }
+    ],
+    "postgres": [
+      {
+        "cask": "postgres",
+        "count": "519"
+      }
+    ],
+    "postgrespreferencepane": [
+      {
+        "cask": "postgrespreferencepane",
+        "count": "36"
+      }
+    ],
+    "postico": [
+      {
+        "cask": "postico",
+        "count": "617"
+      }
+    ],
+    "postman": [
+      {
+        "cask": "postman",
+        "count": "7,450"
+      }
+    ],
+    "powder": [
+      {
+        "cask": "powder",
+        "count": "14"
+      }
+    ],
+    "powder-player": [
+      {
+        "cask": "powder-player",
+        "count": "1"
+      }
+    ],
+    "power-manager": [
+      {
+        "cask": "power-manager",
+        "count": "11"
+      }
+    ],
+    "powerpanel": [
+      {
+        "cask": "powerpanel",
+        "count": "4"
+      }
+    ],
+    "powerphotos": [
+      {
+        "cask": "powerphotos",
+        "count": "19"
+      }
+    ],
+    "powerselect": [
+      {
+        "cask": "powerselect",
+        "count": "1"
+      }
+    ],
+    "powershell": [
+      {
+        "cask": "powershell",
+        "count": "8,023"
+      }
+    ],
+    "powershell-preview": [
+      {
+        "cask": "powershell-preview",
+        "count": "361"
+      }
+    ],
+    "powershell6": [
+      {
+        "cask": "powershell6",
+        "count": "11"
+      }
+    ],
+    "powerword": [
+      {
+        "cask": "powerword",
+        "count": "2"
+      }
+    ],
+    "ppamorim-fruit": [
+      {
+        "cask": "ppamorim-fruit",
+        "count": "1"
+      }
+    ],
+    "praat": [
+      {
+        "cask": "praat",
+        "count": "38"
+      }
+    ],
+    "pragmatapro": [
+      {
+        "cask": "pragmatapro",
+        "count": "8"
+      }
+    ],
+    "pratique": [
+      {
+        "cask": "pratique",
+        "count": "1"
+      }
+    ],
+    "precize": [
+      {
+        "cask": "precize",
+        "count": "1"
+      }
+    ],
+    "pref-setter": [
+      {
+        "cask": "pref-setter",
+        "count": "36"
+      }
+    ],
+    "preferencecleaner": [
+      {
+        "cask": "preferencecleaner",
+        "count": "1"
+      }
+    ],
+    "preform": [
+      {
+        "cask": "preform",
+        "count": "9"
+      }
+    ],
+    "prefs-editor": [
+      {
+        "cask": "prefs-editor",
+        "count": "15"
+      }
+    ],
+    "prepros": [
+      {
+        "cask": "prepros",
+        "count": "21"
+      }
+    ],
+    "presentation": [
+      {
+        "cask": "presentation",
+        "count": "61"
+      }
+    ],
+    "pretzel": [
+      {
+        "cask": "pretzel",
+        "count": "9"
+      }
+    ],
+    "prey": [
+      {
+        "cask": "prey",
+        "count": "17"
+      }
+    ],
+    "prezi-classic": [
+      {
+        "cask": "prezi-classic",
+        "count": "5"
+      }
+    ],
+    "prezi-next": [
+      {
+        "cask": "prezi-next",
+        "count": "7"
+      }
+    ],
+    "prince": [
+      {
+        "cask": "prince",
+        "count": "130"
+      }
+    ],
+    "principle": [
+      {
+        "cask": "principle",
+        "count": "11"
+      }
+    ],
+    "printopia": [
+      {
+        "cask": "printopia",
+        "count": "6"
+      }
+    ],
+    "printrun": [
+      {
+        "cask": "printrun",
+        "count": "36"
+      }
+    ],
+    "prismatik": [
+      {
+        "cask": "prismatik",
+        "count": "9"
+      }
+    ],
+    "pritunl": [
+      {
+        "cask": "pritunl",
+        "count": "201"
+      }
+    ],
+    "private-eye": [
+      {
+        "cask": "private-eye",
+        "count": "35"
+      }
+    ],
+    "private-internet-access": [
+      {
+        "cask": "private-internet-access",
+        "count": "247"
+      }
+    ],
+    "privatetunnel": [
+      {
+        "cask": "privatetunnel",
+        "count": "5"
+      }
+    ],
+    "prizmo": [
+      {
+        "cask": "prizmo",
+        "count": "7"
+      }
+    ],
+    "processing": [
+      {
+        "cask": "processing",
+        "count": "159"
+      }
+    ],
+    "processing2": [
+      {
+        "cask": "processing2",
+        "count": "4"
+      }
+    ],
+    "procexp": [
+      {
+        "cask": "procexp",
+        "count": "6"
+      }
+    ],
+    "proclaim": [
+      {
+        "cask": "proclaim",
+        "count": "2"
+      }
+    ],
+    "product-hunt": [
+      {
+        "cask": "product-hunt",
+        "count": "4"
+      }
+    ],
+    "profilecreator": [
+      {
+        "cask": "profilecreator",
+        "count": "8"
+      }
+    ],
+    "profilemanager": [
+      {
+        "cask": "profilemanager",
+        "count": "1"
+      }
+    ],
+    "profind": [
+      {
+        "cask": "profind",
+        "count": "1"
+      }
+    ],
+    "programmer-dvorak": [
+      {
+        "cask": "programmer-dvorak",
+        "count": "6"
+      }
+    ],
+    "progressive-downloader": [
+      {
+        "cask": "progressive-downloader",
+        "count": "21"
+      }
+    ],
+    "projectlibre": [
+      {
+        "cask": "projectlibre",
+        "count": "57"
+      }
+    ],
+    "prolific-pl2303": [
+      {
+        "cask": "prolific-pl2303",
+        "count": "20"
+      }
+    ],
+    "propresenter": [
+      {
+        "cask": "propresenter",
+        "count": "6"
+      }
+    ],
+    "pros-editor": [
+      {
+        "cask": "pros-editor",
+        "count": "33"
+      }
+    ],
+    "prosys-opc-ua-browser": [
+      {
+        "cask": "prosys-opc-ua-browser",
+        "count": "1"
+      }
+    ],
+    "protege": [
+      {
+        "cask": "protege",
+        "count": "26"
+      }
+    ],
+    "protonmail-bridge": [
+      {
+        "cask": "protonmail-bridge",
+        "count": "94"
+      }
+    ],
+    "protonmail-unofficial": [
+      {
+        "cask": "protonmail-unofficial",
+        "count": "15"
+      }
+    ],
+    "protonvpn": [
+      {
+        "cask": "protonvpn",
+        "count": "300"
+      }
+    ],
+    "protopie": [
+      {
+        "cask": "protopie",
+        "count": "8"
+      }
+    ],
+    "provisioning": [
+      {
+        "cask": "provisioning",
+        "count": "6"
+      }
+    ],
+    "provisionql": [
+      {
+        "cask": "provisionql",
+        "count": "551"
+      }
+    ],
+    "prowritingaid": [
+      {
+        "cask": "prowritingaid",
+        "count": "3"
+      }
+    ],
+    "proxifier": [
+      {
+        "cask": "proxifier",
+        "count": "61"
+      }
+    ],
+    "proximity": [
+      {
+        "cask": "proximity",
+        "count": "2"
+      }
+    ],
+    "proxyman": [
+      {
+        "cask": "proxyman",
+        "count": "246"
+      }
+    ],
+    "prudent": [
+      {
+        "cask": "prudent",
+        "count": "1"
+      }
+    ],
+    "prusaslicer": [
+      {
+        "cask": "prusaslicer",
+        "count": "79"
+      }
+    ],
+    "psequel": [
+      {
+        "cask": "psequel",
+        "count": "169"
+      }
+    ],
+    "psi": [
+      {
+        "cask": "psi",
+        "count": "5"
+      }
+    ],
+    "psi-plus": [
+      {
+        "cask": "psi-plus",
+        "count": "10"
+      }
+    ],
+    "psychopy": [
+      {
+        "cask": "psychopy",
+        "count": "30"
+      }
+    ],
+    "publii": [
+      {
+        "cask": "publii",
+        "count": "8"
+      }
+    ],
+    "publish-or-perish": [
+      {
+        "cask": "publish-or-perish",
+        "count": "4"
+      }
+    ],
+    "pulse-sms": [
+      {
+        "cask": "pulse-sms",
+        "count": "4"
+      }
+    ],
+    "punto-switcher": [
+      {
+        "cask": "punto-switcher",
+        "count": "51"
+      }
+    ],
+    "puppet-agent": [
+      {
+        "cask": "puppet-agent",
+        "count": "83"
+      }
+    ],
+    "puppet-agent-5": [
+      {
+        "cask": "puppet-agent-5",
+        "count": "11"
+      }
+    ],
+    "puppet-agent-6": [
+      {
+        "cask": "puppet-agent-6",
+        "count": "12"
+      }
+    ],
+    "puppet-bolt": [
+      {
+        "cask": "puppet-bolt",
+        "count": "152"
+      }
+    ],
+    "puppetry": [
+      {
+        "cask": "puppetry",
+        "count": "12"
+      }
+    ],
+    "purevpn": [
+      {
+        "cask": "purevpn",
+        "count": "31"
+      }
+    ],
+    "pusher": [
+      {
+        "cask": "pusher",
+        "count": "468"
+      }
+    ],
+    "pushtotalk": [
+      {
+        "cask": "pushtotalk",
+        "count": "1"
+      }
+    ],
+    "putio-adder": [
+      {
+        "cask": "putio-adder",
+        "count": "2"
+      }
+    ],
+    "puush": [
+      {
+        "cask": "puush",
+        "count": "6"
+      }
+    ],
+    "puzzles": [
+      {
+        "cask": "puzzles",
+        "count": "17"
+      }
+    ],
+    "pwnagetool": [
+      {
+        "cask": "pwnagetool",
+        "count": "1"
+      }
+    ],
+    "pxplus-ibm-vga8": [
+      {
+        "cask": "pxplus-ibm-vga8",
+        "count": "4"
+      }
+    ],
+    "pycharm": [
+      {
+        "cask": "pycharm",
+        "count": "1,482"
+      }
+    ],
+    "pycharm-ce": [
+      {
+        "cask": "pycharm-ce",
+        "count": "1,023"
+      }
+    ],
+    "pycharm-ce-with-anaconda-plugin": [
+      {
+        "cask": "pycharm-ce-with-anaconda-plugin",
+        "count": "40"
+      }
+    ],
+    "pycharm-edu": [
+      {
+        "cask": "pycharm-edu",
+        "count": "37"
+      }
+    ],
+    "pycharm-with-anaconda-plugin": [
+      {
+        "cask": "pycharm-with-anaconda-plugin",
+        "count": "13"
+      }
+    ],
+    "pyfa": [
+      {
+        "cask": "pyfa",
+        "count": "53"
+      }
+    ],
+    "pym-player": [
+      {
+        "cask": "pym-player",
+        "count": "2"
+      }
+    ],
+    "pynsource": [
+      {
+        "cask": "pynsource",
+        "count": "2"
+      }
+    ],
+    "python-framework-36": [
+      {
+        "cask": "python-framework-36",
+        "count": "2"
+      }
+    ],
+    "python-framework-38": [
+      {
+        "cask": "python-framework-38",
+        "count": "1"
+      }
+    ],
+    "pyzo": [
+      {
+        "cask": "pyzo",
+        "count": "5"
+      }
+    ],
+    "qbittorrent": [
+      {
+        "cask": "qbittorrent",
+        "count": "1,480"
+      }
+    ],
+    "qblocker": [
+      {
+        "cask": "qblocker",
+        "count": "7"
+      }
+    ],
+    "qbserve": [
+      {
+        "cask": "qbserve",
+        "count": "11"
+      }
+    ],
+    "qcad": [
+      {
+        "cask": "qcad",
+        "count": "40"
+      }
+    ],
+    "qcma": [
+      {
+        "cask": "qcma",
+        "count": "5"
+      }
+    ],
+    "qctools": [
+      {
+        "cask": "qctools",
+        "count": "6"
+      }
+    ],
+    "qdesktop": [
+      {
+        "cask": "qdesktop",
+        "count": "11"
+      }
+    ],
+    "qdslrdashboard": [
+      {
+        "cask": "qdslrdashboard",
+        "count": "4"
+      }
+    ],
+    "qfinder-pro": [
+      {
+        "cask": "qfinder-pro",
+        "count": "17"
+      }
+    ],
+    "qgis": [
+      {
+        "cask": "qgis",
+        "count": "234"
+      }
+    ],
+    "qgroundcontrol": [
+      {
+        "cask": "qgroundcontrol",
+        "count": "8"
+      }
+    ],
+    "qingg": [
+      {
+        "cask": "qingg",
+        "count": "9"
+      }
+    ],
+    "qiyimedia": [
+      {
+        "cask": "qiyimedia",
+        "count": "113"
+      }
+    ],
+    "ql-ansilove": [
+      {
+        "cask": "ql-ansilove",
+        "count": "15"
+      }
+    ],
+    "qlab": [
+      {
+        "cask": "qlab",
+        "count": "6"
+      }
+    ],
+    "qladdict": [
+      {
+        "cask": "qladdict",
+        "count": "72"
+      }
+    ],
+    "qlc-plus": [
+      {
+        "cask": "qlc-plus",
+        "count": "4"
+      }
+    ],
+    "qlcolorcode": [
+      {
+        "cask": "qlcolorcode",
+        "count": "1,941"
+      }
+    ],
+    "qlcommonmark": [
+      {
+        "cask": "qlcommonmark",
+        "count": "37"
+      }
+    ],
+    "qldds": [
+      {
+        "cask": "qldds",
+        "count": "7"
+      }
+    ],
+    "qlfits": [
+      {
+        "cask": "qlfits",
+        "count": "22"
+      }
+    ],
+    "qlgradle": [
+      {
+        "cask": "qlgradle",
+        "count": "36"
+      }
+    ],
+    "qlimagesize": [
+      {
+        "cask": "qlimagesize",
+        "count": "1,498"
+      }
+    ],
+    "qlmarkdown": [
+      {
+        "cask": "qlmarkdown",
+        "count": "2,334"
+      }
+    ],
+    "qlmarkdown-gfm": [
+      {
+        "cask": "qlmarkdown-gfm",
+        "count": "5"
+      }
+    ],
+    "qlmobi": [
+      {
+        "cask": "qlmobi",
+        "count": "46"
+      }
+    ],
+    "qlnetcdf": [
+      {
+        "cask": "qlnetcdf",
+        "count": "8"
+      }
+    ],
+    "qlplayground": [
+      {
+        "cask": "qlplayground",
+        "count": "30"
+      }
+    ],
+    "qlprettypatch": [
+      {
+        "cask": "qlprettypatch",
+        "count": "355"
+      }
+    ],
+    "qlrest": [
+      {
+        "cask": "qlrest",
+        "count": "10"
+      }
+    ],
+    "qlscpt": [
+      {
+        "cask": "qlscpt",
+        "count": "1"
+      }
+    ],
+    "qlstephen": [
+      {
+        "cask": "qlstephen",
+        "count": "2,344"
+      }
+    ],
+    "qlswift": [
+      {
+        "cask": "qlswift",
+        "count": "15"
+      }
+    ],
+    "qlvideo": [
+      {
+        "cask": "qlvideo",
+        "count": "1,480"
+      }
+    ],
+    "qmk-toolbox": [
+      {
+        "cask": "qmk-toolbox",
+        "count": "213"
+      }
+    ],
+    "qmoji": [
+      {
+        "cask": "qmoji",
+        "count": "1"
+      }
+    ],
+    "qnapi": [
+      {
+        "cask": "qnapi",
+        "count": "76"
+      }
+    ],
+    "qobuz": [
+      {
+        "cask": "qobuz",
+        "count": "11"
+      }
+    ],
+    "qownnotes": [
+      {
+        "cask": "qownnotes",
+        "count": "58"
+      }
+    ],
+    "qq": [
+      {
+        "cask": "qq",
+        "count": "534"
+      }
+    ],
+    "qqbrowser": [
+      {
+        "cask": "qqbrowser",
+        "count": "11"
+      }
+    ],
+    "qqlive": [
+      {
+        "cask": "qqlive",
+        "count": "58"
+      }
+    ],
+    "qqmacmgr": [
+      {
+        "cask": "qqmacmgr",
+        "count": "6"
+      }
+    ],
+    "qqmusic": [
+      {
+        "cask": "qqmusic",
+        "count": "173"
+      }
+    ],
+    "qqplayer": [
+      {
+        "cask": "qqplayer",
+        "count": "11"
+      }
+    ],
+    "qr-journal": [
+      {
+        "cask": "qr-journal",
+        "count": "13"
+      }
+    ],
+    "qsync-client": [
+      {
+        "cask": "qsync-client",
+        "count": "18"
+      }
+    ],
+    "qsyncthingtray": [
+      {
+        "cask": "qsyncthingtray",
+        "count": "18"
+      }
+    ],
+    "qt-creator": [
+      {
+        "cask": "qt-creator",
+        "count": "704"
+      }
+    ],
+    "qt-creator-dev": [
+      {
+        "cask": "qt-creator-dev",
+        "count": "11"
+      }
+    ],
+    "qt-design-studio": [
+      {
+        "cask": "qt-design-studio",
+        "count": "26"
+      }
+    ],
+    "qt3dstudio": [
+      {
+        "cask": "qt3dstudio",
+        "count": "1"
+      }
+    ],
+    "qtox": [
+      {
+        "cask": "qtox",
+        "count": "34"
+      }
+    ],
+    "qtpass": [
+      {
+        "cask": "qtpass",
+        "count": "72"
+      }
+    ],
+    "qtspim": [
+      {
+        "cask": "qtspim",
+        "count": "24"
+      }
+    ],
+    "quail": [
+      {
+        "cask": "quail",
+        "count": "3"
+      }
+    ],
+    "quakespasm": [
+      {
+        "cask": "quakespasm",
+        "count": "17"
+      }
+    ],
+    "quassel": [
+      {
+        "cask": "quassel",
+        "count": "4"
+      }
+    ],
+    "quassel-client": [
+      {
+        "cask": "quassel-client",
+        "count": "9"
+      }
+    ],
+    "quaternion": [
+      {
+        "cask": "quaternion",
+        "count": "8"
+      }
+    ],
+    "querious": [
+      {
+        "cask": "querious",
+        "count": "18"
+      }
+    ],
+    "questrade-iq-edge": [
+      {
+        "cask": "questrade-iq-edge",
+        "count": "4"
+      }
+    ],
+    "quickbooks": [
+      {
+        "cask": "quickbooks",
+        "count": "6"
+      }
+    ],
+    "quickbooks-online": [
+      {
+        "cask": "quickbooks-online",
+        "count": "18"
+      }
+    ],
+    "quicken": [
+      {
+        "cask": "quicken",
+        "count": "15"
+      }
+    ],
+    "quickeys": [
+      {
+        "cask": "quickeys",
+        "count": "1"
+      }
+    ],
+    "quickgeojson": [
+      {
+        "cask": "quickgeojson",
+        "count": "10"
+      }
+    ],
+    "quickhash": [
+      {
+        "cask": "quickhash",
+        "count": "8"
+      }
+    ],
+    "quickhue": [
+      {
+        "cask": "quickhue",
+        "count": "4"
+      }
+    ],
+    "quickjson": [
+      {
+        "cask": "quickjson",
+        "count": "10"
+      }
+    ],
+    "quicklook-csv": [
+      {
+        "cask": "quicklook-csv",
+        "count": "578"
+      }
+    ],
+    "quicklook-json": [
+      {
+        "cask": "quicklook-json",
+        "count": "1,913"
+      }
+    ],
+    "quicklook-pat": [
+      {
+        "cask": "quicklook-pat",
+        "count": "52"
+      }
+    ],
+    "quicklook-pfm": [
+      {
+        "cask": "quicklook-pfm",
+        "count": "7"
+      }
+    ],
+    "quicklookapk": [
+      {
+        "cask": "quicklookapk",
+        "count": "198"
+      }
+    ],
+    "quicklookase": [
+      {
+        "cask": "quicklookase",
+        "count": "712"
+      }
+    ],
+    "quicknfo": [
+      {
+        "cask": "quicknfo",
+        "count": "26"
+      }
+    ],
+    "quicksilver": [
+      {
+        "cask": "quicksilver",
+        "count": "73"
+      }
+    ],
+    "quicksync": [
+      {
+        "cask": "quicksync",
+        "count": "3"
+      }
+    ],
+    "quicktime-player7": [
+      {
+        "cask": "quicktime-player7",
+        "count": "5"
+      }
+    ],
+    "quickwords": [
+      {
+        "cask": "quickwords",
+        "count": "4"
+      }
+    ],
+    "quik": [
+      {
+        "cask": "quik",
+        "count": "32"
+      }
+    ],
+    "quip": [
+      {
+        "cask": "quip",
+        "count": "81"
+      }
+    ],
+    "quiterss": [
+      {
+        "cask": "quiterss",
+        "count": "21"
+      }
+    ],
+    "quitter": [
+      {
+        "cask": "quitter",
+        "count": "28"
+      }
+    ],
+    "quodlibet": [
+      {
+        "cask": "quodlibet",
+        "count": "30"
+      }
+    ],
+    "qutebrowser": [
+      {
+        "cask": "qutebrowser",
+        "count": "367"
+      }
+    ],
+    "quupa-bridge": [
+      {
+        "cask": "quupa-bridge",
+        "count": "1"
+      }
+    ],
+    "quuppa-bridge": [
+      {
+        "cask": "quuppa-bridge",
+        "count": "1"
+      }
+    ],
+    "quuppa-site-planner": [
+      {
+        "cask": "quuppa-site-planner",
+        "count": "1"
+      }
+    ],
+    "qv2ray": [
+      {
+        "cask": "qv2ray",
+        "count": "71"
+      }
+    ],
+    "qview": [
+      {
+        "cask": "qview",
+        "count": "153"
+      }
+    ],
+    "qxmledit": [
+      {
+        "cask": "qxmledit",
+        "count": "14"
+      }
+    ],
+    "r": [
+      {
+        "cask": "r",
+        "count": "972"
+      }
+    ],
+    "r-name": [
+      {
+        "cask": "r-name",
+        "count": "3"
+      }
+    ],
+    "rabbitmq": [
+      {
+        "cask": "rabbitmq",
+        "count": "36"
+      }
+    ],
+    "race-into-space": [
+      {
+        "cask": "race-into-space",
+        "count": "2"
+      }
+    ],
+    "racket": [
+      {
+        "cask": "racket",
+        "count": "237"
+      }
+    ],
+    "racket-cs": [
+      {
+        "cask": "racket-cs",
+        "count": "19"
+      }
+    ],
+    "radar": [
+      {
+        "cask": "radar",
+        "count": "5"
+      }
+    ],
+    "radarr": [
+      {
+        "cask": "radarr",
+        "count": "93"
+      }
+    ],
+    "radiant-player": [
+      {
+        "cask": "radiant-player",
+        "count": "3"
+      }
+    ],
+    "radio-silence": [
+      {
+        "cask": "radio-silence",
+        "count": "31"
+      }
+    ],
+    "raindropio": [
+      {
+        "cask": "raindropio",
+        "count": "61"
+      }
+    ],
+    "rambox": [
+      {
+        "cask": "rambox",
+        "count": "142"
+      }
+    ],
+    "ramme": [
+      {
+        "cask": "ramme",
+        "count": "8"
+      }
+    ],
+    "ransomwhere": [
+      {
+        "cask": "ransomwhere",
+        "count": "26"
+      }
+    ],
+    "rapidminer-studio": [
+      {
+        "cask": "rapidminer-studio",
+        "count": "14"
+      }
+    ],
+    "rapidweaver": [
+      {
+        "cask": "rapidweaver",
+        "count": "7"
+      }
+    ],
+    "rar": [
+      {
+        "cask": "rar",
+        "count": "566"
+      }
+    ],
+    "raspberry-pi-imager": [
+      {
+        "cask": "raspberry-pi-imager",
+        "count": "174"
+      }
+    ],
+    "raven": [
+      {
+        "cask": "raven",
+        "count": "5"
+      }
+    ],
+    "raven-reader": [
+      {
+        "cask": "raven-reader",
+        "count": "11"
+      }
+    ],
+    "raw-photo-processor": [
+      {
+        "cask": "raw-photo-processor",
+        "count": "3"
+      }
+    ],
+    "rawtherapee": [
+      {
+        "cask": "rawtherapee",
+        "count": "71"
+      }
+    ],
+    "razer-synapse": [
+      {
+        "cask": "razer-synapse",
+        "count": "54"
+      }
+    ],
+    "razorsql": [
+      {
+        "cask": "razorsql",
+        "count": "31"
+      }
+    ],
+    "rclone-browser": [
+      {
+        "cask": "rclone-browser",
+        "count": "18"
+      }
+    ],
+    "rcloneosx": [
+      {
+        "cask": "rcloneosx",
+        "count": "40"
+      }
+    ],
+    "rcse": [
+      {
+        "cask": "rcse",
+        "count": "1"
+      }
+    ],
+    "react-native-debugger": [
+      {
+        "cask": "react-native-debugger",
+        "count": "4,348"
+      }
+    ],
+    "react-proto": [
+      {
+        "cask": "react-proto",
+        "count": "2"
+      }
+    ],
+    "react-studio": [
+      {
+        "cask": "react-studio",
+        "count": "44"
+      }
+    ],
+    "reactotron": [
+      {
+        "cask": "reactotron",
+        "count": "188"
+      }
+    ],
+    "realforce": [
+      {
+        "cask": "realforce",
+        "count": "5"
+      }
+    ],
+    "realm-studio": [
+      {
+        "cask": "realm-studio",
+        "count": "34"
+      }
+    ],
+    "reaper": [
+      {
+        "cask": "reaper",
+        "count": "127"
+      }
+    ],
+    "receiptquicklook": [
+      {
+        "cask": "receiptquicklook",
+        "count": "6"
+      }
+    ],
+    "receipts": [
+      {
+        "cask": "receipts",
+        "count": "5"
+      }
+    ],
+    "recents": [
+      {
+        "cask": "recents",
+        "count": "8"
+      }
+    ],
+    "recordit": [
+      {
+        "cask": "recordit",
+        "count": "19"
+      }
+    ],
+    "recovery-disk-assistant": [
+      {
+        "cask": "recovery-disk-assistant",
+        "count": "3"
+      }
+    ],
+    "rectangle": [
+      {
+        "cask": "rectangle",
+        "count": "3,172"
+      }
+    ],
+    "red": [
+      {
+        "cask": "red",
+        "count": "4"
+      }
+    ],
+    "red-eye": [
+      {
+        "cask": "red-eye",
+        "count": "6"
+      }
+    ],
+    "redcine-x-pro": [
+      {
+        "cask": "redcine-x-pro",
+        "count": "3"
+      }
+    ],
+    "redeclipse": [
+      {
+        "cask": "redeclipse",
+        "count": "3"
+      }
+    ],
+    "redis": [
+      {
+        "cask": "redis",
+        "count": "94"
+      }
+    ],
+    "refined-github-safari": [
+      {
+        "cask": "refined-github-safari",
+        "count": "34"
+      }
+    ],
+    "reflector": [
+      {
+        "cask": "reflector",
+        "count": "48"
+      }
+    ],
+    "reflector2": [
+      {
+        "cask": "reflector2",
+        "count": "3"
+      }
+    ],
+    "regexhibit": [
+      {
+        "cask": "regexhibit",
+        "count": "4"
+      }
+    ],
+    "reggy": [
+      {
+        "cask": "reggy",
+        "count": "14"
+      }
+    ],
+    "reikey": [
+      {
+        "cask": "reikey",
+        "count": "42"
+      }
+    ],
+    "rekordbox": [
+      {
+        "cask": "rekordbox",
+        "count": "42"
+      }
+    ],
+    "relaunch64": [
+      {
+        "cask": "relaunch64",
+        "count": "1"
+      }
+    ],
+    "rember": [
+      {
+        "cask": "rember",
+        "count": "9"
+      }
+    ],
+    "remember-the-milk": [
+      {
+        "cask": "remember-the-milk",
+        "count": "29"
+      }
+    ],
+    "remote-buddy": [
+      {
+        "cask": "remote-buddy",
+        "count": "1"
+      }
+    ],
+    "remote-desktop-manager": [
+      {
+        "cask": "remote-desktop-manager",
+        "count": "107"
+      }
+    ],
+    "remote-desktop-manager-free": [
+      {
+        "cask": "remote-desktop-manager-free",
+        "count": "84"
+      }
+    ],
+    "remoteviewer": [
+      {
+        "cask": "remoteviewer",
+        "count": "39"
+      }
+    ],
+    "remotix-agent": [
+      {
+        "cask": "remotix-agent",
+        "count": "3"
+      }
+    ],
+    "renamer": [
+      {
+        "cask": "renamer",
+        "count": "19"
+      }
+    ],
+    "renpy": [
+      {
+        "cask": "renpy",
+        "count": "15"
+      }
+    ],
+    "reolink-client": [
+      {
+        "cask": "reolink-client",
+        "count": "1"
+      }
+    ],
+    "repairhomepermissions": [
+      {
+        "cask": "repairhomepermissions",
+        "count": "1"
+      }
+    ],
+    "repetier-host": [
+      {
+        "cask": "repetier-host",
+        "count": "20"
+      }
+    ],
+    "rescuetime": [
+      {
+        "cask": "rescuetime",
+        "count": "147"
+      }
+    ],
+    "resilio-sync": [
+      {
+        "cask": "resilio-sync",
+        "count": "99"
+      }
+    ],
+    "resolutionator": [
+      {
+        "cask": "resolutionator",
+        "count": "20"
+      }
+    ],
+    "restart": [
+      {
+        "cask": "restart",
+        "count": "1"
+      }
+    ],
+    "restclient": [
+      {
+        "cask": "restclient",
+        "count": "9"
+      }
+    ],
+    "resxtreme": [
+      {
+        "cask": "resxtreme",
+        "count": "5"
+      }
+    ],
+    "retinizer": [
+      {
+        "cask": "retinizer",
+        "count": "9"
+      }
+    ],
+    "retro-virtual-machine": [
+      {
+        "cask": "retro-virtual-machine",
+        "count": "3"
+      }
+    ],
+    "retroactive": [
+      {
+        "cask": "retroactive",
+        "count": "4"
+      }
+    ],
+    "retroarch": [
+      {
+        "cask": "retroarch",
+        "count": "110"
+      }
+    ],
+    "retroarch-metal": [
+      {
+        "cask": "retroarch-metal",
+        "count": "26"
+      }
+    ],
+    "retrobatch": [
+      {
+        "cask": "retrobatch",
+        "count": "11"
+      }
+    ],
+    "retroshare": [
+      {
+        "cask": "retroshare",
+        "count": "10"
+      }
+    ],
+    "reunion": [
+      {
+        "cask": "reunion",
+        "count": "3"
+      }
+    ],
+    "reveal": [
+      {
+        "cask": "reveal",
+        "count": "19"
+      }
+    ],
+    "rhinoceros": [
+      {
+        "cask": "rhinoceros",
+        "count": "15"
+      }
+    ],
+    "ricochet": [
+      {
+        "cask": "ricochet",
+        "count": "6"
+      }
+    ],
+    "ricoh-ps-printers-vol4-exp-driver": [
+      {
+        "cask": "ricoh-ps-printers-vol4-exp-driver",
+        "count": "30"
+      }
+    ],
+    "ricoh-theta": [
+      {
+        "cask": "ricoh-theta",
+        "count": "1"
+      }
+    ],
+    "rider": [
+      {
+        "cask": "rider",
+        "count": "220"
+      }
+    ],
+    "ridibooks": [
+      {
+        "cask": "ridibooks",
+        "count": "23"
+      }
+    ],
+    "rightfont": [
+      {
+        "cask": "rightfont",
+        "count": "17"
+      }
+    ],
+    "rightzoom": [
+      {
+        "cask": "rightzoom",
+        "count": "1"
+      }
+    ],
+    "ring": [
+      {
+        "cask": "ring",
+        "count": "13"
+      }
+    ],
+    "ringcentral": [
+      {
+        "cask": "ringcentral",
+        "count": "31"
+      }
+    ],
+    "ringcentral-meetings": [
+      {
+        "cask": "ringcentral-meetings",
+        "count": "36"
+      }
+    ],
+    "ringtones": [
+      {
+        "cask": "ringtones",
+        "count": "2"
+      }
+    ],
+    "riot": [
+      {
+        "cask": "riot",
+        "count": "185"
+      }
+    ],
+    "ripcord": [
+      {
+        "cask": "ripcord",
+        "count": "22"
+      }
+    ],
+    "ripit": [
+      {
+        "cask": "ripit",
+        "count": "6"
+      }
+    ],
+    "roblox": [
+      {
+        "cask": "roblox",
+        "count": "69"
+      }
+    ],
+    "robo-3t": [
+      {
+        "cask": "robo-3t",
+        "count": "705"
+      }
+    ],
+    "robofont": [
+      {
+        "cask": "robofont",
+        "count": "4"
+      }
+    ],
+    "roboform": [
+      {
+        "cask": "roboform",
+        "count": "9"
+      }
+    ],
+    "rocket": [
+      {
+        "cask": "rocket",
+        "count": "291"
+      }
+    ],
+    "rocket-chat": [
+      {
+        "cask": "rocket-chat",
+        "count": "167"
+      }
+    ],
+    "rocket-typist": [
+      {
+        "cask": "rocket-typist",
+        "count": "2"
+      }
+    ],
+    "rodeo": [
+      {
+        "cask": "rodeo",
+        "count": "15"
+      }
+    ],
+    "roku-remote-tool": [
+      {
+        "cask": "roku-remote-tool",
+        "count": "7"
+      }
+    ],
+    "roland-quad-capture-usb-driver": [
+      {
+        "cask": "roland-quad-capture-usb-driver",
+        "count": "2"
+      }
+    ],
+    "rolisteam": [
+      {
+        "cask": "rolisteam",
+        "count": "2"
+      }
+    ],
+    "roon": [
+      {
+        "cask": "roon",
+        "count": "20"
+      }
+    ],
+    "rosaimagewriter": [
+      {
+        "cask": "rosaimagewriter",
+        "count": "7"
+      }
+    ],
+    "rotato": [
+      {
+        "cask": "rotato",
+        "count": "7"
+      }
+    ],
+    "routebuddy": [
+      {
+        "cask": "routebuddy",
+        "count": "3"
+      }
+    ],
+    "routeconverter": [
+      {
+        "cask": "routeconverter",
+        "count": "5"
+      }
+    ],
+    "routemap": [
+      {
+        "cask": "routemap",
+        "count": "1"
+      }
+    ],
+    "rowanj-gitx": [
+      {
+        "cask": "rowanj-gitx",
+        "count": "145"
+      }
+    ],
+    "rowmote-helper": [
+      {
+        "cask": "rowmote-helper",
+        "count": "1"
+      }
+    ],
+    "royal-tsx": [
+      {
+        "cask": "royal-tsx",
+        "count": "135"
+      }
+    ],
+    "royal-tsx@3": [
+      {
+        "cask": "royal-tsx@3",
+        "count": "1"
+      }
+    ],
+    "rpn-scientific": [
+      {
+        "cask": "rpn-scientific",
+        "count": "3"
+      }
+    ],
+    "rpvoip": [
+      {
+        "cask": "rpvoip",
+        "count": "1"
+      }
+    ],
+    "rq": [
+      {
+        "cask": "rq",
+        "count": "16"
+      }
+    ],
+    "rrcc": [
+      {
+        "cask": "rrcc",
+        "count": "3"
+      }
+    ],
+    "rss": [
+      {
+        "cask": "rss",
+        "count": "5"
+      }
+    ],
+    "rssowl": [
+      {
+        "cask": "rssowl",
+        "count": "17"
+      }
+    ],
+    "rstudio": [
+      {
+        "cask": "rstudio",
+        "count": "1,358"
+      }
+    ],
+    "rstudio-daily": [
+      {
+        "cask": "rstudio-daily",
+        "count": "22"
+      }
+    ],
+    "rstudio-preview": [
+      {
+        "cask": "rstudio-preview",
+        "count": "51"
+      }
+    ],
+    "rsyncosx": [
+      {
+        "cask": "rsyncosx",
+        "count": "115"
+      }
+    ],
+    "rubitrack-pro": [
+      {
+        "cask": "rubitrack-pro",
+        "count": "4"
+      }
+    ],
+    "rubymine": [
+      {
+        "cask": "rubymine",
+        "count": "225"
+      }
+    ],
+    "rubymotion": [
+      {
+        "cask": "rubymotion",
+        "count": "4"
+      }
+    ],
+    "runescape": [
+      {
+        "cask": "runescape",
+        "count": "25"
+      }
+    ],
+    "runjs": [
+      {
+        "cask": "runjs",
+        "count": "98"
+      }
+    ],
+    "runway": [
+      {
+        "cask": "runway",
+        "count": "11"
+      }
+    ],
+    "ryver": [
+      {
+        "cask": "ryver",
+        "count": "4"
+      }
+    ],
+    "sabaki": [
+      {
+        "cask": "sabaki",
+        "count": "31"
+      }
+    ],
+    "sabnzbd": [
+      {
+        "cask": "sabnzbd",
+        "count": "48"
+      }
+    ],
+    "safari-technology-preview": [
+      {
+        "cask": "safari-technology-preview",
+        "count": "109"
+      }
+    ],
+    "safaricookiecutter": [
+      {
+        "cask": "safaricookiecutter",
+        "count": "3"
+      }
+    ],
+    "safarisort": [
+      {
+        "cask": "safarisort",
+        "count": "2"
+      }
+    ],
+    "safeincloud-password-manager": [
+      {
+        "cask": "safeincloud-password-manager",
+        "count": "12"
+      }
+    ],
+    "sage": [
+      {
+        "cask": "sage",
+        "count": "159"
+      }
+    ],
+    "saleae-logic": [
+      {
+        "cask": "saleae-logic",
+        "count": "5"
+      }
+    ],
+    "sameboy": [
+      {
+        "cask": "sameboy",
+        "count": "13"
+      }
+    ],
+    "sandstrip": [
+      {
+        "cask": "sandstrip",
+        "count": "1"
+      }
+    ],
+    "santa": [
+      {
+        "cask": "santa",
+        "count": "39"
+      }
+    ],
+    "saoimageds9": [
+      {
+        "cask": "saoimageds9",
+        "count": "15"
+      }
+    ],
+    "sapmachine-jdk": [
+      {
+        "cask": "sapmachine-jdk",
+        "count": "118"
+      }
+    ],
+    "sapmachine11-ea-jdk": [
+      {
+        "cask": "sapmachine11-ea-jdk",
+        "count": "2"
+      }
+    ],
+    "sapmachine11-jdk": [
+      {
+        "cask": "sapmachine11-jdk",
+        "count": "70"
+      }
+    ],
+    "sapmachine11-jre": [
+      {
+        "cask": "sapmachine11-jre",
+        "count": "7"
+      }
+    ],
+    "sapmachine12-jdk": [
+      {
+        "cask": "sapmachine12-jdk",
+        "count": "2"
+      }
+    ],
+    "sapmachine13-ea-jdk": [
+      {
+        "cask": "sapmachine13-ea-jdk",
+        "count": "3"
+      }
+    ],
+    "sapmachine13-jdk": [
+      {
+        "cask": "sapmachine13-jdk",
+        "count": "3"
+      }
+    ],
+    "sapmachine14-ea-jdk": [
+      {
+        "cask": "sapmachine14-ea-jdk",
+        "count": "1"
+      }
+    ],
+    "sapmachine14-jdk": [
+      {
+        "cask": "sapmachine14-jdk",
+        "count": "2"
+      }
+    ],
+    "sapmachine14-jre": [
+      {
+        "cask": "sapmachine14-jre",
+        "count": "1"
+      }
+    ],
+    "sara": [
+      {
+        "cask": "sara",
+        "count": "2"
+      }
+    ],
+    "satellite-eyes": [
+      {
+        "cask": "satellite-eyes",
+        "count": "4"
+      }
+    ],
+    "sauce-connect": [
+      {
+        "cask": "sauce-connect",
+        "count": "17"
+      }
+    ],
+    "sauerbraten": [
+      {
+        "cask": "sauerbraten",
+        "count": "7"
+      }
+    ],
+    "save-hollywood": [
+      {
+        "cask": "save-hollywood",
+        "count": "9"
+      }
+    ],
+    "scala-ide": [
+      {
+        "cask": "scala-ide",
+        "count": "36"
+      }
+    ],
+    "scaleft": [
+      {
+        "cask": "scaleft",
+        "count": "21"
+      }
+    ],
+    "scalingo": [
+      {
+        "cask": "scalingo",
+        "count": "1"
+      }
+    ],
+    "scansion": [
+      {
+        "cask": "scansion",
+        "count": "3"
+      }
+    ],
+    "scap-workbench": [
+      {
+        "cask": "scap-workbench",
+        "count": "6"
+      }
+    ],
+    "scapple": [
+      {
+        "cask": "scapple",
+        "count": "24"
+      }
+    ],
+    "scenebuilder": [
+      {
+        "cask": "scenebuilder",
+        "count": "24"
+      }
+    ],
+    "schism-tracker": [
+      {
+        "cask": "schism-tracker",
+        "count": "5"
+      }
+    ],
+    "scidavis": [
+      {
+        "cask": "scidavis",
+        "count": "15"
+      }
+    ],
+    "scidvsmac": [
+      {
+        "cask": "scidvsmac",
+        "count": "8"
+      }
+    ],
+    "scihubeva": [
+      {
+        "cask": "scihubeva",
+        "count": "19"
+      }
+    ],
+    "scilab": [
+      {
+        "cask": "scilab",
+        "count": "62"
+      }
+    ],
+    "scopebox": [
+      {
+        "cask": "scopebox",
+        "count": "1"
+      }
+    ],
+    "scout": [
+      {
+        "cask": "scout",
+        "count": "3"
+      }
+    ],
+    "scratch": [
+      {
+        "cask": "scratch",
+        "count": "53"
+      }
+    ],
+    "screaming-frog-seo-spider": [
+      {
+        "cask": "screaming-frog-seo-spider",
+        "count": "28"
+      }
+    ],
+    "screen": [
+      {
+        "cask": "screen",
+        "count": "134"
+      }
+    ],
+    "screencast": [
+      {
+        "cask": "screencast",
+        "count": "7"
+      }
+    ],
+    "screenflick": [
+      {
+        "cask": "screenflick",
+        "count": "26"
+      }
+    ],
+    "screenflow": [
+      {
+        "cask": "screenflow",
+        "count": "70"
+      }
+    ],
+    "screenflow5": [
+      {
+        "cask": "screenflow5",
+        "count": "2"
+      }
+    ],
+    "screens": [
+      {
+        "cask": "screens",
+        "count": "74"
+      }
+    ],
+    "screens-connect": [
+      {
+        "cask": "screens-connect",
+        "count": "25"
+      }
+    ],
+    "scribus": [
+      {
+        "cask": "scribus",
+        "count": "199"
+      }
+    ],
+    "scribus-dev": [
+      {
+        "cask": "scribus-dev",
+        "count": "2"
+      }
+    ],
+    "script-debugger": [
+      {
+        "cask": "script-debugger",
+        "count": "23"
+      }
+    ],
+    "scriptql": [
+      {
+        "cask": "scriptql",
+        "count": "20"
+      }
+    ],
+    "scrivener": [
+      {
+        "cask": "scrivener",
+        "count": "61"
+      }
+    ],
+    "scroll-reverser": [
+      {
+        "cask": "scroll-reverser",
+        "count": "288"
+      }
+    ],
+    "scrub": [
+      {
+        "cask": "scrub",
+        "count": "1"
+      }
+    ],
+    "scrutiny": [
+      {
+        "cask": "scrutiny",
+        "count": "10"
+      }
+    ],
+    "scummvm": [
+      {
+        "cask": "scummvm",
+        "count": "42"
+      }
+    ],
+    "sdformatter": [
+      {
+        "cask": "sdformatter",
+        "count": "95"
+      }
+    ],
+    "sdrdx": [
+      {
+        "cask": "sdrdx",
+        "count": "10"
+      }
+    ],
+    "seadrive": [
+      {
+        "cask": "seadrive",
+        "count": "11"
+      }
+    ],
+    "seafile-client": [
+      {
+        "cask": "seafile-client",
+        "count": "76"
+      }
+    ],
+    "seagate-dashboard": [
+      {
+        "cask": "seagate-dashboard",
+        "count": "3"
+      }
+    ],
+    "seaglass": [
+      {
+        "cask": "seaglass",
+        "count": "55"
+      }
+    ],
+    "seamonkey": [
+      {
+        "cask": "seamonkey",
+        "count": "44"
+      }
+    ],
+    "seashore": [
+      {
+        "cask": "seashore",
+        "count": "50"
+      }
+    ],
+    "second-life-viewer": [
+      {
+        "cask": "second-life-viewer",
+        "count": "16"
+      }
+    ],
+    "secure-pipes": [
+      {
+        "cask": "secure-pipes",
+        "count": "18"
+      }
+    ],
+    "securesafe": [
+      {
+        "cask": "securesafe",
+        "count": "1"
+      }
+    ],
+    "securid": [
+      {
+        "cask": "securid",
+        "count": "7"
+      }
+    ],
+    "security-growler": [
+      {
+        "cask": "security-growler",
+        "count": "2"
+      }
+    ],
+    "securityspy": [
+      {
+        "cask": "securityspy",
+        "count": "6"
+      }
+    ],
+    "segger-embedded-studio-for-arm": [
+      {
+        "cask": "segger-embedded-studio-for-arm",
+        "count": "10"
+      }
+    ],
+    "segger-jlink": [
+      {
+        "cask": "segger-jlink",
+        "count": "67"
+      }
+    ],
+    "segger-ozone": [
+      {
+        "cask": "segger-ozone",
+        "count": "6"
+      }
+    ],
+    "sejda-pdf": [
+      {
+        "cask": "sejda-pdf",
+        "count": "4"
+      }
+    ],
+    "sekey": [
+      {
+        "cask": "sekey",
+        "count": "60"
+      }
+    ],
+    "selfcontrol": [
+      {
+        "cask": "selfcontrol",
+        "count": "92"
+      }
+    ],
+    "semulov": [
+      {
+        "cask": "semulov",
+        "count": "16"
+      }
+    ],
+    "sencha": [
+      {
+        "cask": "sencha",
+        "count": "33"
+      }
+    ],
+    "send-anywhere": [
+      {
+        "cask": "send-anywhere",
+        "count": "13"
+      }
+    ],
+    "send-to-kindle": [
+      {
+        "cask": "send-to-kindle",
+        "count": "107"
+      }
+    ],
+    "sensei": [
+      {
+        "cask": "sensei",
+        "count": "35"
+      }
+    ],
+    "sensiblesidebuttons": [
+      {
+        "cask": "sensiblesidebuttons",
+        "count": "108"
+      }
+    ],
+    "sentinel": [
+      {
+        "cask": "sentinel",
+        "count": "24"
+      }
+    ],
+    "sequel-pro": [
+      {
+        "cask": "sequel-pro",
+        "count": "1,350"
+      }
+    ],
+    "sequel-pro-nightly": [
+      {
+        "cask": "sequel-pro-nightly",
+        "count": "436"
+      }
+    ],
+    "sequential": [
+      {
+        "cask": "sequential",
+        "count": "11"
+      }
+    ],
+    "serial": [
+      {
+        "cask": "serial",
+        "count": "31"
+      }
+    ],
+    "serial-tools": [
+      {
+        "cask": "serial-tools",
+        "count": "10"
+      }
+    ],
+    "serviio": [
+      {
+        "cask": "serviio",
+        "count": "28"
+      }
+    ],
+    "servo": [
+      {
+        "cask": "servo",
+        "count": "13"
+      }
+    ],
+    "servpane": [
+      {
+        "cask": "servpane",
+        "count": "5"
+      }
+    ],
+    "session": [
+      {
+        "cask": "session",
+        "count": "18"
+      }
+    ],
+    "session-manager-plugin": [
+      {
+        "cask": "session-manager-plugin",
+        "count": "324"
+      }
+    ],
+    "setapp": [
+      {
+        "cask": "setapp",
+        "count": "231"
+      }
+    ],
+    "sf-symbols": [
+      {
+        "cask": "sf-symbols",
+        "count": "92"
+      }
+    ],
+    "sfdx": [
+      {
+        "cask": "sfdx",
+        "count": "53"
+      }
+    ],
+    "shades": [
+      {
+        "cask": "shades",
+        "count": "16"
+      }
+    ],
+    "shadow": [
+      {
+        "cask": "shadow",
+        "count": "60"
+      }
+    ],
+    "shadow-beta": [
+      {
+        "cask": "shadow-beta",
+        "count": "7"
+      }
+    ],
+    "shadowsocksx": [
+      {
+        "cask": "shadowsocksx",
+        "count": "46"
+      }
+    ],
+    "shadowsocksx-ng": [
+      {
+        "cask": "shadowsocksx-ng",
+        "count": "154"
+      }
+    ],
+    "shadowsocksx-ng-r": [
+      {
+        "cask": "shadowsocksx-ng-r",
+        "count": "129"
+      }
+    ],
+    "shapes": [
+      {
+        "cask": "shapes",
+        "count": "2"
+      }
+    ],
+    "sharemouse": [
+      {
+        "cask": "sharemouse",
+        "count": "143"
+      }
+    ],
+    "sharepod": [
+      {
+        "cask": "sharepod",
+        "count": "1"
+      }
+    ],
+    "sheepshaver": [
+      {
+        "cask": "sheepshaver",
+        "count": "2"
+      }
+    ],
+    "shellhere": [
+      {
+        "cask": "shellhere",
+        "count": "3"
+      }
+    ],
+    "sherlock": [
+      {
+        "cask": "sherlock",
+        "count": "19"
+      }
+    ],
+    "shiba": [
+      {
+        "cask": "shiba",
+        "count": "1"
+      }
+    ],
+    "shift": [
+      {
+        "cask": "shift",
+        "count": "44"
+      }
+    ],
+    "shiftit": [
+      {
+        "cask": "shiftit",
+        "count": "485"
+      }
+    ],
+    "shifty": [
+      {
+        "cask": "shifty",
+        "count": "34"
+      }
+    ],
+    "shimeike-formulatepro": [
+      {
+        "cask": "shimeike-formulatepro",
+        "count": "6"
+      }
+    ],
+    "shimo": [
+      {
+        "cask": "shimo",
+        "count": "42"
+      }
+    ],
+    "shiori": [
+      {
+        "cask": "shiori",
+        "count": "9"
+      }
+    ],
+    "shoes": [
+      {
+        "cask": "shoes",
+        "count": "4"
+      }
+    ],
+    "shortcat": [
+      {
+        "cask": "shortcat",
+        "count": "14"
+      }
+    ],
+    "shortcutdetective": [
+      {
+        "cask": "shortcutdetective",
+        "count": "12"
+      }
+    ],
+    "shortcuts": [
+      {
+        "cask": "shortcuts",
+        "count": "8"
+      }
+    ],
+    "shotcut": [
+      {
+        "cask": "shotcut",
+        "count": "139"
+      }
+    ],
+    "showhiddenfiles": [
+      {
+        "cask": "showhiddenfiles",
+        "count": "3"
+      }
+    ],
+    "showyedge": [
+      {
+        "cask": "showyedge",
+        "count": "16"
+      }
+    ],
+    "shrinkit": [
+      {
+        "cask": "shrinkit",
+        "count": "3"
+      }
+    ],
+    "shupapan": [
+      {
+        "cask": "shupapan",
+        "count": "3"
+      }
+    ],
+    "shutdown": [
+      {
+        "cask": "shutdown",
+        "count": "1"
+      }
+    ],
+    "shuttle": [
+      {
+        "cask": "shuttle",
+        "count": "76"
+      }
+    ],
+    "sia-host-manager": [
+      {
+        "cask": "sia-host-manager",
+        "count": "1"
+      }
+    ],
+    "sia-ui": [
+      {
+        "cask": "sia-ui",
+        "count": "7"
+      }
+    ],
+    "sickbeard-anime": [
+      {
+        "cask": "sickbeard-anime",
+        "count": "2"
+      }
+    ],
+    "sidekick": [
+      {
+        "cask": "sidekick",
+        "count": "1"
+      }
+    ],
+    "sidenotes": [
+      {
+        "cask": "sidenotes",
+        "count": "17"
+      }
+    ],
+    "sidequest": [
+      {
+        "cask": "sidequest",
+        "count": "55"
+      }
+    ],
+    "sidestep": [
+      {
+        "cask": "sidestep",
+        "count": "2"
+      }
+    ],
+    "sigil": [
+      {
+        "cask": "sigil",
+        "count": "80"
+      }
+    ],
+    "signal": [
+      {
+        "cask": "signal",
+        "count": "1,505"
+      }
+    ],
+    "signal-beta": [
+      {
+        "cask": "signal-beta",
+        "count": "14"
+      }
+    ],
+    "signet": [
+      {
+        "cask": "signet",
+        "count": "1"
+      }
+    ],
+    "sigviewer": [
+      {
+        "cask": "sigviewer",
+        "count": "4"
+      }
+    ],
+    "silentknight": [
+      {
+        "cask": "silentknight",
+        "count": "24"
+      }
+    ],
+    "silhouette-saver": [
+      {
+        "cask": "silhouette-saver",
+        "count": "2"
+      }
+    ],
+    "silicon-labs-vcp-driver": [
+      {
+        "cask": "silicon-labs-vcp-driver",
+        "count": "53"
+      }
+    ],
+    "silverlight": [
+      {
+        "cask": "silverlight",
+        "count": "52"
+      }
+    ],
+    "sim-daltonism": [
+      {
+        "cask": "sim-daltonism",
+        "count": "7"
+      }
+    ],
+    "simpholders": [
+      {
+        "cask": "simpholders",
+        "count": "6"
+      }
+    ],
+    "simple-comic": [
+      {
+        "cask": "simple-comic",
+        "count": "97"
+      }
+    ],
+    "simplediagrams": [
+      {
+        "cask": "simplediagrams",
+        "count": "2"
+      }
+    ],
+    "simplefloatingclock": [
+      {
+        "cask": "simplefloatingclock",
+        "count": "7"
+      }
+    ],
+    "simplenote": [
+      {
+        "cask": "simplenote",
+        "count": "140"
+      }
+    ],
+    "simplesynth": [
+      {
+        "cask": "simplesynth",
+        "count": "9"
+      }
+    ],
+    "simplistic": [
+      {
+        "cask": "simplistic",
+        "count": "7"
+      }
+    ],
+    "simply-fortran": [
+      {
+        "cask": "simply-fortran",
+        "count": "5"
+      }
+    ],
+    "simsim": [
+      {
+        "cask": "simsim",
+        "count": "5"
+      }
+    ],
+    "singularity": [
+      {
+        "cask": "singularity",
+        "count": "21"
+      }
+    ],
+    "sip": [
+      {
+        "cask": "sip",
+        "count": "64"
+      }
+    ],
+    "sirimote": [
+      {
+        "cask": "sirimote",
+        "count": "2"
+      }
+    ],
+    "sixtyforce": [
+      {
+        "cask": "sixtyforce",
+        "count": "4"
+      }
+    ],
+    "sizeup": [
+      {
+        "cask": "sizeup",
+        "count": "92"
+      }
+    ],
+    "sizzy": [
+      {
+        "cask": "sizzy",
+        "count": "21"
+      }
+    ],
+    "sketch": [
+      {
+        "cask": "sketch",
+        "count": "837"
+      }
+    ],
+    "sketch-toolbox": [
+      {
+        "cask": "sketch-toolbox",
+        "count": "28"
+      }
+    ],
+    "sketchbook": [
+      {
+        "cask": "sketchbook",
+        "count": "62"
+      }
+    ],
+    "sketchpacks": [
+      {
+        "cask": "sketchpacks",
+        "count": "17"
+      }
+    ],
+    "sketchup": [
+      {
+        "cask": "sketchup",
+        "count": "164"
+      }
+    ],
+    "sketchup-pro": [
+      {
+        "cask": "sketchup-pro",
+        "count": "22"
+      }
+    ],
+    "skim": [
+      {
+        "cask": "skim",
+        "count": "835"
+      }
+    ],
+    "skitch": [
+      {
+        "cask": "skitch",
+        "count": "326"
+      }
+    ],
+    "skreenics": [
+      {
+        "cask": "skreenics",
+        "count": "1"
+      }
+    ],
+    "skybox": [
+      {
+        "cask": "skybox",
+        "count": "2"
+      }
+    ],
+    "skyfonts": [
+      {
+        "cask": "skyfonts",
+        "count": "67"
+      }
+    ],
+    "skype": [
+      {
+        "cask": "skype",
+        "count": "4,349"
+      }
+    ],
+    "skype-for-business": [
+      {
+        "cask": "skype-for-business",
+        "count": "646"
+      }
+    ],
+    "skype-preview": [
+      {
+        "cask": "skype-preview",
+        "count": "8"
+      }
+    ],
+    "skype7": [
+      {
+        "cask": "skype7",
+        "count": "4"
+      }
+    ],
+    "skypewebplugin": [
+      {
+        "cask": "skypewebplugin",
+        "count": "11"
+      }
+    ],
+    "slack": [
+      {
+        "cask": "slack",
+        "count": "6,467"
+      }
+    ],
+    "slack-beta": [
+      {
+        "cask": "slack-beta",
+        "count": "66"
+      }
+    ],
+    "slate": [
+      {
+        "cask": "slate",
+        "count": "64"
+      }
+    ],
+    "sleep": [
+      {
+        "cask": "sleep",
+        "count": "2"
+      }
+    ],
+    "sleipnir": [
+      {
+        "cask": "sleipnir",
+        "count": "9"
+      }
+    ],
+    "slic3r": [
+      {
+        "cask": "slic3r",
+        "count": "37"
+      }
+    ],
+    "slicer": [
+      {
+        "cask": "slicer",
+        "count": "9"
+      }
+    ],
+    "slicer-nightly": [
+      {
+        "cask": "slicer-nightly",
+        "count": "3"
+      }
+    ],
+    "slik": [
+      {
+        "cask": "slik",
+        "count": "3"
+      }
+    ],
+    "slimbatterymonitor": [
+      {
+        "cask": "slimbatterymonitor",
+        "count": "6"
+      }
+    ],
+    "slite": [
+      {
+        "cask": "slite",
+        "count": "15"
+      }
+    ],
+    "sloth": [
+      {
+        "cask": "sloth",
+        "count": "108"
+      }
+    ],
+    "slowquitapps": [
+      {
+        "cask": "slowquitapps",
+        "count": "111"
+      }
+    ],
+    "smallpdf": [
+      {
+        "cask": "smallpdf",
+        "count": "14"
+      }
+    ],
+    "sman": [
+      {
+        "cask": "sman",
+        "count": "1"
+      }
+    ],
+    "smart-converter-pro": [
+      {
+        "cask": "smart-converter-pro",
+        "count": "9"
+      }
+    ],
+    "smartconverter": [
+      {
+        "cask": "smartconverter",
+        "count": "1"
+      }
+    ],
+    "smartgit": [
+      {
+        "cask": "smartgit",
+        "count": "104"
+      }
+    ],
+    "smartsvn": [
+      {
+        "cask": "smartsvn",
+        "count": "68"
+      }
+    ],
+    "smartsynchronize": [
+      {
+        "cask": "smartsynchronize",
+        "count": "11"
+      }
+    ],
+    "smcfancontrol": [
+      {
+        "cask": "smcfancontrol",
+        "count": "684"
+      }
+    ],
+    "smlnj": [
+      {
+        "cask": "smlnj",
+        "count": "233"
+      }
+    ],
+    "smoothscroll": [
+      {
+        "cask": "smoothscroll",
+        "count": "25"
+      }
+    ],
+    "smooze": [
+      {
+        "cask": "smooze",
+        "count": "14"
+      }
+    ],
+    "snagit": [
+      {
+        "cask": "snagit",
+        "count": "81"
+      }
+    ],
+    "snagit4": [
+      {
+        "cask": "snagit4",
+        "count": "2"
+      }
+    ],
+    "snapndrag": [
+      {
+        "cask": "snapndrag",
+        "count": "3"
+      }
+    ],
+    "snappy": [
+      {
+        "cask": "snappy",
+        "count": "34"
+      }
+    ],
+    "sneek": [
+      {
+        "cask": "sneek",
+        "count": "5"
+      }
+    ],
+    "snes9x": [
+      {
+        "cask": "snes9x",
+        "count": "39"
+      }
+    ],
+    "snip": [
+      {
+        "cask": "snip",
+        "count": "40"
+      }
+    ],
+    "snipaste": [
+      {
+        "cask": "snipaste",
+        "count": "216"
+      }
+    ],
+    "sno": [
+      {
+        "cask": "sno",
+        "count": "3"
+      }
+    ],
+    "snowflake-snowsql": [
+      {
+        "cask": "snowflake-snowsql",
+        "count": "259"
+      }
+    ],
+    "soapui": [
+      {
+        "cask": "soapui",
+        "count": "289"
+      }
+    ],
+    "socket-io-tester": [
+      {
+        "cask": "socket-io-tester",
+        "count": "2"
+      }
+    ],
+    "sococo": [
+      {
+        "cask": "sococo",
+        "count": "19"
+      }
+    ],
+    "soda-player": [
+      {
+        "cask": "soda-player",
+        "count": "72"
+      }
+    ],
+    "soduto": [
+      {
+        "cask": "soduto",
+        "count": "11"
+      }
+    ],
+    "sofa-server": [
+      {
+        "cask": "sofa-server",
+        "count": "2"
+      }
+    ],
+    "softmaker-freeoffice": [
+      {
+        "cask": "softmaker-freeoffice",
+        "count": "17"
+      }
+    ],
+    "softorino-youtube-converter": [
+      {
+        "cask": "softorino-youtube-converter",
+        "count": "8"
+      }
+    ],
+    "softraid": [
+      {
+        "cask": "softraid",
+        "count": "3"
+      }
+    ],
+    "softu2f": [
+      {
+        "cask": "softu2f",
+        "count": "8"
+      }
+    ],
+    "softube-central": [
+      {
+        "cask": "softube-central",
+        "count": "3"
+      }
+    ],
+    "sogouinput": [
+      {
+        "cask": "sogouinput",
+        "count": "202"
+      }
+    ],
+    "soluble": [
+      {
+        "cask": "soluble",
+        "count": "3"
+      }
+    ],
+    "solvespace": [
+      {
+        "cask": "solvespace",
+        "count": "9"
+      }
+    ],
+    "somafm": [
+      {
+        "cask": "somafm",
+        "count": "2"
+      }
+    ],
+    "sonarr": [
+      {
+        "cask": "sonarr",
+        "count": "389"
+      }
+    ],
+    "sonarr-menu": [
+      {
+        "cask": "sonarr-menu",
+        "count": "4"
+      }
+    ],
+    "sonic-pi": [
+      {
+        "cask": "sonic-pi",
+        "count": "105"
+      }
+    ],
+    "sonic-visualiser": [
+      {
+        "cask": "sonic-visualiser",
+        "count": "36"
+      }
+    ],
+    "sonoair": [
+      {
+        "cask": "sonoair",
+        "count": "5"
+      }
+    ],
+    "sonos": [
+      {
+        "cask": "sonos",
+        "count": "145"
+      }
+    ],
+    "sony-ps4-remote-play": [
+      {
+        "cask": "sony-ps4-remote-play",
+        "count": "74"
+      }
+    ],
+    "sony-xperia-companion": [
+      {
+        "cask": "sony-xperia-companion",
+        "count": "3"
+      }
+    ],
+    "sopcast": [
+      {
+        "cask": "sopcast",
+        "count": "4"
+      }
+    ],
+    "soqlxplorer": [
+      {
+        "cask": "soqlxplorer",
+        "count": "16"
+      }
+    ],
+    "soulseek": [
+      {
+        "cask": "soulseek",
+        "count": "69"
+      }
+    ],
+    "soulver": [
+      {
+        "cask": "soulver",
+        "count": "94"
+      }
+    ],
+    "soulver2": [
+      {
+        "cask": "soulver2",
+        "count": "3"
+      }
+    ],
+    "sound-blaster-play3": [
+      {
+        "cask": "sound-blaster-play3",
+        "count": "1"
+      }
+    ],
+    "sound-control": [
+      {
+        "cask": "sound-control",
+        "count": "68"
+      }
+    ],
+    "sound-siphon": [
+      {
+        "cask": "sound-siphon",
+        "count": "10"
+      }
+    ],
+    "soundboosterlite": [
+      {
+        "cask": "soundboosterlite",
+        "count": "4"
+      }
+    ],
+    "soundcleod": [
+      {
+        "cask": "soundcleod",
+        "count": "34"
+      }
+    ],
+    "soundcloud-downloader": [
+      {
+        "cask": "soundcloud-downloader",
+        "count": "33"
+      }
+    ],
+    "soundflower": [
+      {
+        "cask": "soundflower",
+        "count": "859"
+      }
+    ],
+    "soundflowerbed": [
+      {
+        "cask": "soundflowerbed",
+        "count": "210"
+      }
+    ],
+    "soundsource": [
+      {
+        "cask": "soundsource",
+        "count": "109"
+      }
+    ],
+    "sourcenote": [
+      {
+        "cask": "sourcenote",
+        "count": "3"
+      }
+    ],
+    "sourcetrail": [
+      {
+        "cask": "sourcetrail",
+        "count": "57"
+      }
+    ],
+    "sourcetree": [
+      {
+        "cask": "sourcetree",
+        "count": "2,263"
+      }
+    ],
+    "sourcetree-beta": [
+      {
+        "cask": "sourcetree-beta",
+        "count": "9"
+      }
+    ],
+    "spaceid": [
+      {
+        "cask": "spaceid",
+        "count": "1"
+      }
+    ],
+    "spacelauncher": [
+      {
+        "cask": "spacelauncher",
+        "count": "6"
+      }
+    ],
+    "spaceradar": [
+      {
+        "cask": "spaceradar",
+        "count": "6"
+      }
+    ],
+    "spamsieve": [
+      {
+        "cask": "spamsieve",
+        "count": "18"
+      }
+    ],
+    "spark": [
+      {
+        "cask": "spark",
+        "count": "215"
+      }
+    ],
+    "sparkle": [
+      {
+        "cask": "sparkle",
+        "count": "25"
+      }
+    ],
+    "sparkleshare": [
+      {
+        "cask": "sparkleshare",
+        "count": "6"
+      }
+    ],
+    "spatial": [
+      {
+        "cask": "spatial",
+        "count": "4"
+      }
+    ],
+    "spatterlight": [
+      {
+        "cask": "spatterlight",
+        "count": "1"
+      }
+    ],
+    "spectacle": [
+      {
+        "cask": "spectacle",
+        "count": "2,143"
+      }
+    ],
+    "spectacle-editor": [
+      {
+        "cask": "spectacle-editor",
+        "count": "8"
+      }
+    ],
+    "spectrum": [
+      {
+        "cask": "spectrum",
+        "count": "11"
+      }
+    ],
+    "speculid": [
+      {
+        "cask": "speculid",
+        "count": "8"
+      }
+    ],
+    "speedcrunch": [
+      {
+        "cask": "speedcrunch",
+        "count": "34"
+      }
+    ],
+    "speedify": [
+      {
+        "cask": "speedify",
+        "count": "27"
+      }
+    ],
+    "spek": [
+      {
+        "cask": "spek",
+        "count": "1"
+      }
+    ],
+    "spideroak-share": [
+      {
+        "cask": "spideroak-share",
+        "count": "3"
+      }
+    ],
+    "spideroakone": [
+      {
+        "cask": "spideroakone",
+        "count": "9"
+      }
+    ],
+    "spike": [
+      {
+        "cask": "spike",
+        "count": "21"
+      }
+    ],
+    "spires": [
+      {
+        "cask": "spires",
+        "count": "3"
+      }
+    ],
+    "splashtop-business": [
+      {
+        "cask": "splashtop-business",
+        "count": "6"
+      }
+    ],
+    "splashtop-personal": [
+      {
+        "cask": "splashtop-personal",
+        "count": "12"
+      }
+    ],
+    "splashtop-streamer": [
+      {
+        "cask": "splashtop-streamer",
+        "count": "18"
+      }
+    ],
+    "splayer": [
+      {
+        "cask": "splayer",
+        "count": "4"
+      }
+    ],
+    "splice": [
+      {
+        "cask": "splice",
+        "count": "23"
+      }
+    ],
+    "splitshow": [
+      {
+        "cask": "splitshow",
+        "count": "5"
+      }
+    ],
+    "spotifree": [
+      {
+        "cask": "spotifree",
+        "count": "38"
+      }
+    ],
+    "spotify": [
+      {
+        "cask": "spotify",
+        "count": "4,765"
+      }
+    ],
+    "spotify-notifications": [
+      {
+        "cask": "spotify-notifications",
+        "count": "81"
+      }
+    ],
+    "spotify-now-playing": [
+      {
+        "cask": "spotify-now-playing",
+        "count": "56"
+      }
+    ],
+    "spotmenu": [
+      {
+        "cask": "spotmenu",
+        "count": "365"
+      }
+    ],
+    "spotspot": [
+      {
+        "cask": "spotspot",
+        "count": "1"
+      }
+    ],
+    "springtoolsuite": [
+      {
+        "cask": "springtoolsuite",
+        "count": "159"
+      }
+    ],
+    "spyder-py2": [
+      {
+        "cask": "spyder-py2",
+        "count": "8"
+      }
+    ],
+    "sql-power-architect-jdbc": [
+      {
+        "cask": "sql-power-architect-jdbc",
+        "count": "4"
+      }
+    ],
+    "sql-tabs": [
+      {
+        "cask": "sql-tabs",
+        "count": "4"
+      }
+    ],
+    "sqlcheck": [
+      {
+        "cask": "sqlcheck",
+        "count": "8"
+      }
+    ],
+    "sqlectron": [
+      {
+        "cask": "sqlectron",
+        "count": "27"
+      }
+    ],
+    "sqleditor": [
+      {
+        "cask": "sqleditor",
+        "count": "11"
+      }
+    ],
+    "sqlexplorer": [
+      {
+        "cask": "sqlexplorer",
+        "count": "12"
+      }
+    ],
+    "sqlitemanager": [
+      {
+        "cask": "sqlitemanager",
+        "count": "18"
+      }
+    ],
+    "sqlitestudio": [
+      {
+        "cask": "sqlitestudio",
+        "count": "100"
+      }
+    ],
+    "sqlpro-for-mssql": [
+      {
+        "cask": "sqlpro-for-mssql",
+        "count": "17"
+      }
+    ],
+    "sqlpro-for-mysql": [
+      {
+        "cask": "sqlpro-for-mysql",
+        "count": "29"
+      }
+    ],
+    "sqlpro-for-postgres": [
+      {
+        "cask": "sqlpro-for-postgres",
+        "count": "37"
+      }
+    ],
+    "sqlpro-for-sqlite": [
+      {
+        "cask": "sqlpro-for-sqlite",
+        "count": "27"
+      }
+    ],
+    "sqlpro-studio": [
+      {
+        "cask": "sqlpro-studio",
+        "count": "36"
+      }
+    ],
+    "sqlworkbenchj": [
+      {
+        "cask": "sqlworkbenchj",
+        "count": "205"
+      }
+    ],
+    "squeak": [
+      {
+        "cask": "squeak",
+        "count": "8"
+      }
+    ],
+    "squidman": [
+      {
+        "cask": "squidman",
+        "count": "60"
+      }
+    ],
+    "squirrel": [
+      {
+        "cask": "squirrel",
+        "count": "344"
+      }
+    ],
+    "squirrelsql": [
+      {
+        "cask": "squirrelsql",
+        "count": "59"
+      }
+    ],
+    "srware-iron": [
+      {
+        "cask": "srware-iron",
+        "count": "9"
+      }
+    ],
+    "ssh-tunnel-manager": [
+      {
+        "cask": "ssh-tunnel-manager",
+        "count": "66"
+      }
+    ],
+    "ssokit": [
+      {
+        "cask": "ssokit",
+        "count": "6"
+      }
+    ],
+    "stack": [
+      {
+        "cask": "stack",
+        "count": "33"
+      }
+    ],
+    "stack-stack": [
+      {
+        "cask": "stack-stack",
+        "count": "16"
+      }
+    ],
+    "stand": [
+      {
+        "cask": "stand",
+        "count": "9"
+      }
+    ],
+    "standard-notes": [
+      {
+        "cask": "standard-notes",
+        "count": "93"
+      }
+    ],
+    "standing-desk": [
+      {
+        "cask": "standing-desk",
+        "count": "2"
+      }
+    ],
+    "starcraft": [
+      {
+        "cask": "starcraft",
+        "count": "26"
+      }
+    ],
+    "stark": [
+      {
+        "cask": "stark",
+        "count": "1"
+      }
+    ],
+    "starleaf": [
+      {
+        "cask": "starleaf",
+        "count": "12"
+      }
+    ],
+    "startninja": [
+      {
+        "cask": "startninja",
+        "count": "4"
+      }
+    ],
+    "startupizer": [
+      {
+        "cask": "startupizer",
+        "count": "1"
+      }
+    ],
+    "staruml": [
+      {
+        "cask": "staruml",
+        "count": "115"
+      }
+    ],
+    "station": [
+      {
+        "cask": "station",
+        "count": "206"
+      }
+    ],
+    "stationtv-link": [
+      {
+        "cask": "stationtv-link",
+        "count": "2"
+      }
+    ],
+    "statusfy": [
+      {
+        "cask": "statusfy",
+        "count": "12"
+      }
+    ],
+    "stay": [
+      {
+        "cask": "stay",
+        "count": "31"
+      }
+    ],
+    "steam": [
+      {
+        "cask": "steam",
+        "count": "2,884"
+      }
+    ],
+    "steamcmd": [
+      {
+        "cask": "steamcmd",
+        "count": "27"
+      }
+    ],
+    "steelseries-engine": [
+      {
+        "cask": "steelseries-engine",
+        "count": "34"
+      }
+    ],
+    "steelseries-exactmouse-tool": [
+      {
+        "cask": "steelseries-exactmouse-tool",
+        "count": "19"
+      }
+    ],
+    "steermouse": [
+      {
+        "cask": "steermouse",
+        "count": "150"
+      }
+    ],
+    "stella": [
+      {
+        "cask": "stella",
+        "count": "7"
+      }
+    ],
+    "stellarium": [
+      {
+        "cask": "stellarium",
+        "count": "123"
+      }
+    ],
+    "stepmania": [
+      {
+        "cask": "stepmania",
+        "count": "5"
+      }
+    ],
+    "steveschow-gfxcardstatus": [
+      {
+        "cask": "steveschow-gfxcardstatus",
+        "count": "28"
+      }
+    ],
+    "stm32cubeide": [
+      {
+        "cask": "stm32cubeide",
+        "count": "2"
+      }
+    ],
+    "stm32cubemx": [
+      {
+        "cask": "stm32cubemx",
+        "count": "7"
+      }
+    ],
+    "stoplight-studio": [
+      {
+        "cask": "stoplight-studio",
+        "count": "88"
+      }
+    ],
+    "storyboarder": [
+      {
+        "cask": "storyboarder",
+        "count": "9"
+      }
+    ],
+    "strawberry": [
+      {
+        "cask": "strawberry",
+        "count": "13"
+      }
+    ],
+    "streamlabs-obs": [
+      {
+        "cask": "streamlabs-obs",
+        "count": "162"
+      }
+    ],
+    "streamlink-twitch-gui": [
+      {
+        "cask": "streamlink-twitch-gui",
+        "count": "47"
+      }
+    ],
+    "stremio": [
+      {
+        "cask": "stremio",
+        "count": "84"
+      }
+    ],
+    "stretchly": [
+      {
+        "cask": "stretchly",
+        "count": "246"
+      }
+    ],
+    "stringsfile": [
+      {
+        "cask": "stringsfile",
+        "count": "3"
+      }
+    ],
+    "strongvpn": [
+      {
+        "cask": "strongvpn",
+        "count": "2"
+      }
+    ],
+    "stubbymanager": [
+      {
+        "cask": "stubbymanager",
+        "count": "6"
+      }
+    ],
+    "studio-3t": [
+      {
+        "cask": "studio-3t",
+        "count": "114"
+      }
+    ],
+    "studiolinkstandalone": [
+      {
+        "cask": "studiolinkstandalone",
+        "count": "6"
+      }
+    ],
+    "subethaedit": [
+      {
+        "cask": "subethaedit",
+        "count": "8"
+      }
+    ],
+    "subler": [
+      {
+        "cask": "subler",
+        "count": "106"
+      }
+    ],
+    "sublercli": [
+      {
+        "cask": "sublercli",
+        "count": "13"
+      }
+    ],
+    "sublime": [
+      {
+        "cask": "sublime",
+        "count": "1"
+      }
+    ],
+    "sublime-merge": [
+      {
+        "cask": "sublime-merge",
+        "count": "349"
+      }
+    ],
+    "sublime-merge-dev": [
+      {
+        "cask": "sublime-merge-dev",
+        "count": "16"
+      }
+    ],
+    "sublime-text": [
+      {
+        "cask": "sublime-text",
+        "count": "4,288"
+      }
+    ],
+    "sublime-text-dev": [
+      {
+        "cask": "sublime-text-dev",
+        "count": "47"
+      }
+    ],
+    "sublime-text2": [
+      {
+        "cask": "sublime-text2",
+        "count": "61"
+      }
+    ],
+    "subnetcalc": [
+      {
+        "cask": "subnetcalc",
+        "count": "12"
+      }
+    ],
+    "subsurface": [
+      {
+        "cask": "subsurface",
+        "count": "3"
+      }
+    ],
+    "subtitle-master": [
+      {
+        "cask": "subtitle-master",
+        "count": "9"
+      }
+    ],
+    "subtitles": [
+      {
+        "cask": "subtitles",
+        "count": "31"
+      }
+    ],
+    "subtools": [
+      {
+        "cask": "subtools",
+        "count": "8"
+      }
+    ],
+    "sunlogincontrol": [
+      {
+        "cask": "sunlogincontrol",
+        "count": "19"
+      }
+    ],
+    "sunsama": [
+      {
+        "cask": "sunsama",
+        "count": "2"
+      }
+    ],
+    "sunvox": [
+      {
+        "cask": "sunvox",
+        "count": "7"
+      }
+    ],
+    "superbeam": [
+      {
+        "cask": "superbeam",
+        "count": "2"
+      }
+    ],
+    "supercollider": [
+      {
+        "cask": "supercollider",
+        "count": "75"
+      }
+    ],
+    "superduper": [
+      {
+        "cask": "superduper",
+        "count": "157"
+      }
+    ],
+    "superhuman": [
+      {
+        "cask": "superhuman",
+        "count": "19"
+      }
+    ],
+    "superproductivity": [
+      {
+        "cask": "superproductivity",
+        "count": "79"
+      }
+    ],
+    "supertuxkart": [
+      {
+        "cask": "supertuxkart",
+        "count": "55"
+      }
+    ],
+    "surfeasy-vpn": [
+      {
+        "cask": "surfeasy-vpn",
+        "count": "1"
+      }
+    ],
+    "surge": [
+      {
+        "cask": "surge",
+        "count": "103"
+      }
+    ],
+    "surge-synthesizer": [
+      {
+        "cask": "surge-synthesizer",
+        "count": "72"
+      }
+    ],
+    "sus-inspector": [
+      {
+        "cask": "sus-inspector",
+        "count": "1"
+      }
+    ],
+    "suspicious-package": [
+      {
+        "cask": "suspicious-package",
+        "count": "1,386"
+      }
+    ],
+    "suunto-moveslink2": [
+      {
+        "cask": "suunto-moveslink2",
+        "count": "4"
+      }
+    ],
+    "svgcleaner": [
+      {
+        "cask": "svgcleaner",
+        "count": "8"
+      }
+    ],
+    "svnx": [
+      {
+        "cask": "svnx",
+        "count": "141"
+      }
+    ],
+    "sweet-home3d": [
+      {
+        "cask": "sweet-home3d",
+        "count": "106"
+      }
+    ],
+    "swift": [
+      {
+        "cask": "swift",
+        "count": "19"
+      }
+    ],
+    "swift-explorer": [
+      {
+        "cask": "swift-explorer",
+        "count": "1"
+      }
+    ],
+    "swift-publisher": [
+      {
+        "cask": "swift-publisher",
+        "count": "5"
+      }
+    ],
+    "swiftdefaultappsprefpane": [
+      {
+        "cask": "swiftdefaultappsprefpane",
+        "count": "64"
+      }
+    ],
+    "swiftformat-for-xcode": [
+      {
+        "cask": "swiftformat-for-xcode",
+        "count": "441"
+      }
+    ],
+    "swiftstack-client": [
+      {
+        "cask": "swiftstack-client",
+        "count": "5"
+      }
+    ],
+    "swifty": [
+      {
+        "cask": "swifty",
+        "count": "4"
+      }
+    ],
+    "swiftybeaver": [
+      {
+        "cask": "swiftybeaver",
+        "count": "9"
+      }
+    ],
+    "swimat": [
+      {
+        "cask": "swimat",
+        "count": "150"
+      }
+    ],
+    "swinsian": [
+      {
+        "cask": "swinsian",
+        "count": "14"
+      }
+    ],
+    "swish": [
+      {
+        "cask": "swish",
+        "count": "29"
+      }
+    ],
+    "switch": [
+      {
+        "cask": "switch",
+        "count": "6"
+      }
+    ],
+    "switchhosts": [
+      {
+        "cask": "switchhosts",
+        "count": "202"
+      }
+    ],
+    "switchkey": [
+      {
+        "cask": "switchkey",
+        "count": "35"
+      }
+    ],
+    "switchresx": [
+      {
+        "cask": "switchresx",
+        "count": "169"
+      }
+    ],
+    "symboliclinker": [
+      {
+        "cask": "symboliclinker",
+        "count": "14"
+      }
+    ],
+    "synalyze-it-pro": [
+      {
+        "cask": "synalyze-it-pro",
+        "count": "10"
+      }
+    ],
+    "sync": [
+      {
+        "cask": "sync",
+        "count": "28"
+      }
+    ],
+    "sync-my-l2p": [
+      {
+        "cask": "sync-my-l2p",
+        "count": "1"
+      }
+    ],
+    "syncmate": [
+      {
+        "cask": "syncmate",
+        "count": "8"
+      }
+    ],
+    "syncovery": [
+      {
+        "cask": "syncovery",
+        "count": "3"
+      }
+    ],
+    "syncplay": [
+      {
+        "cask": "syncplay",
+        "count": "37"
+      }
+    ],
+    "syncterm": [
+      {
+        "cask": "syncterm",
+        "count": "3"
+      }
+    ],
+    "syncthing": [
+      {
+        "cask": "syncthing",
+        "count": "296"
+      }
+    ],
+    "syncthing-brewbar": [
+      {
+        "cask": "syncthing-brewbar",
+        "count": "3"
+      }
+    ],
+    "syncwalkman": [
+      {
+        "cask": "syncwalkman",
+        "count": "3"
+      }
+    ],
+    "synergy": [
+      {
+        "cask": "synergy",
+        "count": "422"
+      }
+    ],
+    "synergy-beta": [
+      {
+        "cask": "synergy-beta",
+        "count": "22"
+      }
+    ],
+    "synfigstudio": [
+      {
+        "cask": "synfigstudio",
+        "count": "15"
+      }
+    ],
+    "synology-assistant": [
+      {
+        "cask": "synology-assistant",
+        "count": "6"
+      }
+    ],
+    "synology-chat": [
+      {
+        "cask": "synology-chat",
+        "count": "6"
+      }
+    ],
+    "synology-cloud-station-backup": [
+      {
+        "cask": "synology-cloud-station-backup",
+        "count": "9"
+      }
+    ],
+    "synology-drive": [
+      {
+        "cask": "synology-drive",
+        "count": "117"
+      }
+    ],
+    "synology-drive-client": [
+      {
+        "cask": "synology-drive-client",
+        "count": "6"
+      }
+    ],
+    "synology-note-station-client": [
+      {
+        "cask": "synology-note-station-client",
+        "count": "18"
+      }
+    ],
+    "synology-photo-station-uploader": [
+      {
+        "cask": "synology-photo-station-uploader",
+        "count": "5"
+      }
+    ],
+    "synology-surveillance-station-client": [
+      {
+        "cask": "synology-surveillance-station-client",
+        "count": "8"
+      }
+    ],
+    "synologyassistant": [
+      {
+        "cask": "synologyassistant",
+        "count": "20"
+      }
+    ],
+    "syntax-highlight": [
+      {
+        "cask": "syntax-highlight",
+        "count": "19"
+      }
+    ],
+    "synthesia": [
+      {
+        "cask": "synthesia",
+        "count": "12"
+      }
+    ],
+    "sysdig-inspect": [
+      {
+        "cask": "sysdig-inspect",
+        "count": "5"
+      }
+    ],
+    "sysex-librarian": [
+      {
+        "cask": "sysex-librarian",
+        "count": "9"
+      }
+    ],
+    "systemupdate": [
+      {
+        "cask": "systemupdate",
+        "count": "2"
+      }
+    ],
+    "systhist": [
+      {
+        "cask": "systhist",
+        "count": "1"
+      }
+    ],
+    "t2m2": [
+      {
+        "cask": "t2m2",
+        "count": "3"
+      }
+    ],
+    "table-tool": [
+      {
+        "cask": "table-tool",
+        "count": "34"
+      }
+    ],
+    "tableau": [
+      {
+        "cask": "tableau",
+        "count": "115"
+      }
+    ],
+    "tableau-prep": [
+      {
+        "cask": "tableau-prep",
+        "count": "21"
+      }
+    ],
+    "tableau-public": [
+      {
+        "cask": "tableau-public",
+        "count": "40"
+      }
+    ],
+    "tableau-reader": [
+      {
+        "cask": "tableau-reader",
+        "count": "12"
+      }
+    ],
+    "tableflip": [
+      {
+        "cask": "tableflip",
+        "count": "7"
+      }
+    ],
+    "tableplus": [
+      {
+        "cask": "tableplus",
+        "count": "835"
+      }
+    ],
+    "tabula": [
+      {
+        "cask": "tabula",
+        "count": "32"
+      }
+    ],
+    "taccy": [
+      {
+        "cask": "taccy",
+        "count": "1"
+      }
+    ],
+    "tad": [
+      {
+        "cask": "tad",
+        "count": "20"
+      }
+    ],
+    "tag": [
+      {
+        "cask": "tag",
+        "count": "3"
+      }
+    ],
+    "tagger": [
+      {
+        "cask": "tagger",
+        "count": "6"
+      }
+    ],
+    "tagspaces": [
+      {
+        "cask": "tagspaces",
+        "count": "10"
+      }
+    ],
+    "tales-of-majeyal": [
+      {
+        "cask": "tales-of-majeyal",
+        "count": "8"
+      }
+    ],
+    "talon": [
+      {
+        "cask": "talon",
+        "count": "5"
+      }
+    ],
+    "tandem": [
+      {
+        "cask": "tandem",
+        "count": "70"
+      }
+    ],
+    "tap": [
+      {
+        "cask": "tap",
+        "count": "3"
+      }
+    ],
+    "taskade": [
+      {
+        "cask": "taskade",
+        "count": "7"
+      }
+    ],
+    "taskexplorer": [
+      {
+        "cask": "taskexplorer",
+        "count": "37"
+      }
+    ],
+    "taskpaper": [
+      {
+        "cask": "taskpaper",
+        "count": "22"
+      }
+    ],
+    "taskquor": [
+      {
+        "cask": "taskquor",
+        "count": "5"
+      }
+    ],
+    "taskwarrior-pomodoro": [
+      {
+        "cask": "taskwarrior-pomodoro",
+        "count": "44"
+      }
+    ],
+    "tastyworks": [
+      {
+        "cask": "tastyworks",
+        "count": "13"
+      }
+    ],
+    "tau": [
+      {
+        "cask": "tau",
+        "count": "3"
+      }
+    ],
+    "tcl": [
+      {
+        "cask": "tcl",
+        "count": "194"
+      }
+    ],
+    "td-agent": [
+      {
+        "cask": "td-agent",
+        "count": "21"
+      }
+    ],
+    "teacode": [
+      {
+        "cask": "teacode",
+        "count": "4"
+      }
+    ],
+    "teambition": [
+      {
+        "cask": "teambition",
+        "count": "13"
+      }
+    ],
+    "teamdrive": [
+      {
+        "cask": "teamdrive",
+        "count": "2"
+      }
+    ],
+    "teamspeak-client": [
+      {
+        "cask": "teamspeak-client",
+        "count": "141"
+      }
+    ],
+    "teamviewer": [
+      {
+        "cask": "teamviewer",
+        "count": "2,393"
+      }
+    ],
+    "teamviewer-host": [
+      {
+        "cask": "teamviewer-host",
+        "count": "14"
+      }
+    ],
+    "teamviewer-quickjoin": [
+      {
+        "cask": "teamviewer-quickjoin",
+        "count": "18"
+      }
+    ],
+    "teamviewer-quicksupport": [
+      {
+        "cask": "teamviewer-quicksupport",
+        "count": "21"
+      }
+    ],
+    "teamviewer8": [
+      {
+        "cask": "teamviewer8",
+        "count": "1"
+      }
+    ],
+    "teensy": [
+      {
+        "cask": "teensy",
+        "count": "46"
+      }
+    ],
+    "teeworlds": [
+      {
+        "cask": "teeworlds",
+        "count": "20"
+      }
+    ],
+    "telavox-flow": [
+      {
+        "cask": "telavox-flow",
+        "count": "2"
+      }
+    ],
+    "telegram": [
+      {
+        "cask": "telegram",
+        "count": "2,294"
+      }
+    ],
+    "telegram-desktop": [
+      {
+        "cask": "telegram-desktop",
+        "count": "581"
+      }
+    ],
+    "telegram-desktop-dev": [
+      {
+        "cask": "telegram-desktop-dev",
+        "count": "31"
+      }
+    ],
+    "tempo": [
+      {
+        "cask": "tempo",
+        "count": "17"
+      }
+    ],
+    "tencent-lemon": [
+      {
+        "cask": "tencent-lemon",
+        "count": "134"
+      }
+    ],
+    "tencent-meeting": [
+      {
+        "cask": "tencent-meeting",
+        "count": "7"
+      }
+    ],
+    "tenor": [
+      {
+        "cask": "tenor",
+        "count": "3"
+      }
+    ],
+    "termhere": [
+      {
+        "cask": "termhere",
+        "count": "12"
+      }
+    ],
+    "terminology": [
+      {
+        "cask": "terminology",
+        "count": "30"
+      }
+    ],
+    "terminus": [
+      {
+        "cask": "terminus",
+        "count": "216"
+      }
+    ],
+    "termius": [
+      {
+        "cask": "termius",
+        "count": "217"
+      }
+    ],
+    "termius-beta": [
+      {
+        "cask": "termius-beta",
+        "count": "5"
+      }
+    ],
+    "terraform-0.10.0": [
+      {
+        "cask": "terraform-0.10.0",
+        "count": "1"
+      }
+    ],
+    "terraform-0.10.7": [
+      {
+        "cask": "terraform-0.10.7",
+        "count": "1"
+      }
+    ],
+    "terraform-0.10.8": [
+      {
+        "cask": "terraform-0.10.8",
+        "count": "4"
+      }
+    ],
+    "terraform-0.11.10": [
+      {
+        "cask": "terraform-0.11.10",
+        "count": "2"
+      }
+    ],
+    "terraform-0.11.11": [
+      {
+        "cask": "terraform-0.11.11",
+        "count": "4"
+      }
+    ],
+    "terraform-0.11.13": [
+      {
+        "cask": "terraform-0.11.13",
+        "count": "2"
+      }
+    ],
+    "terraform-0.11.14": [
+      {
+        "cask": "terraform-0.11.14",
+        "count": "19"
+      }
+    ],
+    "terraform-0.11.3": [
+      {
+        "cask": "terraform-0.11.3",
+        "count": "3"
+      }
+    ],
+    "terraform-0.11.5": [
+      {
+        "cask": "terraform-0.11.5",
+        "count": "1"
+      }
+    ],
+    "terraform-0.11.7": [
+      {
+        "cask": "terraform-0.11.7",
+        "count": "1"
+      }
+    ],
+    "terraform-0.11.8": [
+      {
+        "cask": "terraform-0.11.8",
+        "count": "7"
+      }
+    ],
+    "terraform-0.11.9": [
+      {
+        "cask": "terraform-0.11.9",
+        "count": "2"
+      }
+    ],
+    "terraform-0.12.0": [
+      {
+        "cask": "terraform-0.12.0",
+        "count": "5"
+      }
+    ],
+    "terraform-0.12.13": [
+      {
+        "cask": "terraform-0.12.13",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.14": [
+      {
+        "cask": "terraform-0.12.14",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.17": [
+      {
+        "cask": "terraform-0.12.17",
+        "count": "3"
+      }
+    ],
+    "terraform-0.12.18": [
+      {
+        "cask": "terraform-0.12.18",
+        "count": "3"
+      }
+    ],
+    "terraform-0.12.19": [
+      {
+        "cask": "terraform-0.12.19",
+        "count": "4"
+      }
+    ],
+    "terraform-0.12.20": [
+      {
+        "cask": "terraform-0.12.20",
+        "count": "10"
+      }
+    ],
+    "terraform-0.12.21": [
+      {
+        "cask": "terraform-0.12.21",
+        "count": "7"
+      }
+    ],
+    "terraform-0.12.23": [
+      {
+        "cask": "terraform-0.12.23",
+        "count": "22"
+      }
+    ],
+    "terraform-0.12.24": [
+      {
+        "cask": "terraform-0.12.24",
+        "count": "105"
+      }
+    ],
+    "terraform-0.12.3": [
+      {
+        "cask": "terraform-0.12.3",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.4": [
+      {
+        "cask": "terraform-0.12.4",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.5": [
+      {
+        "cask": "terraform-0.12.5",
+        "count": "2"
+      }
+    ],
+    "terraform-0.12.6": [
+      {
+        "cask": "terraform-0.12.6",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.8": [
+      {
+        "cask": "terraform-0.12.8",
+        "count": "3"
+      }
+    ],
+    "terraform-0.12.9": [
+      {
+        "cask": "terraform-0.12.9",
+        "count": "5"
+      }
+    ],
+    "terraform-0.8.8": [
+      {
+        "cask": "terraform-0.8.8",
+        "count": "1"
+      }
+    ],
+    "terraform-0.9.5": [
+      {
+        "cask": "terraform-0.9.5",
+        "count": "1"
+      }
+    ],
+    "test": [
+      {
+        "cask": "test",
+        "count": "1"
+      }
+    ],
+    "test-formula": [
+      {
+        "cask": "test-formula",
+        "count": "5"
+      }
+    ],
+    "tex-live-utility": [
+      {
+        "cask": "tex-live-utility",
+        "count": "381"
+      }
+    ],
+    "texmacs": [
+      {
+        "cask": "texmacs",
+        "count": "49"
+      }
+    ],
+    "texmaker": [
+      {
+        "cask": "texmaker",
+        "count": "352"
+      }
+    ],
+    "texpad": [
+      {
+        "cask": "texpad",
+        "count": "66"
+      }
+    ],
+    "texshop": [
+      {
+        "cask": "texshop",
+        "count": "127"
+      }
+    ],
+    "texstudio": [
+      {
+        "cask": "texstudio",
+        "count": "435"
+      }
+    ],
+    "textadept": [
+      {
+        "cask": "textadept",
+        "count": "12"
+      }
+    ],
+    "textbar": [
+      {
+        "cask": "textbar",
+        "count": "6"
+      }
+    ],
+    "textexpander": [
+      {
+        "cask": "textexpander",
+        "count": "68"
+      }
+    ],
+    "textmate": [
+      {
+        "cask": "textmate",
+        "count": "619"
+      }
+    ],
+    "textmate-crystal": [
+      {
+        "cask": "textmate-crystal",
+        "count": "3"
+      }
+    ],
+    "textmate-cucumber": [
+      {
+        "cask": "textmate-cucumber",
+        "count": "3"
+      }
+    ],
+    "textmate-editorconfig": [
+      {
+        "cask": "textmate-editorconfig",
+        "count": "3"
+      }
+    ],
+    "textmate-elixir": [
+      {
+        "cask": "textmate-elixir",
+        "count": "3"
+      }
+    ],
+    "textmate-fish": [
+      {
+        "cask": "textmate-fish",
+        "count": "3"
+      }
+    ],
+    "textmate-glsl": [
+      {
+        "cask": "textmate-glsl",
+        "count": "3"
+      }
+    ],
+    "textmate-javascript-babel": [
+      {
+        "cask": "textmate-javascript-babel",
+        "count": "3"
+      }
+    ],
+    "textmate-javascript-eslint": [
+      {
+        "cask": "textmate-javascript-eslint",
+        "count": "3"
+      }
+    ],
+    "textmate-onsave": [
+      {
+        "cask": "textmate-onsave",
+        "count": "3"
+      }
+    ],
+    "textmate-opencl": [
+      {
+        "cask": "textmate-opencl",
+        "count": "3"
+      }
+    ],
+    "textmate-openhab": [
+      {
+        "cask": "textmate-openhab",
+        "count": "3"
+      }
+    ],
+    "textmate-preview": [
+      {
+        "cask": "textmate-preview",
+        "count": "9"
+      }
+    ],
+    "textmate-rubocop": [
+      {
+        "cask": "textmate-rubocop",
+        "count": "3"
+      }
+    ],
+    "textmate-rust": [
+      {
+        "cask": "textmate-rust",
+        "count": "3"
+      }
+    ],
+    "textmate-solarized": [
+      {
+        "cask": "textmate-solarized",
+        "count": "3"
+      }
+    ],
+    "texts": [
+      {
+        "cask": "texts",
+        "count": "4"
+      }
+    ],
+    "textual": [
+      {
+        "cask": "textual",
+        "count": "84"
+      }
+    ],
+    "texturepacker": [
+      {
+        "cask": "texturepacker",
+        "count": "18"
+      }
+    ],
+    "texworks": [
+      {
+        "cask": "texworks",
+        "count": "61"
+      }
+    ],
+    "tftpserver": [
+      {
+        "cask": "tftpserver",
+        "count": "72"
+      }
+    ],
+    "tg-pro": [
+      {
+        "cask": "tg-pro",
+        "count": "33"
+      }
+    ],
+    "th-makerx": [
+      {
+        "cask": "th-makerx",
+        "count": "3"
+      }
+    ],
+    "the-archive-browser": [
+      {
+        "cask": "the-archive-browser",
+        "count": "9"
+      }
+    ],
+    "the-battle-for-wesnoth": [
+      {
+        "cask": "the-battle-for-wesnoth",
+        "count": "21"
+      }
+    ],
+    "the-cheat": [
+      {
+        "cask": "the-cheat",
+        "count": "5"
+      }
+    ],
+    "the-clock": [
+      {
+        "cask": "the-clock",
+        "count": "2"
+      }
+    ],
+    "the-tagger": [
+      {
+        "cask": "the-tagger",
+        "count": "14"
+      }
+    ],
+    "the-unarchiver": [
+      {
+        "cask": "the-unarchiver",
+        "count": "2,250"
+      }
+    ],
+    "thebrain": [
+      {
+        "cask": "thebrain",
+        "count": "14"
+      }
+    ],
+    "thedesk": [
+      {
+        "cask": "thedesk",
+        "count": "12"
+      }
+    ],
+    "themeengine": [
+      {
+        "cask": "themeengine",
+        "count": "3"
+      }
+    ],
+    "there": [
+      {
+        "cask": "there",
+        "count": "35"
+      }
+    ],
+    "therm": [
+      {
+        "cask": "therm",
+        "count": "27"
+      }
+    ],
+    "thetube": [
+      {
+        "cask": "thetube",
+        "count": "1"
+      }
+    ],
+    "thingsmacsandboxhelper": [
+      {
+        "cask": "thingsmacsandboxhelper",
+        "count": "22"
+      }
+    ],
+    "thinkorswim": [
+      {
+        "cask": "thinkorswim",
+        "count": "41"
+      }
+    ],
+    "thonny": [
+      {
+        "cask": "thonny",
+        "count": "16"
+      }
+    ],
+    "thonny-xxl": [
+      {
+        "cask": "thonny-xxl",
+        "count": "2"
+      }
+    ],
+    "thor": [
+      {
+        "cask": "thor",
+        "count": "29"
+      }
+    ],
+    "thought-train": [
+      {
+        "cask": "thought-train",
+        "count": "9"
+      }
+    ],
+    "threads": [
+      {
+        "cask": "threads",
+        "count": "4"
+      }
+    ],
+    "thumbsup": [
+      {
+        "cask": "thumbsup",
+        "count": "3"
+      }
+    ],
+    "thunder": [
+      {
+        "cask": "thunder",
+        "count": "394"
+      }
+    ],
+    "thunderbird": [
+      {
+        "cask": "thunderbird",
+        "count": "838"
+      }
+    ],
+    "thunderbird-beta": [
+      {
+        "cask": "thunderbird-beta",
+        "count": "18"
+      }
+    ],
+    "thunderbird-daily": [
+      {
+        "cask": "thunderbird-daily",
+        "count": "5"
+      }
+    ],
+    "thyme": [
+      {
+        "cask": "thyme",
+        "count": "14"
+      }
+    ],
+    "ti-connect-ce": [
+      {
+        "cask": "ti-connect-ce",
+        "count": "6"
+      }
+    ],
+    "tibco-jaspersoft-studio": [
+      {
+        "cask": "tibco-jaspersoft-studio",
+        "count": "33"
+      }
+    ],
+    "tickeys": [
+      {
+        "cask": "tickeys",
+        "count": "64"
+      }
+    ],
+    "ticktick": [
+      {
+        "cask": "ticktick",
+        "count": "120"
+      }
+    ],
+    "tidal": [
+      {
+        "cask": "tidal",
+        "count": "164"
+      }
+    ],
+    "tiddly": [
+      {
+        "cask": "tiddly",
+        "count": "21"
+      }
+    ],
+    "tidepool-uploader": [
+      {
+        "cask": "tidepool-uploader",
+        "count": "2"
+      }
+    ],
+    "tifig": [
+      {
+        "cask": "tifig",
+        "count": "7"
+      }
+    ],
+    "tiger-trade": [
+      {
+        "cask": "tiger-trade",
+        "count": "6"
+      }
+    ],
+    "tigervnc-viewer": [
+      {
+        "cask": "tigervnc-viewer",
+        "count": "659"
+      }
+    ],
+    "tigervpn": [
+      {
+        "cask": "tigervpn",
+        "count": "7"
+      }
+    ],
+    "tikz-editor": [
+      {
+        "cask": "tikz-editor",
+        "count": "43"
+      }
+    ],
+    "tikzit": [
+      {
+        "cask": "tikzit",
+        "count": "25"
+      }
+    ],
+    "tiled": [
+      {
+        "cask": "tiled",
+        "count": "48"
+      }
+    ],
+    "tiles": [
+      {
+        "cask": "tiles",
+        "count": "116"
+      }
+    ],
+    "time-lapse-assembler": [
+      {
+        "cask": "time-lapse-assembler",
+        "count": "7"
+      }
+    ],
+    "time-out": [
+      {
+        "cask": "time-out",
+        "count": "57"
+      }
+    ],
+    "time-tracker": [
+      {
+        "cask": "time-tracker",
+        "count": "1"
+      }
+    ],
+    "timecamp": [
+      {
+        "cask": "timecamp",
+        "count": "1"
+      }
+    ],
+    "timelane": [
+      {
+        "cask": "timelane",
+        "count": "3"
+      }
+    ],
+    "timely": [
+      {
+        "cask": "timely",
+        "count": "4"
+      }
+    ],
+    "timemachineeditor": [
+      {
+        "cask": "timemachineeditor",
+        "count": "180"
+      }
+    ],
+    "timemator": [
+      {
+        "cask": "timemator",
+        "count": "6"
+      }
+    ],
+    "timer": [
+      {
+        "cask": "timer",
+        "count": "64"
+      }
+    ],
+    "timestamp": [
+      {
+        "cask": "timestamp",
+        "count": "14"
+      }
+    ],
+    "timeular": [
+      {
+        "cask": "timeular",
+        "count": "7"
+      }
+    ],
+    "timing": [
+      {
+        "cask": "timing",
+        "count": "51"
+      }
+    ],
+    "timings": [
+      {
+        "cask": "timings",
+        "count": "1"
+      }
+    ],
+    "tinderbox": [
+      {
+        "cask": "tinderbox",
+        "count": "5"
+      }
+    ],
+    "tinkerwell": [
+      {
+        "cask": "tinkerwell",
+        "count": "18"
+      }
+    ],
+    "tiny-player": [
+      {
+        "cask": "tiny-player",
+        "count": "4"
+      }
+    ],
+    "tinymediamanager": [
+      {
+        "cask": "tinymediamanager",
+        "count": "46"
+      }
+    ],
+    "tinypng4mac": [
+      {
+        "cask": "tinypng4mac",
+        "count": "107"
+      }
+    ],
+    "tipp10": [
+      {
+        "cask": "tipp10",
+        "count": "11"
+      }
+    ],
+    "tiptoi-manager": [
+      {
+        "cask": "tiptoi-manager",
+        "count": "3"
+      }
+    ],
+    "tla-plus-toolbox": [
+      {
+        "cask": "tla-plus-toolbox",
+        "count": "47"
+      }
+    ],
+    "tla-plus-toolbox-nightly": [
+      {
+        "cask": "tla-plus-toolbox-nightly",
+        "count": "2"
+      }
+    ],
+    "tn3270-x": [
+      {
+        "cask": "tn3270-x",
+        "count": "15"
+      }
+    ],
+    "tnefs-enough": [
+      {
+        "cask": "tnefs-enough",
+        "count": "16"
+      }
+    ],
+    "today-scripts": [
+      {
+        "cask": "today-scripts",
+        "count": "3"
+      }
+    ],
+    "todometer": [
+      {
+        "cask": "todometer",
+        "count": "11"
+      }
+    ],
+    "todos": [
+      {
+        "cask": "todos",
+        "count": "1"
+      }
+    ],
+    "todotxt": [
+      {
+        "cask": "todotxt",
+        "count": "15"
+      }
+    ],
+    "todour": [
+      {
+        "cask": "todour",
+        "count": "3"
+      }
+    ],
+    "tofu": [
+      {
+        "cask": "tofu",
+        "count": "1"
+      }
+    ],
+    "toggl": [
+      {
+        "cask": "toggl",
+        "count": "220"
+      }
+    ],
+    "tomighty": [
+      {
+        "cask": "tomighty",
+        "count": "45"
+      }
+    ],
+    "tomtom-sports-connect": [
+      {
+        "cask": "tomtom-sports-connect",
+        "count": "6"
+      }
+    ],
+    "tongbu": [
+      {
+        "cask": "tongbu",
+        "count": "8"
+      }
+    ],
+    "toontown-rewritten": [
+      {
+        "cask": "toontown-rewritten",
+        "count": "6"
+      }
+    ],
+    "topcat": [
+      {
+        "cask": "topcat",
+        "count": "8"
+      }
+    ],
+    "toptracker": [
+      {
+        "cask": "toptracker",
+        "count": "6"
+      }
+    ],
+    "tor-browser": [
+      {
+        "cask": "tor-browser",
+        "count": "1,665"
+      }
+    ],
+    "tor-browser-alpha": [
+      {
+        "cask": "tor-browser-alpha",
+        "count": "12"
+      }
+    ],
+    "torguard": [
+      {
+        "cask": "torguard",
+        "count": "43"
+      }
+    ],
+    "torrent-file-editor": [
+      {
+        "cask": "torrent-file-editor",
+        "count": "7"
+      }
+    ],
+    "tortoisehg": [
+      {
+        "cask": "tortoisehg",
+        "count": "31"
+      }
+    ],
+    "totalspaces": [
+      {
+        "cask": "totalspaces",
+        "count": "2"
+      }
+    ],
+    "touch-bar-pong": [
+      {
+        "cask": "touch-bar-pong",
+        "count": "9"
+      }
+    ],
+    "touch-bar-simulator": [
+      {
+        "cask": "touch-bar-simulator",
+        "count": "72"
+      }
+    ],
+    "touchbarserver": [
+      {
+        "cask": "touchbarserver",
+        "count": "1"
+      }
+    ],
+    "touchdesigner": [
+      {
+        "cask": "touchdesigner",
+        "count": "10"
+      }
+    ],
+    "touchosc-bridge": [
+      {
+        "cask": "touchosc-bridge",
+        "count": "5"
+      }
+    ],
+    "touchosc-editor": [
+      {
+        "cask": "touchosc-editor",
+        "count": "7"
+      }
+    ],
+    "touchswitcher": [
+      {
+        "cask": "touchswitcher",
+        "count": "14"
+      }
+    ],
+    "tower": [
+      {
+        "cask": "tower",
+        "count": "279"
+      }
+    ],
+    "tower2": [
+      {
+        "cask": "tower2",
+        "count": "8"
+      }
+    ],
+    "townwifi": [
+      {
+        "cask": "townwifi",
+        "count": "9"
+      }
+    ],
+    "trader-workstation": [
+      {
+        "cask": "trader-workstation",
+        "count": "13"
+      }
+    ],
+    "trailer": [
+      {
+        "cask": "trailer",
+        "count": "29"
+      }
+    ],
+    "trainerroad": [
+      {
+        "cask": "trainerroad",
+        "count": "6"
+      }
+    ],
+    "transmission": [
+      {
+        "cask": "transmission",
+        "count": "2,261"
+      }
+    ],
+    "transmission-nightly": [
+      {
+        "cask": "transmission-nightly",
+        "count": "22"
+      }
+    ],
+    "transmission-remote-gui": [
+      {
+        "cask": "transmission-remote-gui",
+        "count": "221"
+      }
+    ],
+    "transmit": [
+      {
+        "cask": "transmit",
+        "count": "617"
+      }
+    ],
+    "transmit-disk": [
+      {
+        "cask": "transmit-disk",
+        "count": "5"
+      }
+    ],
+    "transmit4": [
+      {
+        "cask": "transmit4",
+        "count": "3"
+      }
+    ],
+    "transocks": [
+      {
+        "cask": "transocks",
+        "count": "2"
+      }
+    ],
+    "transtype": [
+      {
+        "cask": "transtype",
+        "count": "3"
+      }
+    ],
+    "trash-it": [
+      {
+        "cask": "trash-it",
+        "count": "4"
+      }
+    ],
+    "trayplay": [
+      {
+        "cask": "trayplay",
+        "count": "3"
+      }
+    ],
+    "treesheets": [
+      {
+        "cask": "treesheets",
+        "count": "5"
+      }
+    ],
+    "tresorit": [
+      {
+        "cask": "tresorit",
+        "count": "158"
+      }
+    ],
+    "trezor-bridge": [
+      {
+        "cask": "trezor-bridge",
+        "count": "10"
+      }
+    ],
+    "tribler": [
+      {
+        "cask": "tribler",
+        "count": "10"
+      }
+    ],
+    "trilium-notes": [
+      {
+        "cask": "trilium-notes",
+        "count": "33"
+      }
+    ],
+    "trim-enabler": [
+      {
+        "cask": "trim-enabler",
+        "count": "7"
+      }
+    ],
+    "trinity": [
+      {
+        "cask": "trinity",
+        "count": "6"
+      }
+    ],
+    "triplecheese": [
+      {
+        "cask": "triplecheese",
+        "count": "1"
+      }
+    ],
+    "tripmode": [
+      {
+        "cask": "tripmode",
+        "count": "58"
+      }
+    ],
+    "trojan-qt5": [
+      {
+        "cask": "trojan-qt5",
+        "count": "30"
+      }
+    ],
+    "trolcommander": [
+      {
+        "cask": "trolcommander",
+        "count": "7"
+      }
+    ],
+    "tropy": [
+      {
+        "cask": "tropy",
+        "count": "4"
+      }
+    ],
+    "truecrypt": [
+      {
+        "cask": "truecrypt",
+        "count": "2"
+      }
+    ],
+    "trufont": [
+      {
+        "cask": "trufont",
+        "count": "4"
+      }
+    ],
+    "ttscoff-mmd-quicklook": [
+      {
+        "cask": "ttscoff-mmd-quicklook",
+        "count": "13"
+      }
+    ],
+    "tuck": [
+      {
+        "cask": "tuck",
+        "count": "1"
+      }
+    ],
+    "tuneinstructor": [
+      {
+        "cask": "tuneinstructor",
+        "count": "1"
+      }
+    ],
+    "tuneskit-m4v-converter": [
+      {
+        "cask": "tuneskit-m4v-converter",
+        "count": "5"
+      }
+    ],
+    "tunnelbear": [
+      {
+        "cask": "tunnelbear",
+        "count": "110"
+      }
+    ],
+    "tunnelblick": [
+      {
+        "cask": "tunnelblick",
+        "count": "2,129"
+      }
+    ],
+    "tunnelblick-beta": [
+      {
+        "cask": "tunnelblick-beta",
+        "count": "16"
+      }
+    ],
+    "tuntap": [
+      {
+        "cask": "tuntap",
+        "count": "537"
+      }
+    ],
+    "tuple": [
+      {
+        "cask": "tuple",
+        "count": "99"
+      }
+    ],
+    "turbo-boost-switcher": [
+      {
+        "cask": "turbo-boost-switcher",
+        "count": "200"
+      }
+    ],
+    "turbovnc-viewer": [
+      {
+        "cask": "turbovnc-viewer",
+        "count": "92"
+      }
+    ],
+    "turtl": [
+      {
+        "cask": "turtl",
+        "count": "15"
+      }
+    ],
+    "tusk": [
+      {
+        "cask": "tusk",
+        "count": "21"
+      }
+    ],
+    "tutanota": [
+      {
+        "cask": "tutanota",
+        "count": "27"
+      }
+    ],
+    "tuxera-ntfs": [
+      {
+        "cask": "tuxera-ntfs",
+        "count": "87"
+      }
+    ],
+    "tuxguitar": [
+      {
+        "cask": "tuxguitar",
+        "count": "106"
+      }
+    ],
+    "tv-browser": [
+      {
+        "cask": "tv-browser",
+        "count": "8"
+      }
+    ],
+    "tvrenamer": [
+      {
+        "cask": "tvrenamer",
+        "count": "2"
+      }
+    ],
+    "tweet-tray": [
+      {
+        "cask": "tweet-tray",
+        "count": "2"
+      }
+    ],
+    "tweetbot": [
+      {
+        "cask": "tweetbot",
+        "count": "59"
+      }
+    ],
+    "tweeten": [
+      {
+        "cask": "tweeten",
+        "count": "17"
+      }
+    ],
+    "twine": [
+      {
+        "cask": "twine",
+        "count": "125"
+      }
+    ],
+    "twist": [
+      {
+        "cask": "twist",
+        "count": "18"
+      }
+    ],
+    "twitch": [
+      {
+        "cask": "twitch",
+        "count": "241"
+      }
+    ],
+    "twitter-mini": [
+      {
+        "cask": "twitter-mini",
+        "count": "1"
+      }
+    ],
+    "twonkyserver": [
+      {
+        "cask": "twonkyserver",
+        "count": "1"
+      }
+    ],
+    "tyke": [
+      {
+        "cask": "tyke",
+        "count": "9"
+      }
+    ],
+    "typeface": [
+      {
+        "cask": "typeface",
+        "count": "4"
+      }
+    ],
+    "typeit4me": [
+      {
+        "cask": "typeit4me",
+        "count": "1"
+      }
+    ],
+    "typinator": [
+      {
+        "cask": "typinator",
+        "count": "21"
+      }
+    ],
+    "typora": [
+      {
+        "cask": "typora",
+        "count": "1,134"
+      }
+    ],
+    "tysimulator": [
+      {
+        "cask": "tysimulator",
+        "count": "1"
+      }
+    ],
+    "ubar": [
+      {
+        "cask": "ubar",
+        "count": "34"
+      }
+    ],
+    "uberconference": [
+      {
+        "cask": "uberconference",
+        "count": "3"
+      }
+    ],
+    "ubersicht": [
+      {
+        "cask": "ubersicht",
+        "count": "164"
+      }
+    ],
+    "ubiquiti-unifi-controller": [
+      {
+        "cask": "ubiquiti-unifi-controller",
+        "count": "70"
+      }
+    ],
+    "ubiquiti-unifi-controller-lts": [
+      {
+        "cask": "ubiquiti-unifi-controller-lts",
+        "count": "6"
+      }
+    ],
+    "udeler": [
+      {
+        "cask": "udeler",
+        "count": "18"
+      }
+    ],
+    "udig": [
+      {
+        "cask": "udig",
+        "count": "3"
+      }
+    ],
+    "ueli": [
+      {
+        "cask": "ueli",
+        "count": "25"
+      }
+    ],
+    "uhe-diva": [
+      {
+        "cask": "uhe-diva",
+        "count": "4"
+      }
+    ],
+    "uhe-zebra": [
+      {
+        "cask": "uhe-zebra",
+        "count": "5"
+      }
+    ],
+    "uhk-agent": [
+      {
+        "cask": "uhk-agent",
+        "count": "9"
+      }
+    ],
+    "ui-browser": [
+      {
+        "cask": "ui-browser",
+        "count": "11"
+      }
+    ],
+    "uielementinspector": [
+      {
+        "cask": "uielementinspector",
+        "count": "1"
+      }
+    ],
+    "ukelele": [
+      {
+        "cask": "ukelele",
+        "count": "84"
+      }
+    ],
+    "ukrainian-unicode-layout": [
+      {
+        "cask": "ukrainian-unicode-layout",
+        "count": "8"
+      }
+    ],
+    "ulbow": [
+      {
+        "cask": "ulbow",
+        "count": "2"
+      }
+    ],
+    "ultimaker-cura": [
+      {
+        "cask": "ultimaker-cura",
+        "count": "310"
+      }
+    ],
+    "ultimate": [
+      {
+        "cask": "ultimate",
+        "count": "3"
+      }
+    ],
+    "ultimate-control": [
+      {
+        "cask": "ultimate-control",
+        "count": "2"
+      }
+    ],
+    "ultrastardeluxe": [
+      {
+        "cask": "ultrastardeluxe",
+        "count": "8"
+      }
+    ],
+    "uncolored": [
+      {
+        "cask": "uncolored",
+        "count": "2"
+      }
+    ],
+    "uncrustifyx": [
+      {
+        "cask": "uncrustifyx",
+        "count": "3"
+      }
+    ],
+    "understand": [
+      {
+        "cask": "understand",
+        "count": "28"
+      }
+    ],
+    "unetbootin": [
+      {
+        "cask": "unetbootin",
+        "count": "682"
+      }
+    ],
+    "uni": [
+      {
+        "cask": "uni",
+        "count": "1"
+      }
+    ],
+    "unicodechecker": [
+      {
+        "cask": "unicodechecker",
+        "count": "18"
+      }
+    ],
+    "uniconverter": [
+      {
+        "cask": "uniconverter",
+        "count": "24"
+      }
+    ],
+    "unified-remote": [
+      {
+        "cask": "unified-remote",
+        "count": "14"
+      }
+    ],
+    "uninstallpkg": [
+      {
+        "cask": "uninstallpkg",
+        "count": "48"
+      }
+    ],
+    "unison": [
+      {
+        "cask": "unison",
+        "count": "102"
+      }
+    ],
+    "unison248": [
+      {
+        "cask": "unison248",
+        "count": "1"
+      }
+    ],
+    "unite": [
+      {
+        "cask": "unite",
+        "count": "20"
+      }
+    ],
+    "unity": [
+      {
+        "cask": "unity",
+        "count": "295"
+      }
+    ],
+    "unity-android-support-for-editor": [
+      {
+        "cask": "unity-android-support-for-editor",
+        "count": "17"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.17f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.17f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.3f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.3f1",
+        "count": "10"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.9f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity-download-assistant": [
+      {
+        "cask": "unity-download-assistant",
+        "count": "22"
+      }
+    ],
+    "unity-hub": [
+      {
+        "cask": "unity-hub",
+        "count": "303"
+      }
+    ],
+    "unity-ios-support-for-editor": [
+      {
+        "cask": "unity-ios-support-for-editor",
+        "count": "24"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.17f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.17f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.3f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.3f1",
+        "count": "10"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.7f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.8f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.9f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity-lumin-support-for-editor": [
+      {
+        "cask": "unity-lumin-support-for-editor",
+        "count": "10"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-standard-assets": [
+      {
+        "cask": "unity-standard-assets",
+        "count": "3"
+      }
+    ],
+    "unity-web-player": [
+      {
+        "cask": "unity-web-player",
+        "count": "3"
+      }
+    ],
+    "unity-webgl-support-for-editor": [
+      {
+        "cask": "unity-webgl-support-for-editor",
+        "count": "16"
+      }
+    ],
+    "unity-webgl-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-webgl-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2018.4.13f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-support-for-editor": [
+      {
+        "cask": "unity-windows-support-for-editor",
+        "count": "13"
+      }
+    ],
+    "unity-windows-support-for-editor@2017.4.20f2": [
+      {
+        "cask": "unity-windows-support-for-editor@2017.4.20f2",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.20f2": [
+      {
+        "cask": "unity@2017.4.20f2",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.28f1": [
+      {
+        "cask": "unity@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.12f1": [
+      {
+        "cask": "unity@2018.4.12f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.4.13f1": [
+      {
+        "cask": "unity@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.14f1": [
+      {
+        "cask": "unity@2018.4.14f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.15f1": [
+      {
+        "cask": "unity@2018.4.15f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.17f1": [
+      {
+        "cask": "unity@2018.4.17f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.20f1": [
+      {
+        "cask": "unity@2018.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.21f1": [
+      {
+        "cask": "unity@2018.4.21f1",
+        "count": "19"
+      }
+    ],
+    "unity@2018.4.2f1": [
+      {
+        "cask": "unity@2018.4.2f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.3f1": [
+      {
+        "cask": "unity@2018.4.3f1",
+        "count": "10"
+      }
+    ],
+    "unity@2019.3.10f1": [
+      {
+        "cask": "unity@2019.3.10f1",
+        "count": "3"
+      }
+    ],
+    "unity@2019.3.7f1": [
+      {
+        "cask": "unity@2019.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.8f1": [
+      {
+        "cask": "unity@2019.3.8f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.9f1": [
+      {
+        "cask": "unity@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity@2020.1.0b6": [
+      {
+        "cask": "unity@2020.1.0b6",
+        "count": "1"
+      }
+    ],
+    "unity@5.6.4f1": [
+      {
+        "cask": "unity@5.6.4f1",
+        "count": "1"
+      }
+    ],
+    "universal-media-server": [
+      {
+        "cask": "universal-media-server",
+        "count": "47"
+      }
+    ],
+    "unlox": [
+      {
+        "cask": "unlox",
+        "count": "16"
+      }
+    ],
+    "unofficial-wineskin": [
+      {
+        "cask": "unofficial-wineskin",
+        "count": "2"
+      }
+    ],
+    "unpkg": [
+      {
+        "cask": "unpkg",
+        "count": "31"
+      }
+    ],
+    "unshaky": [
+      {
+        "cask": "unshaky",
+        "count": "53"
+      }
+    ],
+    "upic": [
+      {
+        "cask": "upic",
+        "count": "393"
+      }
+    ],
+    "upm": [
+      {
+        "cask": "upm",
+        "count": "3"
+      }
+    ],
+    "upterm": [
+      {
+        "cask": "upterm",
+        "count": "50"
+      }
+    ],
+    "upwork": [
+      {
+        "cask": "upwork",
+        "count": "39"
+      }
+    ],
+    "urbanterror": [
+      {
+        "cask": "urbanterror",
+        "count": "1"
+      }
+    ],
+    "usage": [
+      {
+        "cask": "usage",
+        "count": "12"
+      }
+    ],
+    "usb-overdrive": [
+      {
+        "cask": "usb-overdrive",
+        "count": "55"
+      }
+    ],
+    "use-engine": [
+      {
+        "cask": "use-engine",
+        "count": "209"
+      }
+    ],
+    "utc-menu-clock": [
+      {
+        "cask": "utc-menu-clock",
+        "count": "41"
+      }
+    ],
+    "utools": [
+      {
+        "cask": "utools",
+        "count": "53"
+      }
+    ],
+    "utox": [
+      {
+        "cask": "utox",
+        "count": "14"
+      }
+    ],
+    "uu-booster": [
+      {
+        "cask": "uu-booster",
+        "count": "34"
+      }
+    ],
+    "uxprotect": [
+      {
+        "cask": "uxprotect",
+        "count": "2"
+      }
+    ],
+    "v2rayu": [
+      {
+        "cask": "v2rayu",
+        "count": "709"
+      }
+    ],
+    "v2rayx": [
+      {
+        "cask": "v2rayx",
+        "count": "358"
+      }
+    ],
+    "vagrant": [
+      {
+        "cask": "vagrant",
+        "count": "7,004"
+      }
+    ],
+    "vagrant-1.8.7": [
+      {
+        "cask": "vagrant-1.8.7",
+        "count": "1"
+      }
+    ],
+    "vagrant-manager": [
+      {
+        "cask": "vagrant-manager",
+        "count": "1,058"
+      }
+    ],
+    "vagrant-vmware-utility": [
+      {
+        "cask": "vagrant-vmware-utility",
+        "count": "119"
+      }
+    ],
+    "valentina-studio": [
+      {
+        "cask": "valentina-studio",
+        "count": "70"
+      }
+    ],
+    "valley": [
+      {
+        "cask": "valley",
+        "count": "6"
+      }
+    ],
+    "vanilla": [
+      {
+        "cask": "vanilla",
+        "count": "252"
+      }
+    ],
+    "vapor": [
+      {
+        "cask": "vapor",
+        "count": "19"
+      }
+    ],
+    "vassal": [
+      {
+        "cask": "vassal",
+        "count": "36"
+      }
+    ],
+    "vault@1.3.0": [
+      {
+        "cask": "vault@1.3.0",
+        "count": "1"
+      }
+    ],
+    "vbox-6-0-16": [
+      {
+        "cask": "vbox-6-0-16",
+        "count": "2"
+      }
+    ],
+    "vcv-rack": [
+      {
+        "cask": "vcv-rack",
+        "count": "46"
+      }
+    ],
+    "vectr": [
+      {
+        "cask": "vectr",
+        "count": "77"
+      }
+    ],
+    "vellum": [
+      {
+        "cask": "vellum",
+        "count": "1"
+      }
+    ],
+    "veonim": [
+      {
+        "cask": "veonim",
+        "count": "12"
+      }
+    ],
+    "veracrypt": [
+      {
+        "cask": "veracrypt",
+        "count": "326"
+      }
+    ],
+    "versions": [
+      {
+        "cask": "versions",
+        "count": "23"
+      }
+    ],
+    "vesta": [
+      {
+        "cask": "vesta",
+        "count": "17"
+      }
+    ],
+    "veusz": [
+      {
+        "cask": "veusz",
+        "count": "9"
+      }
+    ],
+    "viber": [
+      {
+        "cask": "viber",
+        "count": "270"
+      }
+    ],
+    "vidcutter": [
+      {
+        "cask": "vidcutter",
+        "count": "19"
+      }
+    ],
+    "videostream": [
+      {
+        "cask": "videostream",
+        "count": "30"
+      }
+    ],
+    "vidrio": [
+      {
+        "cask": "vidrio",
+        "count": "13"
+      }
+    ],
+    "vidyo": [
+      {
+        "cask": "vidyo",
+        "count": "3"
+      }
+    ],
+    "vienna": [
+      {
+        "cask": "vienna",
+        "count": "111"
+      }
+    ],
+    "vimac": [
+      {
+        "cask": "vimac",
+        "count": "1"
+      }
+    ],
+    "vimediamanager": [
+      {
+        "cask": "vimediamanager",
+        "count": "3"
+      }
+    ],
+    "vimr": [
+      {
+        "cask": "vimr",
+        "count": "301"
+      }
+    ],
+    "vin047-abgx360": [
+      {
+        "cask": "vin047-abgx360",
+        "count": "14"
+      }
+    ],
+    "vip-access": [
+      {
+        "cask": "vip-access",
+        "count": "6"
+      }
+    ],
+    "virtual-ii": [
+      {
+        "cask": "virtual-ii",
+        "count": "2"
+      }
+    ],
+    "virtualbox": [
+      {
+        "cask": "virtualbox",
+        "count": "11,668"
+      }
+    ],
+    "virtualbox-5.2": [
+      {
+        "cask": "virtualbox-5.2",
+        "count": "1"
+      }
+    ],
+    "virtualbox-beta": [
+      {
+        "cask": "virtualbox-beta",
+        "count": "26"
+      }
+    ],
+    "virtualbox-extension-pack": [
+      {
+        "cask": "virtualbox-extension-pack",
+        "count": "1,968"
+      }
+    ],
+    "virtualbox-extension-pack-beta": [
+      {
+        "cask": "virtualbox-extension-pack-beta",
+        "count": "11"
+      }
+    ],
+    "virtualbox-menulet": [
+      {
+        "cask": "virtualbox-menulet",
+        "count": "4"
+      }
+    ],
+    "virtualc64": [
+      {
+        "cask": "virtualc64",
+        "count": "28"
+      }
+    ],
+    "virtualgl": [
+      {
+        "cask": "virtualgl",
+        "count": "11"
+      }
+    ],
+    "virtualhere": [
+      {
+        "cask": "virtualhere",
+        "count": "7"
+      }
+    ],
+    "virtualhereserver": [
+      {
+        "cask": "virtualhereserver",
+        "count": "1"
+      }
+    ],
+    "virtualhostx": [
+      {
+        "cask": "virtualhostx",
+        "count": "2"
+      }
+    ],
+    "virustotaluploader": [
+      {
+        "cask": "virustotaluploader",
+        "count": "13"
+      }
+    ],
+    "viscosity": [
+      {
+        "cask": "viscosity",
+        "count": "348"
+      }
+    ],
+    "visit": [
+      {
+        "cask": "visit",
+        "count": "11"
+      }
+    ],
+    "visual": [
+      {
+        "cask": "visual",
+        "count": "9"
+      }
+    ],
+    "visual-paradigm": [
+      {
+        "cask": "visual-paradigm",
+        "count": "21"
+      }
+    ],
+    "visual-paradigm-ce": [
+      {
+        "cask": "visual-paradigm-ce",
+        "count": "39"
+      }
+    ],
+    "visual-paradigm-project-viewer": [
+      {
+        "cask": "visual-paradigm-project-viewer",
+        "count": "2"
+      }
+    ],
+    "visual-studio": [
+      {
+        "cask": "visual-studio",
+        "count": "660"
+      }
+    ],
+    "visual-studio-code": [
+      {
+        "cask": "visual-studio-code",
+        "count": "15,648"
+      }
+    ],
+    "visual-studio-code-insiders": [
+      {
+        "cask": "visual-studio-code-insiders",
+        "count": "494"
+      }
+    ],
+    "visualboyadvance-m": [
+      {
+        "cask": "visualboyadvance-m",
+        "count": "19"
+      }
+    ],
+    "visualvm": [
+      {
+        "cask": "visualvm",
+        "count": "425"
+      }
+    ],
+    "vitalsource-bookshelf": [
+      {
+        "cask": "vitalsource-bookshelf",
+        "count": "12"
+      }
+    ],
+    "vitamin-r": [
+      {
+        "cask": "vitamin-r",
+        "count": "8"
+      }
+    ],
+    "vivaldi": [
+      {
+        "cask": "vivaldi",
+        "count": "765"
+      }
+    ],
+    "vivaldi-snapshot": [
+      {
+        "cask": "vivaldi-snapshot",
+        "count": "15"
+      }
+    ],
+    "vivi": [
+      {
+        "cask": "vivi",
+        "count": "1"
+      }
+    ],
+    "vk-messenger": [
+      {
+        "cask": "vk-messenger",
+        "count": "6"
+      }
+    ],
+    "vlc": [
+      {
+        "cask": "vlc",
+        "count": "9,533"
+      }
+    ],
+    "vlc-nightly": [
+      {
+        "cask": "vlc-nightly",
+        "count": "39"
+      }
+    ],
+    "vlc-protocol": [
+      {
+        "cask": "vlc-protocol",
+        "count": "3"
+      }
+    ],
+    "vlc-webplugin": [
+      {
+        "cask": "vlc-webplugin",
+        "count": "59"
+      }
+    ],
+    "vlcstreamer": [
+      {
+        "cask": "vlcstreamer",
+        "count": "28"
+      }
+    ],
+    "vmpk": [
+      {
+        "cask": "vmpk",
+        "count": "8"
+      }
+    ],
+    "vmware-fusion": [
+      {
+        "cask": "vmware-fusion",
+        "count": "798"
+      }
+    ],
+    "vmware-fusion-tech-preview": [
+      {
+        "cask": "vmware-fusion-tech-preview",
+        "count": "2"
+      }
+    ],
+    "vmware-fusion10": [
+      {
+        "cask": "vmware-fusion10",
+        "count": "20"
+      }
+    ],
+    "vmware-fusion7": [
+      {
+        "cask": "vmware-fusion7",
+        "count": "2"
+      }
+    ],
+    "vmware-fusion8": [
+      {
+        "cask": "vmware-fusion8",
+        "count": "7"
+      }
+    ],
+    "vmware-horizon-client": [
+      {
+        "cask": "vmware-horizon-client",
+        "count": "163"
+      }
+    ],
+    "vnc-server": [
+      {
+        "cask": "vnc-server",
+        "count": "98"
+      }
+    ],
+    "vnc-viewer": [
+      {
+        "cask": "vnc-viewer",
+        "count": "884"
+      }
+    ],
+    "vnote": [
+      {
+        "cask": "vnote",
+        "count": "131"
+      }
+    ],
+    "voicemac": [
+      {
+        "cask": "voicemac",
+        "count": "4"
+      }
+    ],
+    "voikkospellservice": [
+      {
+        "cask": "voikkospellservice",
+        "count": "3"
+      }
+    ],
+    "volt": [
+      {
+        "cask": "volt",
+        "count": "11"
+      }
+    ],
+    "voodoopad": [
+      {
+        "cask": "voodoopad",
+        "count": "7"
+      }
+    ],
+    "vorta": [
+      {
+        "cask": "vorta",
+        "count": "61"
+      }
+    ],
+    "vox": [
+      {
+        "cask": "vox",
+        "count": "137"
+      }
+    ],
+    "vox-preferences-pane": [
+      {
+        "cask": "vox-preferences-pane",
+        "count": "16"
+      }
+    ],
+    "vox2": [
+      {
+        "cask": "vox2",
+        "count": "1"
+      }
+    ],
+    "voxql": [
+      {
+        "cask": "voxql",
+        "count": "5"
+      }
+    ],
+    "vpn-enabler": [
+      {
+        "cask": "vpn-enabler",
+        "count": "6"
+      }
+    ],
+    "vrep": [
+      {
+        "cask": "vrep",
+        "count": "7"
+      }
+    ],
+    "vscodium": [
+      {
+        "cask": "vscodium",
+        "count": "1,272"
+      }
+    ],
+    "vsee": [
+      {
+        "cask": "vsee",
+        "count": "8"
+      }
+    ],
+    "vu": [
+      {
+        "cask": "vu",
+        "count": "1"
+      }
+    ],
+    "vuescan": [
+      {
+        "cask": "vuescan",
+        "count": "36"
+      }
+    ],
+    "vuescan-x32": [
+      {
+        "cask": "vuescan-x32",
+        "count": "4"
+      }
+    ],
+    "vulkan-sdk": [
+      {
+        "cask": "vulkan-sdk",
+        "count": "153"
+      }
+    ],
+    "vuze": [
+      {
+        "cask": "vuze",
+        "count": "43"
+      }
+    ],
+    "vv": [
+      {
+        "cask": "vv",
+        "count": "23"
+      }
+    ],
+    "vyprvpn": [
+      {
+        "cask": "vyprvpn",
+        "count": "23"
+      }
+    ],
+    "vysor": [
+      {
+        "cask": "vysor",
+        "count": "64"
+      }
+    ],
+    "wacom-inkspace": [
+      {
+        "cask": "wacom-inkspace",
+        "count": "15"
+      }
+    ],
+    "wacom-tablet": [
+      {
+        "cask": "wacom-tablet",
+        "count": "90"
+      }
+    ],
+    "wacom-tablet-patched@5.3.7-6": [
+      {
+        "cask": "wacom-tablet-patched@5.3.7-6",
+        "count": "1"
+      }
+    ],
+    "wakeonlan": [
+      {
+        "cask": "wakeonlan",
+        "count": "34"
+      }
+    ],
+    "wallpaper-wizard": [
+      {
+        "cask": "wallpaper-wizard",
+        "count": "21"
+      }
+    ],
+    "waltr": [
+      {
+        "cask": "waltr",
+        "count": "14"
+      }
+    ],
+    "wanna": [
+      {
+        "cask": "wanna",
+        "count": "1"
+      }
+    ],
+    "warsow": [
+      {
+        "cask": "warsow",
+        "count": "8"
+      }
+    ],
+    "wasabi-wallet": [
+      {
+        "cask": "wasabi-wallet",
+        "count": "12"
+      }
+    ],
+    "watchguard-mobile-vpn-with-ssl": [
+      {
+        "cask": "watchguard-mobile-vpn-with-ssl",
+        "count": "12"
+      }
+    ],
+    "waterfox": [
+      {
+        "cask": "waterfox",
+        "count": "38"
+      }
+    ],
+    "waterfox-current": [
+      {
+        "cask": "waterfox-current",
+        "count": "23"
+      }
+    ],
+    "wavebox": [
+      {
+        "cask": "wavebox",
+        "count": "45"
+      }
+    ],
+    "waves-central": [
+      {
+        "cask": "waves-central",
+        "count": "7"
+      }
+    ],
+    "wavesurfer": [
+      {
+        "cask": "wavesurfer",
+        "count": "4"
+      }
+    ],
+    "wavtap": [
+      {
+        "cask": "wavtap",
+        "count": "1"
+      }
+    ],
+    "wch-ch34x-usb-serial-driver": [
+      {
+        "cask": "wch-ch34x-usb-serial-driver",
+        "count": "22"
+      }
+    ],
+    "wd-firmware-updater": [
+      {
+        "cask": "wd-firmware-updater",
+        "count": "3"
+      }
+    ],
+    "wd-security": [
+      {
+        "cask": "wd-security",
+        "count": "1"
+      }
+    ],
+    "web-sharing": [
+      {
+        "cask": "web-sharing",
+        "count": "5"
+      }
+    ],
+    "webarchiveextractor": [
+      {
+        "cask": "webarchiveextractor",
+        "count": "3"
+      }
+    ],
+    "webcamoid": [
+      {
+        "cask": "webcamoid",
+        "count": "204"
+      }
+    ],
+    "webcatalog": [
+      {
+        "cask": "webcatalog",
+        "count": "38"
+      }
+    ],
+    "webex-meetings": [
+      {
+        "cask": "webex-meetings",
+        "count": "609"
+      }
+    ],
+    "webex-nbr-player": [
+      {
+        "cask": "webex-nbr-player",
+        "count": "7"
+      }
+    ],
+    "webex-teams": [
+      {
+        "cask": "webex-teams",
+        "count": "102"
+      }
+    ],
+    "webex-wrf-player": [
+      {
+        "cask": "webex-wrf-player",
+        "count": "6"
+      }
+    ],
+    "webpack-dashboard": [
+      {
+        "cask": "webpack-dashboard",
+        "count": "12"
+      }
+    ],
+    "webplotdigitizer": [
+      {
+        "cask": "webplotdigitizer",
+        "count": "4"
+      }
+    ],
+    "webponize": [
+      {
+        "cask": "webponize",
+        "count": "86"
+      }
+    ],
+    "webpquicklook": [
+      {
+        "cask": "webpquicklook",
+        "count": "1,362"
+      }
+    ],
+    "webrecorder-player": [
+      {
+        "cask": "webrecorder-player",
+        "count": "3"
+      }
+    ],
+    "website-watchman": [
+      {
+        "cask": "website-watchman",
+        "count": "4"
+      }
+    ],
+    "webstorm": [
+      {
+        "cask": "webstorm",
+        "count": "819"
+      }
+    ],
+    "webtorrent": [
+      {
+        "cask": "webtorrent",
+        "count": "163"
+      }
+    ],
+    "wechat": [
+      {
+        "cask": "wechat",
+        "count": "667"
+      }
+    ],
+    "wechatwebdevtools": [
+      {
+        "cask": "wechatwebdevtools",
+        "count": "122"
+      }
+    ],
+    "wechatwork": [
+      {
+        "cask": "wechatwork",
+        "count": "113"
+      }
+    ],
+    "wechsel": [
+      {
+        "cask": "wechsel",
+        "count": "10"
+      }
+    ],
+    "weiyun": [
+      {
+        "cask": "weiyun",
+        "count": "30"
+      }
+    ],
+    "weka": [
+      {
+        "cask": "weka",
+        "count": "45"
+      }
+    ],
+    "welly": [
+      {
+        "cask": "welly",
+        "count": "62"
+      }
+    ],
+    "wercker": [
+      {
+        "cask": "wercker",
+        "count": "2"
+      }
+    ],
+    "wercker-cli": [
+      {
+        "cask": "wercker-cli",
+        "count": "3"
+      }
+    ],
+    "wewechat": [
+      {
+        "cask": "wewechat",
+        "count": "12"
+      }
+    ],
+    "wey": [
+      {
+        "cask": "wey",
+        "count": "2"
+      }
+    ],
+    "whale": [
+      {
+        "cask": "whale",
+        "count": "7"
+      }
+    ],
+    "whalebird": [
+      {
+        "cask": "whalebird",
+        "count": "21"
+      }
+    ],
+    "whatroute": [
+      {
+        "cask": "whatroute",
+        "count": "10"
+      }
+    ],
+    "whatsapp": [
+      {
+        "cask": "whatsapp",
+        "count": "2,249"
+      }
+    ],
+    "whatsize": [
+      {
+        "cask": "whatsize",
+        "count": "7"
+      }
+    ],
+    "whatsyoursign": [
+      {
+        "cask": "whatsyoursign",
+        "count": "20"
+      }
+    ],
+    "whichspace": [
+      {
+        "cask": "whichspace",
+        "count": "15"
+      }
+    ],
+    "whoozle-android-file-transfer": [
+      {
+        "cask": "whoozle-android-file-transfer",
+        "count": "64"
+      }
+    ],
+    "whoozle-android-file-transfer-nightly": [
+      {
+        "cask": "whoozle-android-file-transfer-nightly",
+        "count": "6"
+      }
+    ],
+    "wickrme": [
+      {
+        "cask": "wickrme",
+        "count": "80"
+      }
+    ],
+    "wickrpro": [
+      {
+        "cask": "wickrpro",
+        "count": "30"
+      }
+    ],
+    "widelands": [
+      {
+        "cask": "widelands",
+        "count": "13"
+      }
+    ],
+    "wifi-explorer": [
+      {
+        "cask": "wifi-explorer",
+        "count": "109"
+      }
+    ],
+    "wifispoof": [
+      {
+        "cask": "wifispoof",
+        "count": "23"
+      }
+    ],
+    "wiiuinjector-gui": [
+      {
+        "cask": "wiiuinjector-gui",
+        "count": "7"
+      }
+    ],
+    "window-switch": [
+      {
+        "cask": "window-switch",
+        "count": "1"
+      }
+    ],
+    "windows95": [
+      {
+        "cask": "windows95",
+        "count": "23"
+      }
+    ],
+    "winds": [
+      {
+        "cask": "winds",
+        "count": "14"
+      }
+    ],
+    "windscribe": [
+      {
+        "cask": "windscribe",
+        "count": "124"
+      }
+    ],
+    "wine-crossover": [
+      {
+        "cask": "wine-crossover",
+        "count": "37"
+      }
+    ],
+    "wine-devel": [
+      {
+        "cask": "wine-devel",
+        "count": "1,144"
+      }
+    ],
+    "wine-stable": [
+      {
+        "cask": "wine-stable",
+        "count": "10,117"
+      }
+    ],
+    "wine-staging": [
+      {
+        "cask": "wine-staging",
+        "count": "162"
+      }
+    ],
+    "wineskin-winery": [
+      {
+        "cask": "wineskin-winery",
+        "count": "204"
+      }
+    ],
+    "wingpersonal": [
+      {
+        "cask": "wingpersonal",
+        "count": "2"
+      }
+    ],
+    "wings3d": [
+      {
+        "cask": "wings3d",
+        "count": "14"
+      }
+    ],
+    "wintertime": [
+      {
+        "cask": "wintertime",
+        "count": "4"
+      }
+    ],
+    "winzip": [
+      {
+        "cask": "winzip",
+        "count": "62"
+      }
+    ],
+    "wire": [
+      {
+        "cask": "wire",
+        "count": "71"
+      }
+    ],
+    "wireframe-sketcher": [
+      {
+        "cask": "wireframe-sketcher",
+        "count": "4"
+      }
+    ],
+    "wireshark": [
+      {
+        "cask": "wireshark",
+        "count": "3,485"
+      }
+    ],
+    "wireshark-chmodbpf": [
+      {
+        "cask": "wireshark-chmodbpf",
+        "count": "264"
+      }
+    ],
+    "witch": [
+      {
+        "cask": "witch",
+        "count": "52"
+      }
+    ],
+    "withings-scale": [
+      {
+        "cask": "withings-scale",
+        "count": "1"
+      }
+    ],
+    "wiznote": [
+      {
+        "cask": "wiznote",
+        "count": "19"
+      }
+    ],
+    "wjoy": [
+      {
+        "cask": "wjoy",
+        "count": "3"
+      }
+    ],
+    "wkhtmltopdf": [
+      {
+        "cask": "wkhtmltopdf",
+        "count": "2,101"
+      }
+    ],
+    "wonderfultools-screensaver": [
+      {
+        "cask": "wonderfultools-screensaver",
+        "count": "1"
+      }
+    ],
+    "wondershare-filmora": [
+      {
+        "cask": "wondershare-filmora",
+        "count": "24"
+      }
+    ],
+    "wordpresscom": [
+      {
+        "cask": "wordpresscom",
+        "count": "43"
+      }
+    ],
+    "wordservice": [
+      {
+        "cask": "wordservice",
+        "count": "11"
+      }
+    ],
+    "workbench": [
+      {
+        "cask": "workbench",
+        "count": "25"
+      }
+    ],
+    "workflowy": [
+      {
+        "cask": "workflowy",
+        "count": "74"
+      }
+    ],
+    "workplace-chat": [
+      {
+        "cask": "workplace-chat",
+        "count": "31"
+      }
+    ],
+    "wowmatrix": [
+      {
+        "cask": "wowmatrix",
+        "count": "1"
+      }
+    ],
+    "wpsoffice": [
+      {
+        "cask": "wpsoffice",
+        "count": "220"
+      }
+    ],
+    "wraparound": [
+      {
+        "cask": "wraparound",
+        "count": "3"
+      }
+    ],
+    "wrike": [
+      {
+        "cask": "wrike",
+        "count": "20"
+      }
+    ],
+    "writefull": [
+      {
+        "cask": "writefull",
+        "count": "4"
+      }
+    ],
+    "writemapper": [
+      {
+        "cask": "writemapper",
+        "count": "2"
+      }
+    ],
+    "writer": [
+      {
+        "cask": "writer",
+        "count": "1"
+      }
+    ],
+    "wwdc": [
+      {
+        "cask": "wwdc",
+        "count": "79"
+      }
+    ],
+    "wwdcsrt": [
+      {
+        "cask": "wwdcsrt",
+        "count": "1"
+      }
+    ],
+    "wxcrafter": [
+      {
+        "cask": "wxcrafter",
+        "count": "5"
+      }
+    ],
+    "x-mirage": [
+      {
+        "cask": "x-mirage",
+        "count": "7"
+      }
+    ],
+    "x-moto": [
+      {
+        "cask": "x-moto",
+        "count": "3"
+      }
+    ],
+    "x2goclient": [
+      {
+        "cask": "x2goclient",
+        "count": "200"
+      }
+    ],
+    "x48": [
+      {
+        "cask": "x48",
+        "count": "9"
+      }
+    ],
+    "xact": [
+      {
+        "cask": "xact",
+        "count": "39"
+      }
+    ],
+    "xamarin": [
+      {
+        "cask": "xamarin",
+        "count": "21"
+      }
+    ],
+    "xamarin-android": [
+      {
+        "cask": "xamarin-android",
+        "count": "20"
+      }
+    ],
+    "xamarin-ios": [
+      {
+        "cask": "xamarin-ios",
+        "count": "43"
+      }
+    ],
+    "xamarin-mac": [
+      {
+        "cask": "xamarin-mac",
+        "count": "20"
+      }
+    ],
+    "xamarin-profiler": [
+      {
+        "cask": "xamarin-profiler",
+        "count": "3"
+      }
+    ],
+    "xamarin-studio": [
+      {
+        "cask": "xamarin-studio",
+        "count": "18"
+      }
+    ],
+    "xamarin-workbooks": [
+      {
+        "cask": "xamarin-workbooks",
+        "count": "4"
+      }
+    ],
+    "xampp": [
+      {
+        "cask": "xampp",
+        "count": "181"
+      }
+    ],
+    "xampp-vm": [
+      {
+        "cask": "xampp-vm",
+        "count": "12"
+      }
+    ],
+    "xaos": [
+      {
+        "cask": "xaos",
+        "count": "3"
+      }
+    ],
+    "xattred": [
+      {
+        "cask": "xattred",
+        "count": "1"
+      }
+    ],
+    "xbench": [
+      {
+        "cask": "xbench",
+        "count": "7"
+      }
+    ],
+    "xbox360-controller-driver-unofficial": [
+      {
+        "cask": "xbox360-controller-driver-unofficial",
+        "count": "33"
+      }
+    ],
+    "xca": [
+      {
+        "cask": "xca",
+        "count": "104"
+      }
+    ],
+    "xctu": [
+      {
+        "cask": "xctu",
+        "count": "3"
+      }
+    ],
+    "xdm": [
+      {
+        "cask": "xdm",
+        "count": "20"
+      }
+    ],
+    "xee": [
+      {
+        "cask": "xee",
+        "count": "56"
+      }
+    ],
+    "xerox-print-driver": [
+      {
+        "cask": "xerox-print-driver",
+        "count": "5"
+      }
+    ],
+    "xiami": [
+      {
+        "cask": "xiami",
+        "count": "44"
+      }
+    ],
+    "ximalaya": [
+      {
+        "cask": "ximalaya",
+        "count": "23"
+      }
+    ],
+    "xit": [
+      {
+        "cask": "xit",
+        "count": "3"
+      }
+    ],
+    "xld": [
+      {
+        "cask": "xld",
+        "count": "299"
+      }
+    ],
+    "xlink-kai": [
+      {
+        "cask": "xlink-kai",
+        "count": "2"
+      }
+    ],
+    "xlplayer": [
+      {
+        "cask": "xlplayer",
+        "count": "8"
+      }
+    ],
+    "xmind": [
+      {
+        "cask": "xmind",
+        "count": "285"
+      }
+    ],
+    "xmind-zen": [
+      {
+        "cask": "xmind-zen",
+        "count": "160"
+      }
+    ],
+    "xmplify": [
+      {
+        "cask": "xmplify",
+        "count": "4"
+      }
+    ],
+    "xnconvert": [
+      {
+        "cask": "xnconvert",
+        "count": "34"
+      }
+    ],
+    "xnviewmp": [
+      {
+        "cask": "xnviewmp",
+        "count": "122"
+      }
+    ],
+    "xoctave": [
+      {
+        "cask": "xoctave",
+        "count": "46"
+      }
+    ],
+    "xonotic": [
+      {
+        "cask": "xonotic",
+        "count": "21"
+      }
+    ],
+    "xpra": [
+      {
+        "cask": "xpra",
+        "count": "68"
+      }
+    ],
+    "xquartz": [
+      {
+        "cask": "xquartz",
+        "count": "18,228"
+      }
+    ],
+    "xrg": [
+      {
+        "cask": "xrg",
+        "count": "31"
+      }
+    ],
+    "xscope": [
+      {
+        "cask": "xscope",
+        "count": "67"
+      }
+    ],
+    "xscreensaver": [
+      {
+        "cask": "xscreensaver",
+        "count": "44"
+      }
+    ],
+    "xtorrent": [
+      {
+        "cask": "xtorrent",
+        "count": "49"
+      }
+    ],
+    "xversion": [
+      {
+        "cask": "xversion",
+        "count": "1"
+      }
+    ],
+    "yacreader": [
+      {
+        "cask": "yacreader",
+        "count": "262"
+      }
+    ],
+    "yahoo-keykey": [
+      {
+        "cask": "yahoo-keykey",
+        "count": "1"
+      }
+    ],
+    "yakyak": [
+      {
+        "cask": "yakyak",
+        "count": "48"
+      }
+    ],
+    "yam-display": [
+      {
+        "cask": "yam-display",
+        "count": "12"
+      }
+    ],
+    "yammer": [
+      {
+        "cask": "yammer",
+        "count": "25"
+      }
+    ],
+    "yandex": [
+      {
+        "cask": "yandex",
+        "count": "49"
+      }
+    ],
+    "yandex-cloud-cli": [
+      {
+        "cask": "yandex-cloud-cli",
+        "count": "11"
+      }
+    ],
+    "yandex-disk": [
+      {
+        "cask": "yandex-disk",
+        "count": "59"
+      }
+    ],
+    "yandexradio": [
+      {
+        "cask": "yandexradio",
+        "count": "11"
+      }
+    ],
+    "yate": [
+      {
+        "cask": "yate",
+        "count": "10"
+      }
+    ],
+    "yed": [
+      {
+        "cask": "yed",
+        "count": "134"
+      }
+    ],
+    "yemuzip": [
+      {
+        "cask": "yemuzip",
+        "count": "2"
+      }
+    ],
+    "yep": [
+      {
+        "cask": "yep",
+        "count": "4"
+      }
+    ],
+    "yinxiangbiji": [
+      {
+        "cask": "yinxiangbiji",
+        "count": "42"
+      }
+    ],
+    "yo": [
+      {
+        "cask": "yo",
+        "count": "12"
+      }
+    ],
+    "yoda": [
+      {
+        "cask": "yoda",
+        "count": "2"
+      }
+    ],
+    "yojimbo": [
+      {
+        "cask": "yojimbo",
+        "count": "5"
+      }
+    ],
+    "youdaodict": [
+      {
+        "cask": "youdaodict",
+        "count": "48"
+      }
+    ],
+    "youdaonote": [
+      {
+        "cask": "youdaonote",
+        "count": "89"
+      }
+    ],
+    "youku": [
+      {
+        "cask": "youku",
+        "count": "120"
+      }
+    ],
+    "youll-never-take-me-alive": [
+      {
+        "cask": "youll-never-take-me-alive",
+        "count": "2"
+      }
+    ],
+    "yourkit-java-profiler": [
+      {
+        "cask": "yourkit-java-profiler",
+        "count": "44"
+      }
+    ],
+    "youtrack-workflow": [
+      {
+        "cask": "youtrack-workflow",
+        "count": "5"
+      }
+    ],
+    "youtube-to-mp3": [
+      {
+        "cask": "youtube-to-mp3",
+        "count": "89"
+      }
+    ],
+    "yt-music": [
+      {
+        "cask": "yt-music",
+        "count": "145"
+      }
+    ],
+    "yu-writer": [
+      {
+        "cask": "yu-writer",
+        "count": "7"
+      }
+    ],
+    "yubico-authenticator": [
+      {
+        "cask": "yubico-authenticator",
+        "count": "102"
+      }
+    ],
+    "yubico-yubikey-manager": [
+      {
+        "cask": "yubico-yubikey-manager",
+        "count": "115"
+      }
+    ],
+    "yubico-yubikey-personalization-gui": [
+      {
+        "cask": "yubico-yubikey-personalization-gui",
+        "count": "43"
+      }
+    ],
+    "yubico-yubikey-piv-manager": [
+      {
+        "cask": "yubico-yubikey-piv-manager",
+        "count": "18"
+      }
+    ],
+    "yubioath-desktop-beta": [
+      {
+        "cask": "yubioath-desktop-beta",
+        "count": "2"
+      }
+    ],
+    "yy": [
+      {
+        "cask": "yy",
+        "count": "6"
+      }
+    ],
+    "yyets": [
+      {
+        "cask": "yyets",
+        "count": "25"
+      }
+    ],
+    "zalo": [
+      {
+        "cask": "zalo",
+        "count": "20"
+      }
+    ],
+    "zandronum": [
+      {
+        "cask": "zandronum",
+        "count": "3"
+      }
+    ],
+    "zappy": [
+      {
+        "cask": "zappy",
+        "count": "29"
+      }
+    ],
+    "zazu": [
+      {
+        "cask": "zazu",
+        "count": "16"
+      }
+    ],
+    "zdoom": [
+      {
+        "cask": "zdoom",
+        "count": "2"
+      }
+    ],
+    "zecwallet": [
+      {
+        "cask": "zecwallet",
+        "count": "7"
+      }
+    ],
+    "zeebe-modeler": [
+      {
+        "cask": "zeebe-modeler",
+        "count": "66"
+      }
+    ],
+    "zenbeats": [
+      {
+        "cask": "zenbeats",
+        "count": "5"
+      }
+    ],
+    "zenmap": [
+      {
+        "cask": "zenmap",
+        "count": "377"
+      }
+    ],
+    "zenmate-vpn": [
+      {
+        "cask": "zenmate-vpn",
+        "count": "5"
+      }
+    ],
+    "zeplin": [
+      {
+        "cask": "zeplin",
+        "count": "466"
+      }
+    ],
+    "zerobranestudio": [
+      {
+        "cask": "zerobranestudio",
+        "count": "20"
+      }
+    ],
+    "zeronet": [
+      {
+        "cask": "zeronet",
+        "count": "17"
+      }
+    ],
+    "zerotier-one": [
+      {
+        "cask": "zerotier-one",
+        "count": "180"
+      }
+    ],
+    "zesarux": [
+      {
+        "cask": "zesarux",
+        "count": "3"
+      }
+    ],
+    "zettelkasten": [
+      {
+        "cask": "zettelkasten",
+        "count": "26"
+      }
+    ],
+    "zettlr": [
+      {
+        "cask": "zettlr",
+        "count": "274"
+      }
+    ],
+    "zim-app": [
+      {
+        "cask": "zim-app",
+        "count": "1"
+      }
+    ],
+    "zipcleaner": [
+      {
+        "cask": "zipcleaner",
+        "count": "6"
+      }
+    ],
+    "zoc": [
+      {
+        "cask": "zoc",
+        "count": "26"
+      }
+    ],
+    "zoho-docs": [
+      {
+        "cask": "zoho-docs",
+        "count": "4"
+      }
+    ],
+    "zoho-mail": [
+      {
+        "cask": "zoho-mail",
+        "count": "20"
+      }
+    ],
+    "zoho-workdrive": [
+      {
+        "cask": "zoho-workdrive",
+        "count": "1"
+      }
+    ],
+    "zoolz": [
+      {
+        "cask": "zoolz",
+        "count": "2"
+      }
+    ],
+    "zoom": [
+      {
+        "cask": "zoom",
+        "count": "2,923"
+      }
+    ],
+    "zoom-in": [
+      {
+        "cask": "zoom-in",
+        "count": "17"
+      }
+    ],
+    "zoomus": [
+      {
+        "cask": "zoomus",
+        "count": "6,829"
+      }
+    ],
+    "zoomus-outlook-plugin": [
+      {
+        "cask": "zoomus-outlook-plugin",
+        "count": "12"
+      }
+    ],
+    "zotero": [
+      {
+        "cask": "zotero",
+        "count": "416"
+      }
+    ],
+    "zsa-wally": [
+      {
+        "cask": "zsa-wally",
+        "count": "13"
+      }
+    ],
+    "zterm": [
+      {
+        "cask": "zterm",
+        "count": "29"
+      }
+    ],
+    "zulip": [
+      {
+        "cask": "zulip",
+        "count": "78"
+      }
+    ],
+    "zulu": [
+      {
+        "cask": "zulu",
+        "count": "118"
+      }
+    ],
+    "zulu-jdk11": [
+      {
+        "cask": "zulu-jdk11",
+        "count": "19"
+      }
+    ],
+    "zulu-jdk12": [
+      {
+        "cask": "zulu-jdk12",
+        "count": "1"
+      }
+    ],
+    "zulu-jdk13": [
+      {
+        "cask": "zulu-jdk13",
+        "count": "5"
+      }
+    ],
+    "zulu-jdk14": [
+      {
+        "cask": "zulu-jdk14",
+        "count": "9"
+      }
+    ],
+    "zulu-jdk15ea": [
+      {
+        "cask": "zulu-jdk15ea",
+        "count": "4"
+      }
+    ],
+    "zulu-jdk7": [
+      {
+        "cask": "zulu-jdk7",
+        "count": "5"
+      }
+    ],
+    "zulu-jdk8": [
+      {
+        "cask": "zulu-jdk8",
+        "count": "32"
+      }
+    ],
+    "zulu-mc": [
+      {
+        "cask": "zulu-mc",
+        "count": "5"
+      }
+    ],
+    "zulu-mission-control": [
+      {
+        "cask": "zulu-mission-control",
+        "count": "1"
+      }
+    ],
+    "zulu11": [
+      {
+        "cask": "zulu11",
+        "count": "221"
+      }
+    ],
+    "zulu13": [
+      {
+        "cask": "zulu13",
+        "count": "19"
+      }
+    ],
+    "zulu7": [
+      {
+        "cask": "zulu7",
+        "count": "124"
+      }
+    ],
+    "zulu8": [
+      {
+        "cask": "zulu8",
+        "count": "400"
+      }
+    ],
+    "zulutest": [
+      {
+        "cask": "zuluTest",
+        "count": "2"
+      }
+    ],
+    "zwift": [
+      {
+        "cask": "zwift",
+        "count": "39"
+      }
+    ],
+    "zxpinstaller": [
+      {
+        "cask": "zxpinstaller",
+        "count": "8"
+      }
+    ]
+  }
+}

--- a/_data/analytics/cask-install/homebrew-cask/365d.json
+++ b/_data/analytics/cask-install/homebrew-cask/365d.json
@@ -1,0 +1,48381 @@
+{
+  "category": "cask_install",
+  "total_items": 8062,
+  "start_date": "2019-05-07",
+  "end_date": "2020-05-06",
+  "total_count": 20529873,
+  "formulae": {
+    "0-ad": [
+      {
+        "cask": "0-ad",
+        "count": "347"
+      }
+    ],
+    "010-editor": [
+      {
+        "cask": "010-editor",
+        "count": "299"
+      }
+    ],
+    "0xed": [
+      {
+        "cask": "0xed",
+        "count": "1,116"
+      }
+    ],
+    "115browser": [
+      {
+        "cask": "115browser",
+        "count": "221"
+      }
+    ],
+    "1clipboard": [
+      {
+        "cask": "1clipboard",
+        "count": "408"
+      }
+    ],
+    "1password": [
+      {
+        "cask": "1password",
+        "count": "25,174"
+      }
+    ],
+    "1password-beta": [
+      {
+        "cask": "1password-beta",
+        "count": "425"
+      }
+    ],
+    "1password-cli": [
+      {
+        "cask": "1password-cli",
+        "count": "6,356"
+      }
+    ],
+    "1password6": [
+      {
+        "cask": "1password6",
+        "count": "514"
+      }
+    ],
+    "245cloud": [
+      {
+        "cask": "245cloud",
+        "count": "9"
+      }
+    ],
+    "2fatotray": [
+      {
+        "cask": "2fatotray",
+        "count": "17"
+      }
+    ],
+    "32-bitcheck": [
+      {
+        "cask": "32-bitcheck",
+        "count": "14"
+      }
+    ],
+    "33-rpm": [
+      {
+        "cask": "33-rpm",
+        "count": "24"
+      }
+    ],
+    "360chrome": [
+      {
+        "cask": "360chrome",
+        "count": "3"
+      }
+    ],
+    "360safe": [
+      {
+        "cask": "360safe",
+        "count": "53"
+      }
+    ],
+    "3cxphone": [
+      {
+        "cask": "3cxphone",
+        "count": "275"
+      }
+    ],
+    "3dconnexion": [
+      {
+        "cask": "3dconnexion",
+        "count": "40"
+      }
+    ],
+    "3dgence-slicer": [
+      {
+        "cask": "3dgence-slicer",
+        "count": "2"
+      }
+    ],
+    "3dgenceslicer": [
+      {
+        "cask": "3dgenceslicer",
+        "count": "9"
+      }
+    ],
+    "4front-bass": [
+      {
+        "cask": "4front-bass",
+        "count": "1"
+      }
+    ],
+    "4front-bass-vst": [
+      {
+        "cask": "4front-bass-vst",
+        "count": "1"
+      }
+    ],
+    "4front-epiano": [
+      {
+        "cask": "4front-epiano",
+        "count": "1"
+      }
+    ],
+    "4front-epiano-vst": [
+      {
+        "cask": "4front-epiano-vst",
+        "count": "2"
+      }
+    ],
+    "4front-piano": [
+      {
+        "cask": "4front-piano",
+        "count": "1"
+      }
+    ],
+    "4front-piano-vst": [
+      {
+        "cask": "4front-piano-vst",
+        "count": "2"
+      }
+    ],
+    "4front-rpiano": [
+      {
+        "cask": "4front-rpiano",
+        "count": "1"
+      }
+    ],
+    "4front-rpiano-au": [
+      {
+        "cask": "4front-rpiano-au",
+        "count": "1"
+      }
+    ],
+    "4front-rpiano-vst": [
+      {
+        "cask": "4front-rpiano-vst",
+        "count": "1"
+      }
+    ],
+    "4k-slideshow-maker": [
+      {
+        "cask": "4k-slideshow-maker",
+        "count": "41"
+      }
+    ],
+    "4k-stogram": [
+      {
+        "cask": "4k-stogram",
+        "count": "95"
+      }
+    ],
+    "4k-video-downloader": [
+      {
+        "cask": "4k-video-downloader",
+        "count": "1,179"
+      }
+    ],
+    "4k-video-to-mp3": [
+      {
+        "cask": "4k-video-to-mp3",
+        "count": "55"
+      }
+    ],
+    "4k-youtube-to-mp3": [
+      {
+        "cask": "4k-youtube-to-mp3",
+        "count": "337"
+      }
+    ],
+    "4peaks": [
+      {
+        "cask": "4peaks",
+        "count": "108"
+      }
+    ],
+    "5kplayer": [
+      {
+        "cask": "5kplayer",
+        "count": "526"
+      }
+    ],
+    "7-billion-humans": [
+      {
+        "cask": "7-billion-humans",
+        "count": "3"
+      }
+    ],
+    "8bitdo-firmware-updater": [
+      {
+        "cask": "8bitdo-firmware-updater",
+        "count": "84"
+      }
+    ],
+    "8tracksradiohelper": [
+      {
+        "cask": "8tracksradiohelper",
+        "count": "10"
+      }
+    ],
+    "99sounds-drum-machine-au": [
+      {
+        "cask": "99sounds-drum-machine-au",
+        "count": "1"
+      }
+    ],
+    "99sounds-drum-machine-vst": [
+      {
+        "cask": "99sounds-drum-machine-vst",
+        "count": "1"
+      }
+    ],
+    "a-better-finder-attributes": [
+      {
+        "cask": "a-better-finder-attributes",
+        "count": "152"
+      }
+    ],
+    "a-better-finder-rename": [
+      {
+        "cask": "a-better-finder-rename",
+        "count": "832"
+      }
+    ],
+    "a-slower-speed-of-light": [
+      {
+        "cask": "a-slower-speed-of-light",
+        "count": "41"
+      }
+    ],
+    "ableton-live": [
+      {
+        "cask": "ableton-live",
+        "count": "164"
+      }
+    ],
+    "ableton-live-10-suite": [
+      {
+        "cask": "ableton-live-10-suite",
+        "count": "1"
+      }
+    ],
+    "ableton-live-intro": [
+      {
+        "cask": "ableton-live-intro",
+        "count": "42"
+      }
+    ],
+    "ableton-live-lite": [
+      {
+        "cask": "ableton-live-lite",
+        "count": "178"
+      }
+    ],
+    "ableton-live-standard": [
+      {
+        "cask": "ableton-live-standard",
+        "count": "69"
+      }
+    ],
+    "ableton-live-standard9": [
+      {
+        "cask": "ableton-live-standard9",
+        "count": "17"
+      }
+    ],
+    "ableton-live-suite": [
+      {
+        "cask": "ableton-live-suite",
+        "count": "421"
+      }
+    ],
+    "ableton-live-suite9": [
+      {
+        "cask": "ableton-live-suite9",
+        "count": "35"
+      }
+    ],
+    "abricotine": [
+      {
+        "cask": "abricotine",
+        "count": "146"
+      }
+    ],
+    "abscissa": [
+      {
+        "cask": "abscissa",
+        "count": "35"
+      }
+    ],
+    "abstract": [
+      {
+        "cask": "abstract",
+        "count": "1,012"
+      }
+    ],
+    "accessmenubarapps": [
+      {
+        "cask": "accessmenubarapps",
+        "count": "115"
+      }
+    ],
+    "accordance": [
+      {
+        "cask": "accordance",
+        "count": "2"
+      }
+    ],
+    "accurics-cli": [
+      {
+        "cask": "accurics-cli",
+        "count": "3"
+      }
+    ],
+    "ace-link": [
+      {
+        "cask": "ace-link",
+        "count": "536"
+      }
+    ],
+    "acorn": [
+      {
+        "cask": "acorn",
+        "count": "330"
+      }
+    ],
+    "acousticbrainz-gui": [
+      {
+        "cask": "acousticbrainz-gui",
+        "count": "22"
+      }
+    ],
+    "acquia-dev": [
+      {
+        "cask": "acquia-dev",
+        "count": "44"
+      }
+    ],
+    "acronis-true-image": [
+      {
+        "cask": "acronis-true-image",
+        "count": "85"
+      }
+    ],
+    "across-lite": [
+      {
+        "cask": "across-lite",
+        "count": "5"
+      }
+    ],
+    "acs-acr39u-smartcard-driver": [
+      {
+        "cask": "acs-acr39u-smartcard-driver",
+        "count": "5"
+      }
+    ],
+    "acslogo": [
+      {
+        "cask": "acslogo",
+        "count": "65"
+      }
+    ],
+    "activedock": [
+      {
+        "cask": "activedock",
+        "count": "122"
+      }
+    ],
+    "activitywatch": [
+      {
+        "cask": "activitywatch",
+        "count": "342"
+      }
+    ],
+    "actual-odbc-pack": [
+      {
+        "cask": "actual-odbc-pack",
+        "count": "81"
+      }
+    ],
+    "adafruit-arduino": [
+      {
+        "cask": "adafruit-arduino",
+        "count": "124"
+      }
+    ],
+    "adapter": [
+      {
+        "cask": "adapter",
+        "count": "482"
+      }
+    ],
+    "additional-tools-for-xcode": [
+      {
+        "cask": "additional-tools-for-xcode",
+        "count": "3"
+      }
+    ],
+    "adguard": [
+      {
+        "cask": "adguard",
+        "count": "1,794"
+      }
+    ],
+    "adguard-nightly": [
+      {
+        "cask": "adguard-nightly",
+        "count": "52"
+      }
+    ],
+    "adium": [
+      {
+        "cask": "adium",
+        "count": "1,853"
+      }
+    ],
+    "adobe-acrobat-pro": [
+      {
+        "cask": "adobe-acrobat-pro",
+        "count": "1,026"
+      }
+    ],
+    "adobe-acrobat-reader": [
+      {
+        "cask": "adobe-acrobat-reader",
+        "count": "18,583"
+      }
+    ],
+    "adobe-acrobat-reader-custom": [
+      {
+        "cask": "adobe-acrobat-reader-custom",
+        "count": "1"
+      }
+    ],
+    "adobe-aftereffects-2019": [
+      {
+        "cask": "adobe-aftereffects-2019",
+        "count": "3"
+      }
+    ],
+    "adobe-air": [
+      {
+        "cask": "adobe-air",
+        "count": "1,892"
+      }
+    ],
+    "adobe-air-beta": [
+      {
+        "cask": "adobe-air-beta",
+        "count": "6"
+      }
+    ],
+    "adobe-air-sdk": [
+      {
+        "cask": "adobe-air-sdk",
+        "count": "52"
+      }
+    ],
+    "adobe-air-sdk@32.0": [
+      {
+        "cask": "adobe-air-sdk@32.0",
+        "count": "1"
+      }
+    ],
+    "adobe-audition-2019": [
+      {
+        "cask": "adobe-audition-2019",
+        "count": "3"
+      }
+    ],
+    "adobe-connect": [
+      {
+        "cask": "adobe-connect",
+        "count": "248"
+      }
+    ],
+    "adobe-creative-cloud": [
+      {
+        "cask": "adobe-creative-cloud",
+        "count": "11,723"
+      }
+    ],
+    "adobe-creative-cloud-cleaner-tool": [
+      {
+        "cask": "adobe-creative-cloud-cleaner-tool",
+        "count": "625"
+      }
+    ],
+    "adobe-digital-editions": [
+      {
+        "cask": "adobe-digital-editions",
+        "count": "988"
+      }
+    ],
+    "adobe-dng-converter": [
+      {
+        "cask": "adobe-dng-converter",
+        "count": "318"
+      }
+    ],
+    "adobe-lens-profile-creator": [
+      {
+        "cask": "adobe-lens-profile-creator",
+        "count": "17"
+      }
+    ],
+    "adobe-photoshop-2019": [
+      {
+        "cask": "adobe-photoshop-2019",
+        "count": "5"
+      }
+    ],
+    "adobe-photoshop-lightroom": [
+      {
+        "cask": "adobe-photoshop-lightroom",
+        "count": "1"
+      }
+    ],
+    "adobe-photoshop-lightroom600": [
+      {
+        "cask": "adobe-photoshop-lightroom600",
+        "count": "1"
+      }
+    ],
+    "adobe_creative_cloud": [
+      {
+        "cask": "adobe_creative_cloud",
+        "count": "69"
+      }
+    ],
+    "adoptopenjdk": [
+      {
+        "cask": "adoptopenjdk",
+        "count": "87,402"
+      }
+    ],
+    "adoptopenjdk10": [
+      {
+        "cask": "adoptopenjdk10",
+        "count": "4,095"
+      }
+    ],
+    "adoptopenjdk11": [
+      {
+        "cask": "adoptopenjdk11",
+        "count": "45,507"
+      }
+    ],
+    "adoptopenjdk11-jre": [
+      {
+        "cask": "adoptopenjdk11-jre",
+        "count": "675"
+      }
+    ],
+    "adoptopenjdk11-openj9": [
+      {
+        "cask": "adoptopenjdk11-openj9",
+        "count": "986"
+      }
+    ],
+    "adoptopenjdk11-openj9-jre": [
+      {
+        "cask": "adoptopenjdk11-openj9-jre",
+        "count": "91"
+      }
+    ],
+    "adoptopenjdk11-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk11-openj9-jre-large",
+        "count": "22"
+      }
+    ],
+    "adoptopenjdk11-openj9-large": [
+      {
+        "cask": "adoptopenjdk11-openj9-large",
+        "count": "125"
+      }
+    ],
+    "adoptopenjdk12": [
+      {
+        "cask": "adoptopenjdk12",
+        "count": "7,984"
+      }
+    ],
+    "adoptopenjdk12-jre": [
+      {
+        "cask": "adoptopenjdk12-jre",
+        "count": "241"
+      }
+    ],
+    "adoptopenjdk12-openj9": [
+      {
+        "cask": "adoptopenjdk12-openj9",
+        "count": "374"
+      }
+    ],
+    "adoptopenjdk12-openj9-jre": [
+      {
+        "cask": "adoptopenjdk12-openj9-jre",
+        "count": "59"
+      }
+    ],
+    "adoptopenjdk12-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk12-openj9-jre-large",
+        "count": "9"
+      }
+    ],
+    "adoptopenjdk12-openj9-large": [
+      {
+        "cask": "adoptopenjdk12-openj9-large",
+        "count": "50"
+      }
+    ],
+    "adoptopenjdk13": [
+      {
+        "cask": "adoptopenjdk13",
+        "count": "6,427"
+      }
+    ],
+    "adoptopenjdk13-jre": [
+      {
+        "cask": "adoptopenjdk13-jre",
+        "count": "430"
+      }
+    ],
+    "adoptopenjdk13-openj9": [
+      {
+        "cask": "adoptopenjdk13-openj9",
+        "count": "332"
+      }
+    ],
+    "adoptopenjdk13-openj9-jre": [
+      {
+        "cask": "adoptopenjdk13-openj9-jre",
+        "count": "50"
+      }
+    ],
+    "adoptopenjdk13-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk13-openj9-jre-large",
+        "count": "9"
+      }
+    ],
+    "adoptopenjdk13-openj9-large": [
+      {
+        "cask": "adoptopenjdk13-openj9-large",
+        "count": "47"
+      }
+    ],
+    "adoptopenjdk14": [
+      {
+        "cask": "adoptopenjdk14",
+        "count": "3,105"
+      }
+    ],
+    "adoptopenjdk14-jre": [
+      {
+        "cask": "adoptopenjdk14-jre",
+        "count": "104"
+      }
+    ],
+    "adoptopenjdk14-openj9": [
+      {
+        "cask": "adoptopenjdk14-openj9",
+        "count": "169"
+      }
+    ],
+    "adoptopenjdk14-openj9-jre": [
+      {
+        "cask": "adoptopenjdk14-openj9-jre",
+        "count": "32"
+      }
+    ],
+    "adoptopenjdk14-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk14-openj9-jre-large",
+        "count": "8"
+      }
+    ],
+    "adoptopenjdk14-openj9-large": [
+      {
+        "cask": "adoptopenjdk14-openj9-large",
+        "count": "22"
+      }
+    ],
+    "adoptopenjdk8": [
+      {
+        "cask": "adoptopenjdk8",
+        "count": "389,532"
+      }
+    ],
+    "adoptopenjdk8-jre": [
+      {
+        "cask": "adoptopenjdk8-jre",
+        "count": "3,976"
+      }
+    ],
+    "adoptopenjdk8-openj9": [
+      {
+        "cask": "adoptopenjdk8-openj9",
+        "count": "1,622"
+      }
+    ],
+    "adoptopenjdk8-openj9-jre": [
+      {
+        "cask": "adoptopenjdk8-openj9-jre",
+        "count": "162"
+      }
+    ],
+    "adoptopenjdk8-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk8-openj9-jre-large",
+        "count": "38"
+      }
+    ],
+    "adoptopenjdk8-openj9-large": [
+      {
+        "cask": "adoptopenjdk8-openj9-large",
+        "count": "202"
+      }
+    ],
+    "adoptopenjdk9": [
+      {
+        "cask": "adoptopenjdk9",
+        "count": "5,482"
+      }
+    ],
+    "adsr-sample-manager": [
+      {
+        "cask": "adsr-sample-manager",
+        "count": "6"
+      }
+    ],
+    "adtpro": [
+      {
+        "cask": "adtpro",
+        "count": "1"
+      }
+    ],
+    "advancedrestclient": [
+      {
+        "cask": "advancedrestclient",
+        "count": "337"
+      }
+    ],
+    "adventure": [
+      {
+        "cask": "adventure",
+        "count": "155"
+      }
+    ],
+    "adware-removal-tool": [
+      {
+        "cask": "adware-removal-tool",
+        "count": "96"
+      }
+    ],
+    "aegisub": [
+      {
+        "cask": "aegisub",
+        "count": "663"
+      }
+    ],
+    "aeon-timeline": [
+      {
+        "cask": "aeon-timeline",
+        "count": "1"
+      }
+    ],
+    "aerial": [
+      {
+        "cask": "aerial",
+        "count": "13,344"
+      }
+    ],
+    "aerial-beta": [
+      {
+        "cask": "aerial-beta",
+        "count": "7"
+      }
+    ],
+    "aether": [
+      {
+        "cask": "aether",
+        "count": "46"
+      }
+    ],
+    "aeux": [
+      {
+        "cask": "aeux",
+        "count": "11"
+      }
+    ],
+    "aexol-remote-mouse": [
+      {
+        "cask": "aexol-remote-mouse",
+        "count": "26"
+      }
+    ],
+    "affinic-debugger": [
+      {
+        "cask": "affinic-debugger",
+        "count": "6"
+      }
+    ],
+    "affinity-designer-beta": [
+      {
+        "cask": "affinity-designer-beta",
+        "count": "100"
+      }
+    ],
+    "affinity-photo-beta": [
+      {
+        "cask": "affinity-photo-beta",
+        "count": "173"
+      }
+    ],
+    "after-dark-classic": [
+      {
+        "cask": "after-dark-classic",
+        "count": "66"
+      }
+    ],
+    "agenda": [
+      {
+        "cask": "agenda",
+        "count": "688"
+      }
+    ],
+    "agfeo-dashboard": [
+      {
+        "cask": "agfeo-dashboard",
+        "count": "11"
+      }
+    ],
+    "aimersoft-video-converter-ultimate": [
+      {
+        "cask": "aimersoft-video-converter-ultimate",
+        "count": "35"
+      }
+    ],
+    "air-connect": [
+      {
+        "cask": "air-connect",
+        "count": "81"
+      }
+    ],
+    "air-video-server-hd": [
+      {
+        "cask": "air-video-server-hd",
+        "count": "116"
+      }
+    ],
+    "airbass": [
+      {
+        "cask": "airbass",
+        "count": "1"
+      }
+    ],
+    "airbuddy": [
+      {
+        "cask": "airbuddy",
+        "count": "3"
+      }
+    ],
+    "aircall": [
+      {
+        "cask": "aircall",
+        "count": "49"
+      }
+    ],
+    "airdisplay": [
+      {
+        "cask": "airdisplay",
+        "count": "69"
+      }
+    ],
+    "airdroid": [
+      {
+        "cask": "airdroid",
+        "count": "694"
+      }
+    ],
+    "airflow": [
+      {
+        "cask": "airflow",
+        "count": "677"
+      }
+    ],
+    "airfoil": [
+      {
+        "cask": "airfoil",
+        "count": "574"
+      }
+    ],
+    "airmail-beta": [
+      {
+        "cask": "airmail-beta",
+        "count": "122"
+      }
+    ],
+    "airmedia": [
+      {
+        "cask": "airmedia",
+        "count": "724"
+      }
+    ],
+    "airparrot": [
+      {
+        "cask": "airparrot",
+        "count": "175"
+      }
+    ],
+    "airpass": [
+      {
+        "cask": "airpass",
+        "count": "62"
+      }
+    ],
+    "airqmon": [
+      {
+        "cask": "airqmon",
+        "count": "23"
+      }
+    ],
+    "airserver": [
+      {
+        "cask": "airserver",
+        "count": "951"
+      }
+    ],
+    "airtable": [
+      {
+        "cask": "airtable",
+        "count": "503"
+      }
+    ],
+    "airtame": [
+      {
+        "cask": "airtame",
+        "count": "553"
+      }
+    ],
+    "airtest-ide": [
+      {
+        "cask": "airtest-ide",
+        "count": "2"
+      }
+    ],
+    "airtestide": [
+      {
+        "cask": "airtestide",
+        "count": "1"
+      }
+    ],
+    "airtool": [
+      {
+        "cask": "airtool",
+        "count": "172"
+      }
+    ],
+    "airtrash": [
+      {
+        "cask": "airtrash",
+        "count": "4"
+      }
+    ],
+    "airunlock": [
+      {
+        "cask": "airunlock",
+        "count": "22"
+      }
+    ],
+    "airy": [
+      {
+        "cask": "airy",
+        "count": "184"
+      }
+    ],
+    "aja-io4kplus": [
+      {
+        "cask": "aja-io4kplus",
+        "count": "7"
+      }
+    ],
+    "aja-system-test": [
+      {
+        "cask": "aja-system-test",
+        "count": "170"
+      }
+    ],
+    "akai-professional-lpd8-editor": [
+      {
+        "cask": "akai-professional-lpd8-editor",
+        "count": "2"
+      }
+    ],
+    "alacritty": [
+      {
+        "cask": "alacritty",
+        "count": "30,880"
+      }
+    ],
+    "alacritty@0.3.3": [
+      {
+        "cask": "alacritty@0.3.3",
+        "count": "2"
+      }
+    ],
+    "aladin": [
+      {
+        "cask": "aladin",
+        "count": "31"
+      }
+    ],
+    "alcatraz": [
+      {
+        "cask": "alcatraz",
+        "count": "20"
+      }
+    ],
+    "alchemy": [
+      {
+        "cask": "alchemy",
+        "count": "39"
+      }
+    ],
+    "alephone": [
+      {
+        "cask": "alephone",
+        "count": "15"
+      }
+    ],
+    "aleth": [
+      {
+        "cask": "aleth",
+        "count": "3"
+      }
+    ],
+    "alfaview": [
+      {
+        "cask": "alfaview",
+        "count": "30"
+      }
+    ],
+    "alfred": [
+      {
+        "cask": "alfred",
+        "count": "43,788"
+      }
+    ],
+    "alfred-3.8.2_963": [
+      {
+        "cask": "alfred-3.8.2_963",
+        "count": "1"
+      }
+    ],
+    "alfred-beta": [
+      {
+        "cask": "alfred-beta",
+        "count": "6"
+      }
+    ],
+    "alfred-evernote": [
+      {
+        "cask": "alfred-evernote",
+        "count": "1"
+      }
+    ],
+    "alfred-numi": [
+      {
+        "cask": "alfred-numi",
+        "count": "100"
+      }
+    ],
+    "alfred-snippetslab": [
+      {
+        "cask": "alfred-snippetslab",
+        "count": "2"
+      }
+    ],
+    "alfred-sound-bank": [
+      {
+        "cask": "alfred-sound-bank",
+        "count": "3"
+      }
+    ],
+    "alfred-things": [
+      {
+        "cask": "alfred-things",
+        "count": "12"
+      }
+    ],
+    "alfred2": [
+      {
+        "cask": "alfred2",
+        "count": "91"
+      }
+    ],
+    "alfred3": [
+      {
+        "cask": "alfred3",
+        "count": "671"
+      }
+    ],
+    "algodoo": [
+      {
+        "cask": "algodoo",
+        "count": "45"
+      }
+    ],
+    "alice": [
+      {
+        "cask": "alice",
+        "count": "14"
+      }
+    ],
+    "aliedit": [
+      {
+        "cask": "aliedit",
+        "count": "9"
+      }
+    ],
+    "alifix": [
+      {
+        "cask": "alifix",
+        "count": "12"
+      }
+    ],
+    "alimail": [
+      {
+        "cask": "alimail",
+        "count": "1"
+      }
+    ],
+    "alinof-timer": [
+      {
+        "cask": "alinof-timer",
+        "count": "96"
+      }
+    ],
+    "alisma": [
+      {
+        "cask": "alisma",
+        "count": "8"
+      }
+    ],
+    "aliview": [
+      {
+        "cask": "aliview",
+        "count": "1"
+      }
+    ],
+    "aliwangwang": [
+      {
+        "cask": "aliwangwang",
+        "count": "1,540"
+      }
+    ],
+    "aliwebdevtools": [
+      {
+        "cask": "aliwebdevtools",
+        "count": "2"
+      }
+    ],
+    "aliworkbench": [
+      {
+        "cask": "aliworkbench",
+        "count": "48"
+      }
+    ],
+    "all-in-one-messenger": [
+      {
+        "cask": "all-in-one-messenger",
+        "count": "36"
+      }
+    ],
+    "alloy": [
+      {
+        "cask": "alloy",
+        "count": "10"
+      }
+    ],
+    "alt-c": [
+      {
+        "cask": "alt-c",
+        "count": "77"
+      }
+    ],
+    "alt-tab": [
+      {
+        "cask": "alt-tab",
+        "count": "1,444"
+      }
+    ],
+    "alt-tab-macos": [
+      {
+        "cask": "alt-tab-macos",
+        "count": "1"
+      }
+    ],
+    "altair-graphql-client": [
+      {
+        "cask": "altair-graphql-client",
+        "count": "3,020"
+      }
+    ],
+    "altdeploy": [
+      {
+        "cask": "altdeploy",
+        "count": "47"
+      }
+    ],
+    "alternote": [
+      {
+        "cask": "alternote",
+        "count": "38"
+      }
+    ],
+    "altserver": [
+      {
+        "cask": "altserver",
+        "count": "304"
+      }
+    ],
+    "alttab": [
+      {
+        "cask": "alttab",
+        "count": "1"
+      }
+    ],
+    "alva": [
+      {
+        "cask": "alva",
+        "count": "73"
+      }
+    ],
+    "amadeus-pro": [
+      {
+        "cask": "amadeus-pro",
+        "count": "45"
+      }
+    ],
+    "amadine": [
+      {
+        "cask": "amadine",
+        "count": "22"
+      }
+    ],
+    "amazon-chime": [
+      {
+        "cask": "amazon-chime",
+        "count": "1,180"
+      }
+    ],
+    "amazon-corretto": [
+      {
+        "cask": "amazon-corretto",
+        "count": "2"
+      }
+    ],
+    "amazon-music": [
+      {
+        "cask": "amazon-music",
+        "count": "2,143"
+      }
+    ],
+    "amazon-photos": [
+      {
+        "cask": "amazon-photos",
+        "count": "525"
+      }
+    ],
+    "amazon-workdocs": [
+      {
+        "cask": "amazon-workdocs",
+        "count": "131"
+      }
+    ],
+    "amazon-workspaces": [
+      {
+        "cask": "amazon-workspaces",
+        "count": "1,155"
+      }
+    ],
+    "amethyst": [
+      {
+        "cask": "amethyst",
+        "count": "14,421"
+      }
+    ],
+    "amitv87-pip": [
+      {
+        "cask": "amitv87-pip",
+        "count": "252"
+      }
+    ],
+    "amm": [
+      {
+        "cask": "amm",
+        "count": "44"
+      }
+    ],
+    "ammonite": [
+      {
+        "cask": "ammonite",
+        "count": "308"
+      }
+    ],
+    "amorphousdiskmark": [
+      {
+        "cask": "amorphousdiskmark",
+        "count": "291"
+      }
+    ],
+    "amphetamine-enhancer": [
+      {
+        "cask": "amphetamine-enhancer",
+        "count": "2"
+      }
+    ],
+    "ample-guitar-m-lite": [
+      {
+        "cask": "ample-guitar-m-lite",
+        "count": "3"
+      }
+    ],
+    "ample-pbass-lite": [
+      {
+        "cask": "ample-pbass-lite",
+        "count": "4"
+      }
+    ],
+    "ample-percussion-clouddrum": [
+      {
+        "cask": "ample-percussion-clouddrum",
+        "count": "3"
+      }
+    ],
+    "ampps": [
+      {
+        "cask": "ampps",
+        "count": "147"
+      }
+    ],
+    "amule": [
+      {
+        "cask": "amule",
+        "count": "1"
+      }
+    ],
+    "amvidia-tag-editor": [
+      {
+        "cask": "amvidia-tag-editor",
+        "count": "4"
+      }
+    ],
+    "anaconda": [
+      {
+        "cask": "anaconda",
+        "count": "37,010"
+      }
+    ],
+    "anaconda2": [
+      {
+        "cask": "anaconda2",
+        "count": "226"
+      }
+    ],
+    "ananas-analytics-desktop-edition": [
+      {
+        "cask": "ananas-analytics-desktop-edition",
+        "count": "26"
+      }
+    ],
+    "ananas-desktop": [
+      {
+        "cask": "ananas-desktop",
+        "count": "2"
+      }
+    ],
+    "android-file-transfer": [
+      {
+        "cask": "android-file-transfer",
+        "count": "13,521"
+      }
+    ],
+    "android-file-transfer-custom": [
+      {
+        "cask": "android-file-transfer-custom",
+        "count": "2"
+      }
+    ],
+    "android-messages": [
+      {
+        "cask": "android-messages",
+        "count": "585"
+      }
+    ],
+    "android-ndk": [
+      {
+        "cask": "android-ndk",
+        "count": "6,021"
+      }
+    ],
+    "android-ndk-10e": [
+      {
+        "cask": "android-ndk-10e",
+        "count": "1"
+      }
+    ],
+    "android-ndk-13b": [
+      {
+        "cask": "android-ndk-13b",
+        "count": "7"
+      }
+    ],
+    "android-ndk-16b": [
+      {
+        "cask": "android-ndk-16b",
+        "count": "15"
+      }
+    ],
+    "android-ndk-19b": [
+      {
+        "cask": "android-ndk-19b",
+        "count": "1"
+      }
+    ],
+    "android-ndk-for-unity@2018.1.0f2": [
+      {
+        "cask": "android-ndk-for-unity@2018.1.0f2",
+        "count": "1"
+      }
+    ],
+    "android-ndk-for-unity@2018.2.18f1": [
+      {
+        "cask": "android-ndk-for-unity@2018.2.18f1",
+        "count": "2"
+      }
+    ],
+    "android-ndk-for-unity@2018.4.5f1": [
+      {
+        "cask": "android-ndk-for-unity@2018.4.5f1",
+        "count": "3"
+      }
+    ],
+    "android-ndk-for-unity@2019.2.11f1": [
+      {
+        "cask": "android-ndk-for-unity@2019.2.11f1",
+        "count": "1"
+      }
+    ],
+    "android-ndk-for-unity@2019.2.15f1": [
+      {
+        "cask": "android-ndk-for-unity@2019.2.15f1",
+        "count": "1"
+      }
+    ],
+    "android-ndk-unity": [
+      {
+        "cask": "android-ndk-unity",
+        "count": "2"
+      }
+    ],
+    "android-ndk12": [
+      {
+        "cask": "android-ndk12",
+        "count": "1"
+      }
+    ],
+    "android-ndk14": [
+      {
+        "cask": "android-ndk14",
+        "count": "1"
+      }
+    ],
+    "android-ndk15": [
+      {
+        "cask": "android-ndk15",
+        "count": "1"
+      }
+    ],
+    "android-ndk16": [
+      {
+        "cask": "android-ndk16",
+        "count": "1"
+      }
+    ],
+    "android-ndk@10e": [
+      {
+        "cask": "android-ndk@10e",
+        "count": "1"
+      }
+    ],
+    "android-platform-tools": [
+      {
+        "cask": "android-platform-tools",
+        "count": "178,481"
+      }
+    ],
+    "android-sdk": [
+      {
+        "cask": "android-sdk",
+        "count": "57,840"
+      }
+    ],
+    "android-sdk-custom": [
+      {
+        "cask": "android-sdk-custom",
+        "count": "6"
+      }
+    ],
+    "android-sdk@25": [
+      {
+        "cask": "android-sdk@25",
+        "count": "1"
+      }
+    ],
+    "android-studio": [
+      {
+        "cask": "android-studio",
+        "count": "27,018"
+      }
+    ],
+    "android-studio-custom": [
+      {
+        "cask": "android-studio-custom",
+        "count": "10"
+      }
+    ],
+    "android-studio-preview": [
+      {
+        "cask": "android-studio-preview",
+        "count": "431"
+      }
+    ],
+    "android-studio-two": [
+      {
+        "cask": "android-studio-two",
+        "count": "6"
+      }
+    ],
+    "android-studio2": [
+      {
+        "cask": "android-studio2",
+        "count": "1"
+      }
+    ],
+    "androidndk-15b-android": [
+      {
+        "cask": "androidndk-15b-android",
+        "count": "3"
+      }
+    ],
+    "androidtool": [
+      {
+        "cask": "androidtool",
+        "count": "1,530"
+      }
+    ],
+    "angband": [
+      {
+        "cask": "angband",
+        "count": "61"
+      }
+    ],
+    "angry-ip-scanner": [
+      {
+        "cask": "angry-ip-scanner",
+        "count": "2,765"
+      }
+    ],
+    "angular-console": [
+      {
+        "cask": "angular-console",
+        "count": "204"
+      }
+    ],
+    "anka-build": [
+      {
+        "cask": "anka-build",
+        "count": "1"
+      }
+    ],
+    "anka-flow": [
+      {
+        "cask": "anka-flow",
+        "count": "178"
+      }
+    ],
+    "anki": [
+      {
+        "cask": "anki",
+        "count": "5,519"
+      }
+    ],
+    "ankiapp-anki": [
+      {
+        "cask": "ankiapp-anki",
+        "count": "192"
+      }
+    ],
+    "anne-pro": [
+      {
+        "cask": "anne-pro",
+        "count": "2"
+      }
+    ],
+    "anonym": [
+      {
+        "cask": "anonym",
+        "count": "36"
+      }
+    ],
+    "anonymousvpn": [
+      {
+        "cask": "anonymousvpn",
+        "count": "53"
+      }
+    ],
+    "another-redis-desktop-manager": [
+      {
+        "cask": "another-redis-desktop-manager",
+        "count": "3,345"
+      }
+    ],
+    "ansible-dk": [
+      {
+        "cask": "ansible-dk",
+        "count": "162"
+      }
+    ],
+    "ansiterm2": [
+      {
+        "cask": "ansiterm2",
+        "count": "1"
+      }
+    ],
+    "antconc": [
+      {
+        "cask": "antconc",
+        "count": "56"
+      }
+    ],
+    "antetype": [
+      {
+        "cask": "antetype",
+        "count": "1"
+      }
+    ],
+    "antfileconverter": [
+      {
+        "cask": "antfileconverter",
+        "count": "5"
+      }
+    ],
+    "antsword": [
+      {
+        "cask": "antsword",
+        "count": "1"
+      }
+    ],
+    "antsword-loader": [
+      {
+        "cask": "antsword-loader",
+        "count": "80"
+      }
+    ],
+    "anvil": [
+      {
+        "cask": "anvil",
+        "count": "96"
+      }
+    ],
+    "anybar": [
+      {
+        "cask": "anybar",
+        "count": "504"
+      }
+    ],
+    "anyconnect": [
+      {
+        "cask": "anyconnect",
+        "count": "3"
+      }
+    ],
+    "anydesk": [
+      {
+        "cask": "anydesk",
+        "count": "3,984"
+      }
+    ],
+    "anydesk-4.3.0": [
+      {
+        "cask": "anydesk-4.3.0",
+        "count": "1"
+      }
+    ],
+    "anydo": [
+      {
+        "cask": "anydo",
+        "count": "112"
+      }
+    ],
+    "anyipsum": [
+      {
+        "cask": "anyipsum",
+        "count": "26"
+      }
+    ],
+    "anylist": [
+      {
+        "cask": "anylist",
+        "count": "168"
+      }
+    ],
+    "anylogic": [
+      {
+        "cask": "anylogic",
+        "count": "3"
+      }
+    ],
+    "anytrans": [
+      {
+        "cask": "anytrans",
+        "count": "123"
+      }
+    ],
+    "anytrans-for-android": [
+      {
+        "cask": "anytrans-for-android",
+        "count": "89"
+      }
+    ],
+    "anzeigenchef": [
+      {
+        "cask": "anzeigenchef",
+        "count": "2"
+      }
+    ],
+    "ao": [
+      {
+        "cask": "ao",
+        "count": "264"
+      }
+    ],
+    "apache-couchdb": [
+      {
+        "cask": "apache-couchdb",
+        "count": "221"
+      }
+    ],
+    "apache-directory-studio": [
+      {
+        "cask": "apache-directory-studio",
+        "count": "2,236"
+      }
+    ],
+    "ape": [
+      {
+        "cask": "ape",
+        "count": "1"
+      }
+    ],
+    "ape-cli": [
+      {
+        "cask": "ape-cli",
+        "count": "1"
+      }
+    ],
+    "apfelstrudel": [
+      {
+        "cask": "apfelstrudel",
+        "count": "9"
+      }
+    ],
+    "apk-icon-editor": [
+      {
+        "cask": "apk-icon-editor",
+        "count": "28"
+      }
+    ],
+    "apm-planner": [
+      {
+        "cask": "apm-planner",
+        "count": "5"
+      }
+    ],
+    "apogee-one": [
+      {
+        "cask": "apogee-one",
+        "count": "1"
+      }
+    ],
+    "apogee-quartet": [
+      {
+        "cask": "apogee-quartet",
+        "count": "5"
+      }
+    ],
+    "apogee-symphony": [
+      {
+        "cask": "apogee-symphony",
+        "count": "1"
+      }
+    ],
+    "app-cleaner": [
+      {
+        "cask": "app-cleaner",
+        "count": "1,979"
+      }
+    ],
+    "app-cleaner-uninstaller": [
+      {
+        "cask": "app-cleaner-uninstaller",
+        "count": "1"
+      }
+    ],
+    "app-tamer": [
+      {
+        "cask": "app-tamer",
+        "count": "92"
+      }
+    ],
+    "appcleaner": [
+      {
+        "cask": "appcleaner",
+        "count": "24,195"
+      }
+    ],
+    "appcode": [
+      {
+        "cask": "appcode",
+        "count": "1,561"
+      }
+    ],
+    "appcode-eap": [
+      {
+        "cask": "appcode-eap",
+        "count": "19"
+      }
+    ],
+    "appdelete": [
+      {
+        "cask": "appdelete",
+        "count": "304"
+      }
+    ],
+    "appearin": [
+      {
+        "cask": "appearin",
+        "count": "33"
+      }
+    ],
+    "appgate-sdp-client": [
+      {
+        "cask": "appgate-sdp-client",
+        "count": "216"
+      }
+    ],
+    "appgrid": [
+      {
+        "cask": "appgrid",
+        "count": "68"
+      }
+    ],
+    "appicon-generated": [
+      {
+        "cask": "appicon-generated",
+        "count": "2"
+      }
+    ],
+    "appium": [
+      {
+        "cask": "appium",
+        "count": "1,489"
+      }
+    ],
+    "apple-brother-printer-drivers": [
+      {
+        "cask": "apple-brother-printer-drivers",
+        "count": "4"
+      }
+    ],
+    "apple-connect": [
+      {
+        "cask": "apple-connect",
+        "count": "1"
+      }
+    ],
+    "apple-connect3.2": [
+      {
+        "cask": "apple-connect3.2",
+        "count": "1"
+      }
+    ],
+    "apple-events": [
+      {
+        "cask": "apple-events",
+        "count": "76"
+      }
+    ],
+    "apple-hewlett-packard-printer-drivers": [
+      {
+        "cask": "apple-hewlett-packard-printer-drivers",
+        "count": "88"
+      }
+    ],
+    "apple-juice": [
+      {
+        "cask": "apple-juice",
+        "count": "504"
+      }
+    ],
+    "apple-self-service": [
+      {
+        "cask": "apple-self-service",
+        "count": "3"
+      }
+    ],
+    "apple-yubikey-memento": [
+      {
+        "cask": "apple-yubikey-memento",
+        "count": "1"
+      }
+    ],
+    "apple2ix": [
+      {
+        "cask": "apple2ix",
+        "count": "3"
+      }
+    ],
+    "applejdk-cask": [
+      {
+        "cask": "applejdk-cask",
+        "count": "1"
+      }
+    ],
+    "applejuice-core": [
+      {
+        "cask": "applejuice-core",
+        "count": "5"
+      }
+    ],
+    "applejuice-gui": [
+      {
+        "cask": "applejuice-gui",
+        "count": "2"
+      }
+    ],
+    "applepi-baker": [
+      {
+        "cask": "applepi-baker",
+        "count": "976"
+      }
+    ],
+    "apppolice": [
+      {
+        "cask": "apppolice",
+        "count": "199"
+      }
+    ],
+    "appshelf": [
+      {
+        "cask": "appshelf",
+        "count": "15"
+      }
+    ],
+    "appstore-quickview": [
+      {
+        "cask": "appstore-quickview",
+        "count": "29"
+      }
+    ],
+    "appstudio": [
+      {
+        "cask": "appstudio",
+        "count": "22"
+      }
+    ],
+    "apptivate": [
+      {
+        "cask": "apptivate",
+        "count": "159"
+      }
+    ],
+    "apptrap": [
+      {
+        "cask": "apptrap",
+        "count": "211"
+      }
+    ],
+    "appzapper": [
+      {
+        "cask": "appzapper",
+        "count": "832"
+      }
+    ],
+    "aptanastudio": [
+      {
+        "cask": "aptanastudio",
+        "count": "234"
+      }
+    ],
+    "aptible": [
+      {
+        "cask": "aptible",
+        "count": "1,268"
+      }
+    ],
+    "aqua-data-studio": [
+      {
+        "cask": "aqua-data-studio",
+        "count": "131"
+      }
+    ],
+    "aquamacs": [
+      {
+        "cask": "aquamacs",
+        "count": "841"
+      }
+    ],
+    "aquaskk": [
+      {
+        "cask": "aquaskk",
+        "count": "324"
+      }
+    ],
+    "aquaterm": [
+      {
+        "cask": "aquaterm",
+        "count": "2,332"
+      }
+    ],
+    "aquiline-check": [
+      {
+        "cask": "aquiline-check",
+        "count": "6"
+      }
+    ],
+    "araxis-merge": [
+      {
+        "cask": "araxis-merge",
+        "count": "541"
+      }
+    ],
+    "archi": [
+      {
+        "cask": "archi",
+        "count": "131"
+      }
+    ],
+    "archichect": [
+      {
+        "cask": "archichect",
+        "count": "9"
+      }
+    ],
+    "archipelago": [
+      {
+        "cask": "archipelago",
+        "count": "19"
+      }
+    ],
+    "archiver": [
+      {
+        "cask": "archiver",
+        "count": "372"
+      }
+    ],
+    "ardm": [
+      {
+        "cask": "ardm",
+        "count": "28"
+      }
+    ],
+    "arduino": [
+      {
+        "cask": "arduino",
+        "count": "6,942"
+      }
+    ],
+    "arduino-nightly": [
+      {
+        "cask": "arduino-nightly",
+        "count": "94"
+      }
+    ],
+    "argos3-webviz": [
+      {
+        "cask": "argos3-webviz",
+        "count": "5"
+      }
+    ],
+    "argouml": [
+      {
+        "cask": "argouml",
+        "count": "229"
+      }
+    ],
+    "aria-maestosa": [
+      {
+        "cask": "aria-maestosa",
+        "count": "40"
+      }
+    ],
+    "aria2d": [
+      {
+        "cask": "aria2d",
+        "count": "362"
+      }
+    ],
+    "aria2gui": [
+      {
+        "cask": "aria2gui",
+        "count": "4,793"
+      }
+    ],
+    "ariang": [
+      {
+        "cask": "ariang",
+        "count": "226"
+      }
+    ],
+    "ark-desktop-wallet": [
+      {
+        "cask": "ark-desktop-wallet",
+        "count": "25"
+      }
+    ],
+    "arkclient": [
+      {
+        "cask": "arkclient",
+        "count": "3"
+      }
+    ],
+    "armitage": [
+      {
+        "cask": "armitage",
+        "count": "836"
+      }
+    ],
+    "armortext": [
+      {
+        "cask": "armortext",
+        "count": "2"
+      }
+    ],
+    "armory": [
+      {
+        "cask": "armory",
+        "count": "64"
+      }
+    ],
+    "arq": [
+      {
+        "cask": "arq",
+        "count": "1,361"
+      }
+    ],
+    "arq-cloud-backup": [
+      {
+        "cask": "arq-cloud-backup",
+        "count": "63"
+      }
+    ],
+    "arq-fix": [
+      {
+        "cask": "arq-fix",
+        "count": "1"
+      }
+    ],
+    "arq5": [
+      {
+        "cask": "arq5",
+        "count": "10"
+      }
+    ],
+    "arrayfire": [
+      {
+        "cask": "arrayfire",
+        "count": "115"
+      }
+    ],
+    "arrsync": [
+      {
+        "cask": "arrsync",
+        "count": "85"
+      }
+    ],
+    "art-directors-toolkit": [
+      {
+        "cask": "art-directors-toolkit",
+        "count": "14"
+      }
+    ],
+    "art-of-illusion": [
+      {
+        "cask": "art-of-illusion",
+        "count": "2"
+      }
+    ],
+    "artisan": [
+      {
+        "cask": "artisan",
+        "count": "65"
+      }
+    ],
+    "artpip": [
+      {
+        "cask": "artpip",
+        "count": "58"
+      }
+    ],
+    "artsacoustic-reverb": [
+      {
+        "cask": "artsacoustic-reverb",
+        "count": "1"
+      }
+    ],
+    "arturia-ambient-soundscapes": [
+      {
+        "cask": "arturia-ambient-soundscapes",
+        "count": "1"
+      }
+    ],
+    "arturia-analog-lab": [
+      {
+        "cask": "arturia-analog-lab",
+        "count": "1"
+      }
+    ],
+    "arturia-dark-ambient": [
+      {
+        "cask": "arturia-dark-ambient",
+        "count": "1"
+      }
+    ],
+    "arturia-house-chords": [
+      {
+        "cask": "arturia-house-chords",
+        "count": "1"
+      }
+    ],
+    "arturia-iconic-vibration": [
+      {
+        "cask": "arturia-iconic-vibration",
+        "count": "1"
+      }
+    ],
+    "arturia-midi-control-center": [
+      {
+        "cask": "arturia-midi-control-center",
+        "count": "2"
+      }
+    ],
+    "arturia-mini-v": [
+      {
+        "cask": "arturia-mini-v",
+        "count": "1"
+      }
+    ],
+    "arturia-software-center": [
+      {
+        "cask": "arturia-software-center",
+        "count": "1"
+      }
+    ],
+    "as": [
+      {
+        "cask": "as",
+        "count": "13"
+      }
+    ],
+    "asc-timetables": [
+      {
+        "cask": "asc-timetables",
+        "count": "1"
+      }
+    ],
+    "ascension": [
+      {
+        "cask": "ascension",
+        "count": "33"
+      }
+    ],
+    "asciidocfx": [
+      {
+        "cask": "asciidocfx",
+        "count": "507"
+      }
+    ],
+    "aseprite": [
+      {
+        "cask": "aseprite",
+        "count": "4"
+      }
+    ],
+    "asix-ax88179": [
+      {
+        "cask": "asix-ax88179",
+        "count": "151"
+      }
+    ],
+    "aspera-connect": [
+      {
+        "cask": "aspera-connect",
+        "count": "142"
+      }
+    ],
+    "aspera-connect-new": [
+      {
+        "cask": "aspera-connect-new",
+        "count": "7"
+      }
+    ],
+    "aspera-connect-one-click": [
+      {
+        "cask": "aspera-connect-one-click",
+        "count": "15"
+      }
+    ],
+    "asset-catalog-tinkerer": [
+      {
+        "cask": "asset-catalog-tinkerer",
+        "count": "896"
+      }
+    ],
+    "astah-professional": [
+      {
+        "cask": "astah-professional",
+        "count": "141"
+      }
+    ],
+    "astah-sysml": [
+      {
+        "cask": "astah-sysml",
+        "count": "6"
+      }
+    ],
+    "astro-command-center": [
+      {
+        "cask": "astro-command-center",
+        "count": "25"
+      }
+    ],
+    "astropad": [
+      {
+        "cask": "astropad",
+        "count": "159"
+      }
+    ],
+    "astropad-studio": [
+      {
+        "cask": "astropad-studio",
+        "count": "23"
+      }
+    ],
+    "atext": [
+      {
+        "cask": "atext",
+        "count": "753"
+      }
+    ],
+    "atlantis": [
+      {
+        "cask": "atlantis",
+        "count": "52"
+      }
+    ],
+    "atlassian-companion": [
+      {
+        "cask": "atlassian-companion",
+        "count": "4"
+      }
+    ],
+    "atlauncher": [
+      {
+        "cask": "atlauncher",
+        "count": "47"
+      }
+    ],
+    "atok": [
+      {
+        "cask": "atok",
+        "count": "119"
+      }
+    ],
+    "atok-passport": [
+      {
+        "cask": "atok-passport",
+        "count": "5"
+      }
+    ],
+    "atom": [
+      {
+        "cask": "atom",
+        "count": "63,453"
+      }
+    ],
+    "atom-beta": [
+      {
+        "cask": "atom-beta",
+        "count": "363"
+      }
+    ],
+    "atom-custom": [
+      {
+        "cask": "atom-custom",
+        "count": "10"
+      }
+    ],
+    "atom-nightly": [
+      {
+        "cask": "atom-nightly",
+        "count": "102"
+      }
+    ],
+    "atom@1.35.1": [
+      {
+        "cask": "atom@1.35.1",
+        "count": "378"
+      }
+    ],
+    "atto-config-430": [
+      {
+        "cask": "atto-config-430",
+        "count": "9"
+      }
+    ],
+    "atto-tlfc-190326": [
+      {
+        "cask": "atto-tlfc-190326",
+        "count": "6"
+      }
+    ],
+    "atto-tlfc-228": [
+      {
+        "cask": "atto-tlfc-228",
+        "count": "8"
+      }
+    ],
+    "au-lab": [
+      {
+        "cask": "au-lab",
+        "count": "637"
+      }
+    ],
+    "audacity": [
+      {
+        "cask": "audacity",
+        "count": "80"
+      }
+    ],
+    "audeze-reveal": [
+      {
+        "cask": "audeze-reveal",
+        "count": "1"
+      }
+    ],
+    "audio-damage-eos": [
+      {
+        "cask": "audio-damage-eos",
+        "count": "1"
+      }
+    ],
+    "audio-hijack": [
+      {
+        "cask": "audio-hijack",
+        "count": "1,026"
+      }
+    ],
+    "audio-toolbox": [
+      {
+        "cask": "audio-toolbox",
+        "count": "2"
+      }
+    ],
+    "audiobook-builder": [
+      {
+        "cask": "audiobook-builder",
+        "count": "97"
+      }
+    ],
+    "audiobookbinder": [
+      {
+        "cask": "audiobookbinder",
+        "count": "181"
+      }
+    ],
+    "audioscrobbler": [
+      {
+        "cask": "audioscrobbler",
+        "count": "20"
+      }
+    ],
+    "audioslicer": [
+      {
+        "cask": "audioslicer",
+        "count": "40"
+      }
+    ],
+    "audirvana": [
+      {
+        "cask": "audirvana",
+        "count": "269"
+      }
+    ],
+    "audirvana-plus2": [
+      {
+        "cask": "audirvana-plus2",
+        "count": "1"
+      }
+    ],
+    "augur": [
+      {
+        "cask": "augur",
+        "count": "38"
+      }
+    ],
+    "aurora": [
+      {
+        "cask": "aurora",
+        "count": "61"
+      }
+    ],
+    "aurora-hdr": [
+      {
+        "cask": "aurora-hdr",
+        "count": "54"
+      }
+    ],
+    "aurora-hdr-2018": [
+      {
+        "cask": "aurora-hdr-2018",
+        "count": "1"
+      }
+    ],
+    "auryo": [
+      {
+        "cask": "auryo",
+        "count": "44"
+      }
+    ],
+    "ausweisapp2": [
+      {
+        "cask": "ausweisapp2",
+        "count": "2"
+      }
+    ],
+    "authy": [
+      {
+        "cask": "authy",
+        "count": "6,387"
+      }
+    ],
+    "auto-updates": [
+      {
+        "cask": "auto-updates",
+        "count": "2"
+      }
+    ],
+    "autobeat-player": [
+      {
+        "cask": "autobeat-player",
+        "count": "2"
+      }
+    ],
+    "autocad": [
+      {
+        "cask": "autocad",
+        "count": "1"
+      }
+    ],
+    "autodesk-fusion-360": [
+      {
+        "cask": "autodesk-fusion-360",
+        "count": "1"
+      }
+    ],
+    "autodesk-fusion360": [
+      {
+        "cask": "autodesk-fusion360",
+        "count": "625"
+      }
+    ],
+    "autodmg": [
+      {
+        "cask": "autodmg",
+        "count": "348"
+      }
+    ],
+    "autofirma": [
+      {
+        "cask": "autofirma",
+        "count": "64"
+      }
+    ],
+    "automatic": [
+      {
+        "cask": "automatic",
+        "count": "1"
+      }
+    ],
+    "automute": [
+      {
+        "cask": "automute",
+        "count": "95"
+      }
+    ],
+    "autopano-giga": [
+      {
+        "cask": "autopano-giga",
+        "count": "5"
+      }
+    ],
+    "autopano-pro": [
+      {
+        "cask": "autopano-pro",
+        "count": "1"
+      }
+    ],
+    "autopkgr": [
+      {
+        "cask": "autopkgr",
+        "count": "257"
+      }
+    ],
+    "autovolume": [
+      {
+        "cask": "autovolume",
+        "count": "14"
+      }
+    ],
+    "autumn": [
+      {
+        "cask": "autumn",
+        "count": "48"
+      }
+    ],
+    "avast-secureline-vpn": [
+      {
+        "cask": "avast-secureline-vpn",
+        "count": "55"
+      }
+    ],
+    "avast-security": [
+      {
+        "cask": "avast-security",
+        "count": "1,436"
+      }
+    ],
+    "aveee_adobe_cc2020": [
+      {
+        "cask": "aveee_adobe_cc2020",
+        "count": "3"
+      }
+    ],
+    "aveee_adobe_remover": [
+      {
+        "cask": "aveee_adobe_remover",
+        "count": "1"
+      }
+    ],
+    "aveee_blender2.80": [
+      {
+        "cask": "aveee_blender2.80",
+        "count": "1"
+      }
+    ],
+    "aveee_blender2.81": [
+      {
+        "cask": "aveee_blender2.81",
+        "count": "2"
+      }
+    ],
+    "aveee_blender2.82": [
+      {
+        "cask": "aveee_blender2.82",
+        "count": "1"
+      }
+    ],
+    "aveee_pulsesecure": [
+      {
+        "cask": "aveee_pulsesecure",
+        "count": "1"
+      }
+    ],
+    "aveee_renderman": [
+      {
+        "cask": "aveee_renderman",
+        "count": "2"
+      }
+    ],
+    "aveee_rmfh": [
+      {
+        "cask": "aveee_rmfh",
+        "count": "5"
+      }
+    ],
+    "aveee_slack": [
+      {
+        "cask": "aveee_slack",
+        "count": "1"
+      }
+    ],
+    "aveee_vuescan": [
+      {
+        "cask": "aveee_vuescan",
+        "count": "1"
+      }
+    ],
+    "aveee_workgroup": [
+      {
+        "cask": "aveee_workgroup",
+        "count": "2"
+      }
+    ],
+    "avg-antivirus": [
+      {
+        "cask": "avg-antivirus",
+        "count": "354"
+      }
+    ],
+    "aviatrix-vpn-client": [
+      {
+        "cask": "aviatrix-vpn-client",
+        "count": "290"
+      }
+    ],
+    "avibrazil-rdm": [
+      {
+        "cask": "avibrazil-rdm",
+        "count": "1,511"
+      }
+    ],
+    "avid-link": [
+      {
+        "cask": "avid-link",
+        "count": "1"
+      }
+    ],
+    "avid-mediacomposer-201911": [
+      {
+        "cask": "avid-mediacomposer-201911",
+        "count": "5"
+      }
+    ],
+    "avid-mediacomposer-20199": [
+      {
+        "cask": "avid-mediacomposer-20199",
+        "count": "3"
+      }
+    ],
+    "avidcodecsle": [
+      {
+        "cask": "avidcodecsle",
+        "count": "87"
+      }
+    ],
+    "avidemux": [
+      {
+        "cask": "avidemux",
+        "count": "1,923"
+      }
+    ],
+    "avifquicklook": [
+      {
+        "cask": "avifquicklook",
+        "count": "1"
+      }
+    ],
+    "avira": [
+      {
+        "cask": "avira",
+        "count": "66"
+      }
+    ],
+    "avira-antivirus": [
+      {
+        "cask": "avira-antivirus",
+        "count": "655"
+      }
+    ],
+    "avira-vpn": [
+      {
+        "cask": "avira-vpn",
+        "count": "33"
+      }
+    ],
+    "avitools": [
+      {
+        "cask": "avitools",
+        "count": "14"
+      }
+    ],
+    "avocode": [
+      {
+        "cask": "avocode",
+        "count": "234"
+      }
+    ],
+    "avogadro": [
+      {
+        "cask": "avogadro",
+        "count": "237"
+      }
+    ],
+    "avogadro-graph": [
+      {
+        "cask": "avogadro-graph",
+        "count": "1"
+      }
+    ],
+    "awa": [
+      {
+        "cask": "awa",
+        "count": "19"
+      }
+    ],
+    "aware": [
+      {
+        "cask": "aware",
+        "count": "274"
+      }
+    ],
+    "awareness": [
+      {
+        "cask": "awareness",
+        "count": "93"
+      }
+    ],
+    "awips-python": [
+      {
+        "cask": "awips-python",
+        "count": "54"
+      }
+    ],
+    "aws-cli": [
+      {
+        "cask": "aws-cli",
+        "count": "2"
+      }
+    ],
+    "aws-vault": [
+      {
+        "cask": "aws-vault",
+        "count": "17,375"
+      }
+    ],
+    "aws-vault-beta": [
+      {
+        "cask": "aws-vault-beta",
+        "count": "1"
+      }
+    ],
+    "awsaml": [
+      {
+        "cask": "awsaml",
+        "count": "232"
+      }
+    ],
+    "awscli": [
+      {
+        "cask": "awscli",
+        "count": "2"
+      }
+    ],
+    "awscli-v2-unofficial": [
+      {
+        "cask": "awscli-v2-unofficial",
+        "count": "3"
+      }
+    ],
+    "awsx": [
+      {
+        "cask": "awsx",
+        "count": "6"
+      }
+    ],
+    "axe-core": [
+      {
+        "cask": "axe-core",
+        "count": "13"
+      }
+    ],
+    "axe-edit-iii": [
+      {
+        "cask": "axe-edit-iii",
+        "count": "3"
+      }
+    ],
+    "axe-electrum": [
+      {
+        "cask": "axe-electrum",
+        "count": "2"
+      }
+    ],
+    "axoloti": [
+      {
+        "cask": "axoloti",
+        "count": "1"
+      }
+    ],
+    "axoloti-runtime": [
+      {
+        "cask": "axoloti-runtime",
+        "count": "1"
+      }
+    ],
+    "axure-rp": [
+      {
+        "cask": "axure-rp",
+        "count": "976"
+      }
+    ],
+    "axure-rp8": [
+      {
+        "cask": "axure-rp8",
+        "count": "3"
+      }
+    ],
+    "azcopy": [
+      {
+        "cask": "azcopy",
+        "count": "2"
+      }
+    ],
+    "azuljdk11": [
+      {
+        "cask": "azuljdk11",
+        "count": "1"
+      }
+    ],
+    "azuljdk8": [
+      {
+        "cask": "azuljdk8",
+        "count": "1"
+      }
+    ],
+    "azure-data-studio": [
+      {
+        "cask": "azure-data-studio",
+        "count": "3,394"
+      }
+    ],
+    "back-in-time": [
+      {
+        "cask": "back-in-time",
+        "count": "41"
+      }
+    ],
+    "backblaze": [
+      {
+        "cask": "backblaze",
+        "count": "1,760"
+      }
+    ],
+    "backblaze-downloader": [
+      {
+        "cask": "backblaze-downloader",
+        "count": "147"
+      }
+    ],
+    "background-music": [
+      {
+        "cask": "background-music",
+        "count": "11,808"
+      }
+    ],
+    "background-music-pre": [
+      {
+        "cask": "background-music-pre",
+        "count": "215"
+      }
+    ],
+    "backlog": [
+      {
+        "cask": "backlog",
+        "count": "29"
+      }
+    ],
+    "backupandsync": [
+      {
+        "cask": "backupandsync",
+        "count": "15"
+      }
+    ],
+    "backuploupe": [
+      {
+        "cask": "backuploupe",
+        "count": "229"
+      }
+    ],
+    "badlion-client": [
+      {
+        "cask": "badlion-client",
+        "count": "16"
+      }
+    ],
+    "badlionclient": [
+      {
+        "cask": "badlionclient",
+        "count": "1"
+      }
+    ],
+    "baiducloud": [
+      {
+        "cask": "baiducloud",
+        "count": "648"
+      }
+    ],
+    "baiduhi": [
+      {
+        "cask": "baiduhi",
+        "count": "45"
+      }
+    ],
+    "baiduinput": [
+      {
+        "cask": "baiduinput",
+        "count": "411"
+      }
+    ],
+    "baidunetdisk": [
+      {
+        "cask": "baidunetdisk",
+        "count": "5,183"
+      }
+    ],
+    "baidunetdisk2.2.2": [
+      {
+        "cask": "baidunetdisk2.2.2",
+        "count": "2"
+      }
+    ],
+    "baiduwebdevtools": [
+      {
+        "cask": "baiduwebdevtools",
+        "count": "1"
+      }
+    ],
+    "bailiff": [
+      {
+        "cask": "bailiff",
+        "count": "6"
+      }
+    ],
+    "balance-lock": [
+      {
+        "cask": "balance-lock",
+        "count": "48"
+      }
+    ],
+    "balenaetcher": [
+      {
+        "cask": "balenaetcher",
+        "count": "27,502"
+      }
+    ],
+    "ballast": [
+      {
+        "cask": "ballast",
+        "count": "253"
+      }
+    ],
+    "ballerina": [
+      {
+        "cask": "ballerina",
+        "count": "15"
+      }
+    ],
+    "balloon-desktop": [
+      {
+        "cask": "balloon-desktop",
+        "count": "4"
+      }
+    ],
+    "balsamiq-mockups": [
+      {
+        "cask": "balsamiq-mockups",
+        "count": "767"
+      }
+    ],
+    "balsamiq-wireframes": [
+      {
+        "cask": "balsamiq-wireframes",
+        "count": "184"
+      }
+    ],
+    "bandage": [
+      {
+        "cask": "bandage",
+        "count": "24"
+      }
+    ],
+    "bankid": [
+      {
+        "cask": "bankid",
+        "count": "119"
+      }
+    ],
+    "banking-4": [
+      {
+        "cask": "banking-4",
+        "count": "146"
+      }
+    ],
+    "banktivity": [
+      {
+        "cask": "banktivity",
+        "count": "207"
+      }
+    ],
+    "banshee": [
+      {
+        "cask": "banshee",
+        "count": "92"
+      }
+    ],
+    "baretorrent": [
+      {
+        "cask": "baretorrent",
+        "count": "197"
+      }
+    ],
+    "baritone": [
+      {
+        "cask": "baritone",
+        "count": "20"
+      }
+    ],
+    "barklyjava8": [
+      {
+        "cask": "barklyjava8",
+        "count": "49"
+      }
+    ],
+    "barmaid": [
+      {
+        "cask": "barmaid",
+        "count": "16"
+      }
+    ],
+    "barracuda-archive-search": [
+      {
+        "cask": "barracuda-archive-search",
+        "count": "1"
+      }
+    ],
+    "barrier": [
+      {
+        "cask": "barrier",
+        "count": "2,289"
+      }
+    ],
+    "bartender": [
+      {
+        "cask": "bartender",
+        "count": "8,119"
+      }
+    ],
+    "bartender-beta": [
+      {
+        "cask": "bartender-beta",
+        "count": "1"
+      }
+    ],
+    "barxtemp": [
+      {
+        "cask": "barxtemp",
+        "count": "79"
+      }
+    ],
+    "base": [
+      {
+        "cask": "base",
+        "count": "149"
+      }
+    ],
+    "basecamp": [
+      {
+        "cask": "basecamp",
+        "count": "713"
+      }
+    ],
+    "basictex": [
+      {
+        "cask": "basictex",
+        "count": "20,554"
+      }
+    ],
+    "basler-pylon": [
+      {
+        "cask": "basler-pylon",
+        "count": "2"
+      }
+    ],
+    "bassshapes": [
+      {
+        "cask": "bassshapes",
+        "count": "1"
+      }
+    ],
+    "batchmod": [
+      {
+        "cask": "batchmod",
+        "count": "188"
+      }
+    ],
+    "bathyscaphe": [
+      {
+        "cask": "bathyscaphe",
+        "count": "216"
+      }
+    ],
+    "batteries": [
+      {
+        "cask": "batteries",
+        "count": "1"
+      }
+    ],
+    "battery-guardian": [
+      {
+        "cask": "battery-guardian",
+        "count": "79"
+      }
+    ],
+    "battery-report": [
+      {
+        "cask": "battery-report",
+        "count": "77"
+      }
+    ],
+    "battle-net": [
+      {
+        "cask": "battle-net",
+        "count": "3,281"
+      }
+    ],
+    "battle-net-installer": [
+      {
+        "cask": "battle-net-installer",
+        "count": "3"
+      }
+    ],
+    "battlescribe": [
+      {
+        "cask": "battlescribe",
+        "count": "23"
+      }
+    ],
+    "baudline": [
+      {
+        "cask": "baudline",
+        "count": "63"
+      }
+    ],
+    "bb-java7": [
+      {
+        "cask": "bb-java7",
+        "count": "5"
+      }
+    ],
+    "bb-java8": [
+      {
+        "cask": "bb-java8",
+        "count": "5"
+      }
+    ],
+    "bbc-iplayer-downloads": [
+      {
+        "cask": "bbc-iplayer-downloads",
+        "count": "119"
+      }
+    ],
+    "bbedit": [
+      {
+        "cask": "bbedit",
+        "count": "4,057"
+      }
+    ],
+    "bdash": [
+      {
+        "cask": "bdash",
+        "count": "37"
+      }
+    ],
+    "bdinfo": [
+      {
+        "cask": "bdinfo",
+        "count": "22"
+      }
+    ],
+    "beacon-finder": [
+      {
+        "cask": "beacon-finder",
+        "count": "2"
+      }
+    ],
+    "beacon-scanner": [
+      {
+        "cask": "beacon-scanner",
+        "count": "76"
+      }
+    ],
+    "beagleim": [
+      {
+        "cask": "beagleim",
+        "count": "37"
+      }
+    ],
+    "beagleim-beta": [
+      {
+        "cask": "beagleim-beta",
+        "count": "4"
+      }
+    ],
+    "beaker-browser": [
+      {
+        "cask": "beaker-browser",
+        "count": "341"
+      }
+    ],
+    "beamer": [
+      {
+        "cask": "beamer",
+        "count": "504"
+      }
+    ],
+    "bean": [
+      {
+        "cask": "bean",
+        "count": "57"
+      }
+    ],
+    "beardedspice": [
+      {
+        "cask": "beardedspice",
+        "count": "764"
+      }
+    ],
+    "bearychat": [
+      {
+        "cask": "bearychat",
+        "count": "30"
+      }
+    ],
+    "beatport-pro": [
+      {
+        "cask": "beatport-pro",
+        "count": "71"
+      }
+    ],
+    "beatunes": [
+      {
+        "cask": "beatunes",
+        "count": "39"
+      }
+    ],
+    "beautune": [
+      {
+        "cask": "beautune",
+        "count": "3"
+      }
+    ],
+    "bee": [
+      {
+        "cask": "bee",
+        "count": "125"
+      }
+    ],
+    "beekeeper-studio": [
+      {
+        "cask": "beekeeper-studio",
+        "count": "2"
+      }
+    ],
+    "beersmith": [
+      {
+        "cask": "beersmith",
+        "count": "30"
+      }
+    ],
+    "behringer-x-air-edit": [
+      {
+        "cask": "behringer-x-air-edit",
+        "count": "2"
+      }
+    ],
+    "behringer-x32-edit": [
+      {
+        "cask": "behringer-x32-edit",
+        "count": "17"
+      }
+    ],
+    "beoplay-software-update": [
+      {
+        "cask": "beoplay-software-update",
+        "count": "36"
+      }
+    ],
+    "bestres": [
+      {
+        "cask": "bestres",
+        "count": "66"
+      }
+    ],
+    "betaflight-configurator": [
+      {
+        "cask": "betaflight-configurator",
+        "count": "147"
+      }
+    ],
+    "better-window-manager": [
+      {
+        "cask": "better-window-manager",
+        "count": "64"
+      }
+    ],
+    "bettertouchtool": [
+      {
+        "cask": "bettertouchtool",
+        "count": "12,183"
+      }
+    ],
+    "bettertouchtool-2428": [
+      {
+        "cask": "bettertouchtool-2428",
+        "count": "1"
+      }
+    ],
+    "betterzip": [
+      {
+        "cask": "betterzip",
+        "count": "7,507"
+      }
+    ],
+    "betterzip-beta": [
+      {
+        "cask": "betterzip-beta",
+        "count": "8"
+      }
+    ],
+    "betterzipql": [
+      {
+        "cask": "betterzipql",
+        "count": "146"
+      }
+    ],
+    "between": [
+      {
+        "cask": "between",
+        "count": "35"
+      }
+    ],
+    "betwixt": [
+      {
+        "cask": "betwixt",
+        "count": "30"
+      }
+    ],
+    "beyond-compare": [
+      {
+        "cask": "beyond-compare",
+        "count": "4,604"
+      }
+    ],
+    "beyond-compare-beta": [
+      {
+        "cask": "beyond-compare-beta",
+        "count": "87"
+      }
+    ],
+    "bforartists": [
+      {
+        "cask": "bforartists",
+        "count": "13"
+      }
+    ],
+    "bfxr": [
+      {
+        "cask": "bfxr",
+        "count": "51"
+      }
+    ],
+    "bibdesk": [
+      {
+        "cask": "bibdesk",
+        "count": "1,160"
+      }
+    ],
+    "big-mean-folder-machine": [
+      {
+        "cask": "big-mean-folder-machine",
+        "count": "37"
+      }
+    ],
+    "bilibili": [
+      {
+        "cask": "bilibili",
+        "count": "622"
+      }
+    ],
+    "bilibili-live-helper": [
+      {
+        "cask": "bilibili-live-helper",
+        "count": "7"
+      }
+    ],
+    "bilimini": [
+      {
+        "cask": "bilimini",
+        "count": "16"
+      }
+    ],
+    "binance": [
+      {
+        "cask": "binance",
+        "count": "1"
+      }
+    ],
+    "binary-ninja": [
+      {
+        "cask": "binary-ninja",
+        "count": "193"
+      }
+    ],
+    "bink-player": [
+      {
+        "cask": "bink-player",
+        "count": "6"
+      }
+    ],
+    "bino": [
+      {
+        "cask": "bino",
+        "count": "44"
+      }
+    ],
+    "biopassfido": [
+      {
+        "cask": "biopassfido",
+        "count": "4"
+      }
+    ],
+    "birdfont": [
+      {
+        "cask": "birdfont",
+        "count": "191"
+      }
+    ],
+    "biscuit": [
+      {
+        "cask": "biscuit",
+        "count": "142"
+      }
+    ],
+    "bisq": [
+      {
+        "cask": "bisq",
+        "count": "178"
+      }
+    ],
+    "bit-slicer": [
+      {
+        "cask": "bit-slicer",
+        "count": "121"
+      }
+    ],
+    "bitbar": [
+      {
+        "cask": "bitbar",
+        "count": "4,629"
+      }
+    ],
+    "bitcoin-classic": [
+      {
+        "cask": "bitcoin-classic",
+        "count": "1"
+      }
+    ],
+    "bitcoin-core": [
+      {
+        "cask": "bitcoin-core",
+        "count": "425"
+      }
+    ],
+    "bitcoin-unlimited": [
+      {
+        "cask": "bitcoin-unlimited",
+        "count": "1"
+      }
+    ],
+    "bitdefender": [
+      {
+        "cask": "bitdefender",
+        "count": "1"
+      }
+    ],
+    "bitkeeper": [
+      {
+        "cask": "bitkeeper",
+        "count": "6"
+      }
+    ],
+    "bitlord": [
+      {
+        "cask": "bitlord",
+        "count": "1"
+      }
+    ],
+    "bitmessage": [
+      {
+        "cask": "bitmessage",
+        "count": "71"
+      }
+    ],
+    "bitpim": [
+      {
+        "cask": "bitpim",
+        "count": "2"
+      }
+    ],
+    "bitrix24": [
+      {
+        "cask": "bitrix24",
+        "count": "65"
+      }
+    ],
+    "bitshares": [
+      {
+        "cask": "bitshares",
+        "count": "16"
+      }
+    ],
+    "bitwarden": [
+      {
+        "cask": "bitwarden",
+        "count": "6,277"
+      }
+    ],
+    "bitwig-studio": [
+      {
+        "cask": "bitwig-studio",
+        "count": "89"
+      }
+    ],
+    "biz-talk": [
+      {
+        "cask": "biz-talk",
+        "count": "5"
+      }
+    ],
+    "blackhole": [
+      {
+        "cask": "blackhole",
+        "count": "5,684"
+      }
+    ],
+    "blackscreen-screensaver": [
+      {
+        "cask": "blackscreen-screensaver",
+        "count": "14"
+      }
+    ],
+    "blackthorne": [
+      {
+        "cask": "blackthorne",
+        "count": "6"
+      }
+    ],
+    "blackvue-viewer": [
+      {
+        "cask": "blackvue-viewer",
+        "count": "30"
+      }
+    ],
+    "blank-screensaver": [
+      {
+        "cask": "blank-screensaver",
+        "count": "118"
+      }
+    ],
+    "blankscreen": [
+      {
+        "cask": "blankscreen",
+        "count": "1"
+      }
+    ],
+    "blender": [
+      {
+        "cask": "blender",
+        "count": "8,712"
+      }
+    ],
+    "blender-beta": [
+      {
+        "cask": "blender-beta",
+        "count": "1"
+      }
+    ],
+    "blheli-configurator": [
+      {
+        "cask": "blheli-configurator",
+        "count": "32"
+      }
+    ],
+    "blink1control": [
+      {
+        "cask": "blink1control",
+        "count": "31"
+      }
+    ],
+    "blisk": [
+      {
+        "cask": "blisk",
+        "count": "448"
+      }
+    ],
+    "blitz": [
+      {
+        "cask": "blitz",
+        "count": "118"
+      }
+    ],
+    "blitzgg": [
+      {
+        "cask": "blitzgg",
+        "count": "1"
+      }
+    ],
+    "blobby-volley2": [
+      {
+        "cask": "blobby-volley2",
+        "count": "48"
+      }
+    ],
+    "blockblock": [
+      {
+        "cask": "blockblock",
+        "count": "615"
+      }
+    ],
+    "blocks-code": [
+      {
+        "cask": "blocks-code",
+        "count": "10"
+      }
+    ],
+    "blockstack": [
+      {
+        "cask": "blockstack",
+        "count": "58"
+      }
+    ],
+    "blocs": [
+      {
+        "cask": "blocs",
+        "count": "40"
+      }
+    ],
+    "bloodhound": [
+      {
+        "cask": "bloodhound",
+        "count": "201"
+      }
+    ],
+    "bloomrpc": [
+      {
+        "cask": "bloomrpc",
+        "count": "9,762"
+      }
+    ],
+    "blooo": [
+      {
+        "cask": "blooo",
+        "count": "3"
+      }
+    ],
+    "blowhole": [
+      {
+        "cask": "blowhole",
+        "count": "5"
+      }
+    ],
+    "blu-ray-player": [
+      {
+        "cask": "blu-ray-player",
+        "count": "95"
+      }
+    ],
+    "blu-ray-player-pro": [
+      {
+        "cask": "blu-ray-player-pro",
+        "count": "98"
+      }
+    ],
+    "blue-jeans": [
+      {
+        "cask": "blue-jeans",
+        "count": "14,974"
+      }
+    ],
+    "blue-jeans-browser-plugin": [
+      {
+        "cask": "blue-jeans-browser-plugin",
+        "count": "91"
+      }
+    ],
+    "bluecat-chorus-vst3": [
+      {
+        "cask": "bluecat-chorus-vst3",
+        "count": "3"
+      }
+    ],
+    "bluecat-flanger-vst3": [
+      {
+        "cask": "bluecat-flanger-vst3",
+        "count": "1"
+      }
+    ],
+    "bluecat-freeamp-vst3": [
+      {
+        "cask": "bluecat-freeamp-vst3",
+        "count": "2"
+      }
+    ],
+    "bluecat-freqanalyst-vst3": [
+      {
+        "cask": "bluecat-freqanalyst-vst3",
+        "count": "2"
+      }
+    ],
+    "bluecat-gainsuite-vst3": [
+      {
+        "cask": "bluecat-gainsuite-vst3",
+        "count": "1"
+      }
+    ],
+    "bluecat-phaser-vst3": [
+      {
+        "cask": "bluecat-phaser-vst3",
+        "count": "1"
+      }
+    ],
+    "bluecat-tripleeq-au": [
+      {
+        "cask": "bluecat-tripleeq-au",
+        "count": "2"
+      }
+    ],
+    "bluecat-tripleeq-vst3": [
+      {
+        "cask": "bluecat-tripleeq-vst3",
+        "count": "2"
+      }
+    ],
+    "bluefish": [
+      {
+        "cask": "bluefish",
+        "count": "164"
+      }
+    ],
+    "bluegriffon": [
+      {
+        "cask": "bluegriffon",
+        "count": "124"
+      }
+    ],
+    "blueharvest": [
+      {
+        "cask": "blueharvest",
+        "count": "137"
+      }
+    ],
+    "bluej": [
+      {
+        "cask": "bluej",
+        "count": "229"
+      }
+    ],
+    "bluesense": [
+      {
+        "cask": "bluesense",
+        "count": "18"
+      }
+    ],
+    "blueservice": [
+      {
+        "cask": "blueservice",
+        "count": "3"
+      }
+    ],
+    "bluestacks": [
+      {
+        "cask": "bluestacks",
+        "count": "2,687"
+      }
+    ],
+    "bmux": [
+      {
+        "cask": "bmux",
+        "count": "2"
+      }
+    ],
+    "bmw-vagrant": [
+      {
+        "cask": "bmw-vagrant",
+        "count": "28"
+      }
+    ],
+    "bob": [
+      {
+        "cask": "bob",
+        "count": "1,293"
+      }
+    ],
+    "boc-security-plugin": [
+      {
+        "cask": "boc-security-plugin",
+        "count": "1"
+      }
+    ],
+    "bodo": [
+      {
+        "cask": "bodo",
+        "count": "1"
+      }
+    ],
+    "boinc": [
+      {
+        "cask": "boinc",
+        "count": "555"
+      }
+    ],
+    "boingo-wi-finder": [
+      {
+        "cask": "boingo-wi-finder",
+        "count": "1"
+      }
+    ],
+    "bolts": [
+      {
+        "cask": "bolts",
+        "count": "36"
+      }
+    ],
+    "bonitastudiocommunity": [
+      {
+        "cask": "bonitastudiocommunity",
+        "count": "26"
+      }
+    ],
+    "bonjeff": [
+      {
+        "cask": "bonjeff",
+        "count": "36"
+      }
+    ],
+    "bonjour-browser": [
+      {
+        "cask": "bonjour-browser",
+        "count": "505"
+      }
+    ],
+    "bookends": [
+      {
+        "cask": "bookends",
+        "count": "217"
+      }
+    ],
+    "bookmacster": [
+      {
+        "cask": "bookmacster",
+        "count": "58"
+      }
+    ],
+    "bookshelf": [
+      {
+        "cask": "bookshelf",
+        "count": "1"
+      }
+    ],
+    "boom": [
+      {
+        "cask": "boom",
+        "count": "283"
+      }
+    ],
+    "boom-3d": [
+      {
+        "cask": "boom-3d",
+        "count": "726"
+      }
+    ],
+    "boom-recorder": [
+      {
+        "cask": "boom-recorder",
+        "count": "4"
+      }
+    ],
+    "boom3d": [
+      {
+        "cask": "boom3d",
+        "count": "1"
+      }
+    ],
+    "boonzi": [
+      {
+        "cask": "boonzi",
+        "count": "4"
+      }
+    ],
+    "boostnote": [
+      {
+        "cask": "boostnote",
+        "count": "4,165"
+      }
+    ],
+    "bootchamp": [
+      {
+        "cask": "bootchamp",
+        "count": "43"
+      }
+    ],
+    "bootstrap-studio": [
+      {
+        "cask": "bootstrap-studio",
+        "count": "168"
+      }
+    ],
+    "bootxchanger": [
+      {
+        "cask": "bootxchanger",
+        "count": "28"
+      }
+    ],
+    "booxter": [
+      {
+        "cask": "booxter",
+        "count": "3"
+      }
+    ],
+    "borgbackup": [
+      {
+        "cask": "borgbackup",
+        "count": "1,943"
+      }
+    ],
+    "bose-soundtouch": [
+      {
+        "cask": "bose-soundtouch",
+        "count": "41"
+      }
+    ],
+    "bose-updater": [
+      {
+        "cask": "bose-updater",
+        "count": "147"
+      }
+    ],
+    "bossa": [
+      {
+        "cask": "bossa",
+        "count": "88"
+      }
+    ],
+    "bot-framework-emulator": [
+      {
+        "cask": "bot-framework-emulator",
+        "count": "168"
+      }
+    ],
+    "bowtie": [
+      {
+        "cask": "bowtie",
+        "count": "219"
+      }
+    ],
+    "box-drive": [
+      {
+        "cask": "box-drive",
+        "count": "1,084"
+      }
+    ],
+    "box-edit": [
+      {
+        "cask": "box-edit",
+        "count": "99"
+      }
+    ],
+    "box-sync": [
+      {
+        "cask": "box-sync",
+        "count": "862"
+      }
+    ],
+    "boxcryptor": [
+      {
+        "cask": "boxcryptor",
+        "count": "590"
+      }
+    ],
+    "boxer": [
+      {
+        "cask": "boxer",
+        "count": "380"
+      }
+    ],
+    "boxofsnoo-fairmount": [
+      {
+        "cask": "boxofsnoo-fairmount",
+        "count": "38"
+      }
+    ],
+    "boxy-suite": [
+      {
+        "cask": "boxy-suite",
+        "count": "66"
+      }
+    ],
+    "brackets": [
+      {
+        "cask": "brackets",
+        "count": "3,668"
+      }
+    ],
+    "bradiko": [
+      {
+        "cask": "bradiko",
+        "count": "3"
+      }
+    ],
+    "bragi-updater": [
+      {
+        "cask": "bragi-updater",
+        "count": "1"
+      }
+    ],
+    "braid": [
+      {
+        "cask": "braid",
+        "count": "1"
+      }
+    ],
+    "brain-workshop": [
+      {
+        "cask": "brain-workshop",
+        "count": "59"
+      }
+    ],
+    "brainfm": [
+      {
+        "cask": "brainfm",
+        "count": "61"
+      }
+    ],
+    "brainio": [
+      {
+        "cask": "brainio",
+        "count": "2"
+      }
+    ],
+    "brave": [
+      {
+        "cask": "brave",
+        "count": "4"
+      }
+    ],
+    "brave-browser": [
+      {
+        "cask": "brave-browser",
+        "count": "22,234"
+      }
+    ],
+    "brave-browser-beta": [
+      {
+        "cask": "brave-browser-beta",
+        "count": "965"
+      }
+    ],
+    "brave-browser-dev": [
+      {
+        "cask": "brave-browser-dev",
+        "count": "436"
+      }
+    ],
+    "brave-browser-nightly": [
+      {
+        "cask": "brave-browser-nightly",
+        "count": "131"
+      }
+    ],
+    "breakaway": [
+      {
+        "cask": "breakaway",
+        "count": "21"
+      }
+    ],
+    "breaktimer": [
+      {
+        "cask": "breaktimer",
+        "count": "16"
+      }
+    ],
+    "breeze": [
+      {
+        "cask": "breeze",
+        "count": "14"
+      }
+    ],
+    "brewservicesmenubar": [
+      {
+        "cask": "brewservicesmenubar",
+        "count": "528"
+      }
+    ],
+    "brewtarget": [
+      {
+        "cask": "brewtarget",
+        "count": "46"
+      }
+    ],
+    "bria": [
+      {
+        "cask": "bria",
+        "count": "57"
+      }
+    ],
+    "bria-teams": [
+      {
+        "cask": "bria-teams",
+        "count": "13"
+      }
+    ],
+    "bricklink-studio": [
+      {
+        "cask": "bricklink-studio",
+        "count": "123"
+      }
+    ],
+    "bricksmith": [
+      {
+        "cask": "bricksmith",
+        "count": "50"
+      }
+    ],
+    "brightness": [
+      {
+        "cask": "brightness",
+        "count": "107"
+      }
+    ],
+    "brightness-sync": [
+      {
+        "cask": "brightness-sync",
+        "count": "25"
+      }
+    ],
+    "brisk": [
+      {
+        "cask": "brisk",
+        "count": "55"
+      }
+    ],
+    "brisync": [
+      {
+        "cask": "brisync",
+        "count": "155"
+      }
+    ],
+    "brl-cad-mged": [
+      {
+        "cask": "brl-cad-mged",
+        "count": "55"
+      }
+    ],
+    "brogue": [
+      {
+        "cask": "brogue",
+        "count": "94"
+      }
+    ],
+    "brook": [
+      {
+        "cask": "brook",
+        "count": "635"
+      }
+    ],
+    "brooklyn": [
+      {
+        "cask": "brooklyn",
+        "count": "6,607"
+      }
+    ],
+    "brother-p-touch-editor": [
+      {
+        "cask": "brother-p-touch-editor",
+        "count": "64"
+      }
+    ],
+    "brother-p-touch-update-software": [
+      {
+        "cask": "brother-p-touch-update-software",
+        "count": "29"
+      }
+    ],
+    "brother-pt-p710bt-printer-driver": [
+      {
+        "cask": "brother-pt-p710bt-printer-driver",
+        "count": "1"
+      }
+    ],
+    "brother-pt-p710bt-printer-setting-tool": [
+      {
+        "cask": "brother-pt-p710bt-printer-setting-tool",
+        "count": "1"
+      }
+    ],
+    "browser-chooserx": [
+      {
+        "cask": "browser-chooserx",
+        "count": "29"
+      }
+    ],
+    "browserosaurus": [
+      {
+        "cask": "browserosaurus",
+        "count": "609"
+      }
+    ],
+    "browserstacklocal": [
+      {
+        "cask": "browserstacklocal",
+        "count": "421"
+      }
+    ],
+    "brushviewql": [
+      {
+        "cask": "brushviewql",
+        "count": "2"
+      }
+    ],
+    "bsm": [
+      {
+        "cask": "bsm",
+        "count": "12"
+      }
+    ],
+    "btcpayserver-vault": [
+      {
+        "cask": "btcpayserver-vault",
+        "count": "8"
+      }
+    ],
+    "bubo": [
+      {
+        "cask": "bubo",
+        "count": "15"
+      }
+    ],
+    "buckshot": [
+      {
+        "cask": "buckshot",
+        "count": "1"
+      }
+    ],
+    "buddi": [
+      {
+        "cask": "buddi",
+        "count": "2"
+      }
+    ],
+    "bughub": [
+      {
+        "cask": "bughub",
+        "count": "1"
+      }
+    ],
+    "buildit-base-tools": [
+      {
+        "cask": "buildit-base-tools",
+        "count": "2"
+      }
+    ],
+    "buildit-java-based-tools": [
+      {
+        "cask": "buildit-java-based-tools",
+        "count": "1"
+      }
+    ],
+    "buildsettingextractor": [
+      {
+        "cask": "buildsettingextractor",
+        "count": "7"
+      }
+    ],
+    "bumptag": [
+      {
+        "cask": "bumptag",
+        "count": "1"
+      }
+    ],
+    "bunch": [
+      {
+        "cask": "bunch",
+        "count": "134"
+      }
+    ],
+    "bundle-intellij": [
+      {
+        "cask": "bundle-intellij",
+        "count": "3"
+      }
+    ],
+    "bunqcommunity-bunq": [
+      {
+        "cask": "bunqcommunity-bunq",
+        "count": "194"
+      }
+    ],
+    "burn": [
+      {
+        "cask": "burn",
+        "count": "1,795"
+      }
+    ],
+    "burp-suite": [
+      {
+        "cask": "burp-suite",
+        "count": "2,320"
+      }
+    ],
+    "burp-suite-pro": [
+      {
+        "cask": "burp-suite-pro",
+        "count": "4"
+      }
+    ],
+    "busycal": [
+      {
+        "cask": "busycal",
+        "count": "259"
+      }
+    ],
+    "busycontacts": [
+      {
+        "cask": "busycontacts",
+        "count": "78"
+      }
+    ],
+    "butler": [
+      {
+        "cask": "butler",
+        "count": "77"
+      }
+    ],
+    "butt": [
+      {
+        "cask": "butt",
+        "count": "114"
+      }
+    ],
+    "butter": [
+      {
+        "cask": "butter",
+        "count": "20"
+      }
+    ],
+    "buttercup": [
+      {
+        "cask": "buttercup",
+        "count": "1,001"
+      }
+    ],
+    "bwana": [
+      {
+        "cask": "bwana",
+        "count": "72"
+      }
+    ],
+    "bytewebdevtools": [
+      {
+        "cask": "bytewebdevtools",
+        "count": "1"
+      }
+    ],
+    "bzflag": [
+      {
+        "cask": "bzflag",
+        "count": "149"
+      }
+    ],
+    "c0re100-qbittorrent": [
+      {
+        "cask": "c0re100-qbittorrent",
+        "count": "378"
+      }
+    ],
+    "cabal": [
+      {
+        "cask": "cabal",
+        "count": "264"
+      }
+    ],
+    "cabal-desktop": [
+      {
+        "cask": "cabal-desktop",
+        "count": "2"
+      }
+    ],
+    "cableguys-filtershaper": [
+      {
+        "cask": "cableguys-filtershaper",
+        "count": "1"
+      }
+    ],
+    "cableguys-halftime": [
+      {
+        "cask": "cableguys-halftime",
+        "count": "1"
+      }
+    ],
+    "cableguys-shaperbox": [
+      {
+        "cask": "cableguys-shaperbox",
+        "count": "1"
+      }
+    ],
+    "cableguys-volumeshaper": [
+      {
+        "cask": "cableguys-volumeshaper",
+        "count": "1"
+      }
+    ],
+    "cacher": [
+      {
+        "cask": "cacher",
+        "count": "276"
+      }
+    ],
+    "caffeine": [
+      {
+        "cask": "caffeine",
+        "count": "14,183"
+      }
+    ],
+    "cajviewer": [
+      {
+        "cask": "cajviewer",
+        "count": "235"
+      }
+    ],
+    "cakebrew": [
+      {
+        "cask": "cakebrew",
+        "count": "10,359"
+      }
+    ],
+    "calcservice": [
+      {
+        "cask": "calcservice",
+        "count": "19"
+      }
+    ],
+    "caldigit-docking-utility": [
+      {
+        "cask": "caldigit-docking-utility",
+        "count": "49"
+      }
+    ],
+    "caldigit-thunderbolt-charging": [
+      {
+        "cask": "caldigit-thunderbolt-charging",
+        "count": "60"
+      }
+    ],
+    "caldigit-usb-c-pro-dock-driver": [
+      {
+        "cask": "caldigit-usb-c-pro-dock-driver",
+        "count": "2"
+      }
+    ],
+    "calendar-366": [
+      {
+        "cask": "calendar-366",
+        "count": "7"
+      }
+    ],
+    "calibre": [
+      {
+        "cask": "calibre",
+        "count": "27,664"
+      }
+    ],
+    "calibre3": [
+      {
+        "cask": "calibre3",
+        "count": "1"
+      }
+    ],
+    "callersbane": [
+      {
+        "cask": "callersbane",
+        "count": "4"
+      }
+    ],
+    "camed": [
+      {
+        "cask": "camed",
+        "count": "25"
+      }
+    ],
+    "camera-live": [
+      {
+        "cask": "camera-live",
+        "count": "84"
+      }
+    ],
+    "camerabag-photo": [
+      {
+        "cask": "camerabag-photo",
+        "count": "12"
+      }
+    ],
+    "camranger": [
+      {
+        "cask": "camranger",
+        "count": "1"
+      }
+    ],
+    "camtasia": [
+      {
+        "cask": "camtasia",
+        "count": "372"
+      }
+    ],
+    "camtasia2": [
+      {
+        "cask": "camtasia2",
+        "count": "1"
+      }
+    ],
+    "camtwist": [
+      {
+        "cask": "camtwist",
+        "count": "182"
+      }
+    ],
+    "camtwist-beta": [
+      {
+        "cask": "camtwist-beta",
+        "count": "2"
+      }
+    ],
+    "camtwiststudio": [
+      {
+        "cask": "camtwiststudio",
+        "count": "1"
+      }
+    ],
+    "camunda-modeler": [
+      {
+        "cask": "camunda-modeler",
+        "count": "934"
+      }
+    ],
+    "canary": [
+      {
+        "cask": "canary",
+        "count": "413"
+      }
+    ],
+    "candybar": [
+      {
+        "cask": "candybar",
+        "count": "32"
+      }
+    ],
+    "canoe": [
+      {
+        "cask": "canoe",
+        "count": "3"
+      }
+    ],
+    "canon-captureontouch-utility": [
+      {
+        "cask": "canon-captureontouch-utility",
+        "count": "9"
+      }
+    ],
+    "canon-eos-utility": [
+      {
+        "cask": "canon-eos-utility",
+        "count": "169"
+      }
+    ],
+    "canon-ijscanner1": [
+      {
+        "cask": "canon-ijscanner1",
+        "count": "2"
+      }
+    ],
+    "canon-ijscanner13f": [
+      {
+        "cask": "canon-ijscanner13f",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner14f": [
+      {
+        "cask": "canon-ijscanner14f",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner3": [
+      {
+        "cask": "canon-ijscanner3",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner5": [
+      {
+        "cask": "canon-ijscanner5",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner6": [
+      {
+        "cask": "canon-ijscanner6",
+        "count": "1"
+      }
+    ],
+    "canon-imageformula-driver": [
+      {
+        "cask": "canon-imageformula-driver",
+        "count": "5"
+      }
+    ],
+    "canon-imagerunner-printer-driver-ufrii": [
+      {
+        "cask": "canon-imagerunner-printer-driver-ufrii",
+        "count": "2"
+      }
+    ],
+    "canon-lide-90": [
+      {
+        "cask": "canon-lide-90",
+        "count": "8"
+      }
+    ],
+    "canon-pixma-mg6200-printer-driver": [
+      {
+        "cask": "canon-pixma-mg6200-printer-driver",
+        "count": "1"
+      }
+    ],
+    "canon-pixma-scanner-driver-ica": [
+      {
+        "cask": "canon-pixma-scanner-driver-ica",
+        "count": "66"
+      }
+    ],
+    "canon-printer": [
+      {
+        "cask": "canon-printer",
+        "count": "1"
+      }
+    ],
+    "canon-printer-driver": [
+      {
+        "cask": "canon-printer-driver",
+        "count": "7"
+      }
+    ],
+    "canon-scanner-driver": [
+      {
+        "cask": "canon-scanner-driver",
+        "count": "7"
+      }
+    ],
+    "canon-ufrii-lt-printer-driver": [
+      {
+        "cask": "canon-ufrii-lt-printer-driver",
+        "count": "36"
+      }
+    ],
+    "canoscan-lide500f": [
+      {
+        "cask": "canoscan-lide500f",
+        "count": "5"
+      }
+    ],
+    "canoscan-toolbox": [
+      {
+        "cask": "canoscan-toolbox",
+        "count": "4"
+      }
+    ],
+    "cantata": [
+      {
+        "cask": "cantata",
+        "count": "377"
+      }
+    ],
+    "caprine": [
+      {
+        "cask": "caprine",
+        "count": "3,634"
+      }
+    ],
+    "captain": [
+      {
+        "cask": "captain",
+        "count": "201"
+      }
+    ],
+    "captin": [
+      {
+        "cask": "captin",
+        "count": "143"
+      }
+    ],
+    "caption": [
+      {
+        "cask": "caption",
+        "count": "141"
+      }
+    ],
+    "capto": [
+      {
+        "cask": "capto",
+        "count": "88"
+      }
+    ],
+    "captur": [
+      {
+        "cask": "captur",
+        "count": "20"
+      }
+    ],
+    "capture-on-touch": [
+      {
+        "cask": "capture-on-touch",
+        "count": "2"
+      }
+    ],
+    "capture-one": [
+      {
+        "cask": "capture-one",
+        "count": "277"
+      }
+    ],
+    "carbon-copy-cloner": [
+      {
+        "cask": "carbon-copy-cloner",
+        "count": "2,616"
+      }
+    ],
+    "cardhop": [
+      {
+        "cask": "cardhop",
+        "count": "257"
+      }
+    ],
+    "caret": [
+      {
+        "cask": "caret",
+        "count": "162"
+      }
+    ],
+    "caret-beta": [
+      {
+        "cask": "caret-beta",
+        "count": "2"
+      }
+    ],
+    "cargo": [
+      {
+        "cask": "cargo",
+        "count": "2"
+      }
+    ],
+    "cask": [
+      {
+        "cask": "cask",
+        "count": "3"
+      }
+    ],
+    "castbridge": [
+      {
+        "cask": "castbridge",
+        "count": "6"
+      }
+    ],
+    "catalina-cache-cleaner": [
+      {
+        "cask": "catalina-cache-cleaner",
+        "count": "74"
+      }
+    ],
+    "catch": [
+      {
+        "cask": "catch",
+        "count": "97"
+      }
+    ],
+    "catdv-cc-panel": [
+      {
+        "cask": "catdv-cc-panel",
+        "count": "32"
+      }
+    ],
+    "catdv-pegasus-1307": [
+      {
+        "cask": "catdv-pegasus-1307",
+        "count": "6"
+      }
+    ],
+    "catdv-pro-1219": [
+      {
+        "cask": "catdv-pro-1219",
+        "count": "8"
+      }
+    ],
+    "cathode": [
+      {
+        "cask": "cathode",
+        "count": "201"
+      }
+    ],
+    "catlight": [
+      {
+        "cask": "catlight",
+        "count": "93"
+      }
+    ],
+    "causality": [
+      {
+        "cask": "causality",
+        "count": "1"
+      }
+    ],
+    "cave-story": [
+      {
+        "cask": "cave-story",
+        "count": "62"
+      }
+    ],
+    "cbz-manager": [
+      {
+        "cask": "cbz-manager",
+        "count": "22"
+      }
+    ],
+    "ccleaner": [
+      {
+        "cask": "ccleaner",
+        "count": "3,796"
+      }
+    ],
+    "ccmenu": [
+      {
+        "cask": "ccmenu",
+        "count": "488"
+      }
+    ],
+    "cctalk": [
+      {
+        "cask": "cctalk",
+        "count": "63"
+      }
+    ],
+    "cd-to": [
+      {
+        "cask": "cd-to",
+        "count": "241"
+      }
+    ],
+    "cd-to-hyper": [
+      {
+        "cask": "cd-to-hyper",
+        "count": "3"
+      }
+    ],
+    "cd-to-iterm": [
+      {
+        "cask": "cd-to-iterm",
+        "count": "174"
+      }
+    ],
+    "cd-to-terminal": [
+      {
+        "cask": "cd-to-terminal",
+        "count": "76"
+      }
+    ],
+    "celemony-melodyne-editor": [
+      {
+        "cask": "celemony-melodyne-editor",
+        "count": "1"
+      }
+    ],
+    "celestia": [
+      {
+        "cask": "celestia",
+        "count": "79"
+      }
+    ],
+    "celestialteapot-runway": [
+      {
+        "cask": "celestialteapot-runway",
+        "count": "3"
+      }
+    ],
+    "celldesigner": [
+      {
+        "cask": "celldesigner",
+        "count": "24"
+      }
+    ],
+    "cellery": [
+      {
+        "cask": "cellery",
+        "count": "83"
+      }
+    ],
+    "cellery-nightly": [
+      {
+        "cask": "cellery-nightly",
+        "count": "8"
+      }
+    ],
+    "cellprofiler": [
+      {
+        "cask": "cellprofiler",
+        "count": "17"
+      }
+    ],
+    "cellular": [
+      {
+        "cask": "cellular",
+        "count": "3"
+      }
+    ],
+    "cemu": [
+      {
+        "cask": "cemu",
+        "count": "56"
+      }
+    ],
+    "cenon": [
+      {
+        "cask": "cenon",
+        "count": "12"
+      }
+    ],
+    "cerebro": [
+      {
+        "cask": "cerebro",
+        "count": "236"
+      }
+    ],
+    "cert-quicklook": [
+      {
+        "cask": "cert-quicklook",
+        "count": "1"
+      }
+    ],
+    "cevelop": [
+      {
+        "cask": "cevelop",
+        "count": "131"
+      }
+    ],
+    "cewe": [
+      {
+        "cask": "cewe",
+        "count": "16"
+      }
+    ],
+    "cewe-fotoimport": [
+      {
+        "cask": "cewe-fotoimport",
+        "count": "1"
+      }
+    ],
+    "cewe-fotoview": [
+      {
+        "cask": "cewe-fotoview",
+        "count": "1"
+      }
+    ],
+    "cewedk": [
+      {
+        "cask": "cewedk",
+        "count": "1"
+      }
+    ],
+    "cg-bazelisk": [
+      {
+        "cask": "cg-bazelisk",
+        "count": "2"
+      }
+    ],
+    "cgoban": [
+      {
+        "cask": "cgoban",
+        "count": "17"
+      }
+    ],
+    "chai": [
+      {
+        "cask": "chai",
+        "count": "92"
+      }
+    ],
+    "chalk": [
+      {
+        "cask": "chalk",
+        "count": "85"
+      }
+    ],
+    "chameleon-ssd-optimizer": [
+      {
+        "cask": "chameleon-ssd-optimizer",
+        "count": "76"
+      }
+    ],
+    "championify": [
+      {
+        "cask": "championify",
+        "count": "1"
+      }
+    ],
+    "changes": [
+      {
+        "cask": "changes",
+        "count": "16"
+      }
+    ],
+    "charger-information": [
+      {
+        "cask": "charger-information",
+        "count": "1"
+      }
+    ],
+    "charles": [
+      {
+        "cask": "charles",
+        "count": "9,126"
+      }
+    ],
+    "charles-applejava": [
+      {
+        "cask": "charles-applejava",
+        "count": "27"
+      }
+    ],
+    "charles-beta": [
+      {
+        "cask": "charles-beta",
+        "count": "44"
+      }
+    ],
+    "charles-custom": [
+      {
+        "cask": "charles-custom",
+        "count": "8"
+      }
+    ],
+    "charles3": [
+      {
+        "cask": "charles3",
+        "count": "13"
+      }
+    ],
+    "charles@3": [
+      {
+        "cask": "charles@3",
+        "count": "2"
+      }
+    ],
+    "charlessoft-timetracker": [
+      {
+        "cask": "charlessoft-timetracker",
+        "count": "31"
+      }
+    ],
+    "chatmate-for-facebook": [
+      {
+        "cask": "chatmate-for-facebook",
+        "count": "106"
+      }
+    ],
+    "chatmate-for-whatsapp": [
+      {
+        "cask": "chatmate-for-whatsapp",
+        "count": "255"
+      }
+    ],
+    "chatology": [
+      {
+        "cask": "chatology",
+        "count": "114"
+      }
+    ],
+    "chatty": [
+      {
+        "cask": "chatty",
+        "count": "107"
+      }
+    ],
+    "chatty-mac": [
+      {
+        "cask": "chatty-mac",
+        "count": "4"
+      }
+    ],
+    "chatwork": [
+      {
+        "cask": "chatwork",
+        "count": "460"
+      }
+    ],
+    "cheatsheet": [
+      {
+        "cask": "cheatsheet",
+        "count": "10,902"
+      }
+    ],
+    "checkpoint": [
+      {
+        "cask": "checkpoint",
+        "count": "1"
+      }
+    ],
+    "checkra1n": [
+      {
+        "cask": "checkra1n",
+        "count": "624"
+      }
+    ],
+    "checksum-validator": [
+      {
+        "cask": "checksum-validator",
+        "count": "2"
+      }
+    ],
+    "cheetah3d": [
+      {
+        "cask": "cheetah3d",
+        "count": "35"
+      }
+    ],
+    "chef-infra-client": [
+      {
+        "cask": "chef-infra-client",
+        "count": "59"
+      }
+    ],
+    "chef-workstation": [
+      {
+        "cask": "chef-workstation",
+        "count": "2,189"
+      }
+    ],
+    "chefdk": [
+      {
+        "cask": "chefdk",
+        "count": "3,620"
+      }
+    ],
+    "chefdk0120": [
+      {
+        "cask": "chefdk0120",
+        "count": "1"
+      }
+    ],
+    "chefdk@3": [
+      {
+        "cask": "chefdk@3",
+        "count": "1"
+      }
+    ],
+    "chemdoodle": [
+      {
+        "cask": "chemdoodle",
+        "count": "15"
+      }
+    ],
+    "chessx": [
+      {
+        "cask": "chessx",
+        "count": "134"
+      }
+    ],
+    "chiaki": [
+      {
+        "cask": "chiaki",
+        "count": "30"
+      }
+    ],
+    "chicken": [
+      {
+        "cask": "chicken",
+        "count": "358"
+      }
+    ],
+    "chirp-daily": [
+      {
+        "cask": "chirp-daily",
+        "count": "56"
+      }
+    ],
+    "chitchat": [
+      {
+        "cask": "chitchat",
+        "count": "13"
+      }
+    ],
+    "chocolat": [
+      {
+        "cask": "chocolat",
+        "count": "68"
+      }
+    ],
+    "choose-wisely": [
+      {
+        "cask": "choose-wisely",
+        "count": "6"
+      }
+    ],
+    "choosy": [
+      {
+        "cask": "choosy",
+        "count": "990"
+      }
+    ],
+    "chromatic": [
+      {
+        "cask": "chromatic",
+        "count": "10"
+      }
+    ],
+    "chrome": [
+      {
+        "cask": "chrome",
+        "count": "20"
+      }
+    ],
+    "chrome-devtools": [
+      {
+        "cask": "chrome-devtools",
+        "count": "593"
+      }
+    ],
+    "chrome-remote-desktop-host": [
+      {
+        "cask": "chrome-remote-desktop-host",
+        "count": "1,194"
+      }
+    ],
+    "chromedriver": [
+      {
+        "cask": "chromedriver",
+        "count": "129,137"
+      }
+    ],
+    "chromedriver-beta": [
+      {
+        "cask": "chromedriver-beta",
+        "count": "552"
+      }
+    ],
+    "chromedriver-dev": [
+      {
+        "cask": "chromedriver-dev",
+        "count": "2"
+      }
+    ],
+    "chromedriver73": [
+      {
+        "cask": "chromedriver73",
+        "count": "3"
+      }
+    ],
+    "chromedriver74": [
+      {
+        "cask": "chromedriver74",
+        "count": "2"
+      }
+    ],
+    "chromedriver79": [
+      {
+        "cask": "chromedriver79",
+        "count": "1"
+      }
+    ],
+    "chromedriver80": [
+      {
+        "cask": "chromedriver80",
+        "count": "2"
+      }
+    ],
+    "chromium": [
+      {
+        "cask": "chromium",
+        "count": "19,932"
+      }
+    ],
+    "chromium-portia": [
+      {
+        "cask": "chromium-portia",
+        "count": "3"
+      }
+    ],
+    "chromium-snapshot": [
+      {
+        "cask": "chromium-snapshot",
+        "count": "8"
+      }
+    ],
+    "chromium-snapshots": [
+      {
+        "cask": "chromium-snapshots",
+        "count": "7"
+      }
+    ],
+    "chronicle": [
+      {
+        "cask": "chronicle",
+        "count": "23"
+      }
+    ],
+    "chronoagent": [
+      {
+        "cask": "chronoagent",
+        "count": "28"
+      }
+    ],
+    "chronos": [
+      {
+        "cask": "chronos",
+        "count": "62"
+      }
+    ],
+    "chronosync": [
+      {
+        "cask": "chronosync",
+        "count": "243"
+      }
+    ],
+    "chronycontrol": [
+      {
+        "cask": "chronycontrol",
+        "count": "102"
+      }
+    ],
+    "chrysalis": [
+      {
+        "cask": "chrysalis",
+        "count": "140"
+      }
+    ],
+    "cinch": [
+      {
+        "cask": "cinch",
+        "count": "183"
+      }
+    ],
+    "cinder": [
+      {
+        "cask": "cinder",
+        "count": "59"
+      }
+    ],
+    "cinebench": [
+      {
+        "cask": "cinebench",
+        "count": "803"
+      }
+    ],
+    "cineplay": [
+      {
+        "cask": "cineplay",
+        "count": "2"
+      }
+    ],
+    "circuit": [
+      {
+        "cask": "circuit",
+        "count": "7"
+      }
+    ],
+    "cirrus": [
+      {
+        "cask": "cirrus",
+        "count": "11"
+      }
+    ],
+    "cisco-anyconnect": [
+      {
+        "cask": "cisco-anyconnect",
+        "count": "1"
+      }
+    ],
+    "cisco-proximity": [
+      {
+        "cask": "cisco-proximity",
+        "count": "13,619"
+      }
+    ],
+    "cisdem-data-recovery": [
+      {
+        "cask": "cisdem-data-recovery",
+        "count": "68"
+      }
+    ],
+    "cisdem-document-reader": [
+      {
+        "cask": "cisdem-document-reader",
+        "count": "39"
+      }
+    ],
+    "cisdem-pdf-converter-ocr": [
+      {
+        "cask": "cisdem-pdf-converter-ocr",
+        "count": "76"
+      }
+    ],
+    "cisdem-pdfmanagerultimate": [
+      {
+        "cask": "cisdem-pdfmanagerultimate",
+        "count": "29"
+      }
+    ],
+    "cisdem-pdftoolkit": [
+      {
+        "cask": "cisdem-pdftoolkit",
+        "count": "34"
+      }
+    ],
+    "citra": [
+      {
+        "cask": "citra",
+        "count": "218"
+      }
+    ],
+    "citrix-epa": [
+      {
+        "cask": "citrix-epa",
+        "count": "4"
+      }
+    ],
+    "citrix-receiver": [
+      {
+        "cask": "citrix-receiver",
+        "count": "2"
+      }
+    ],
+    "citrix-workspace": [
+      {
+        "cask": "citrix-workspace",
+        "count": "36"
+      }
+    ],
+    "cityofzion-neon": [
+      {
+        "cask": "cityofzion-neon",
+        "count": "70"
+      }
+    ],
+    "ck550-macos": [
+      {
+        "cask": "ck550-macos",
+        "count": "13"
+      }
+    ],
+    "ckan": [
+      {
+        "cask": "ckan",
+        "count": "106"
+      }
+    ],
+    "ckb": [
+      {
+        "cask": "ckb",
+        "count": "1"
+      }
+    ],
+    "ckb-next": [
+      {
+        "cask": "ckb-next",
+        "count": "110"
+      }
+    ],
+    "clamxav": [
+      {
+        "cask": "clamxav",
+        "count": "601"
+      }
+    ],
+    "clashx": [
+      {
+        "cask": "clashx",
+        "count": "3,872"
+      }
+    ],
+    "clashxr": [
+      {
+        "cask": "clashxr",
+        "count": "1"
+      }
+    ],
+    "class-dump": [
+      {
+        "cask": "class-dump",
+        "count": "1"
+      }
+    ],
+    "classroom-assistant": [
+      {
+        "cask": "classroom-assistant",
+        "count": "22"
+      }
+    ],
+    "clean-me": [
+      {
+        "cask": "clean-me",
+        "count": "1,740"
+      }
+    ],
+    "cleanapp": [
+      {
+        "cask": "cleanapp",
+        "count": "88"
+      }
+    ],
+    "cleanmymac": [
+      {
+        "cask": "cleanmymac",
+        "count": "5,943"
+      }
+    ],
+    "cleanmymac3": [
+      {
+        "cask": "cleanmymac3",
+        "count": "253"
+      }
+    ],
+    "cleanshot": [
+      {
+        "cask": "cleanshot",
+        "count": "24"
+      }
+    ],
+    "cleartext": [
+      {
+        "cask": "cleartext",
+        "count": "22"
+      }
+    ],
+    "clec-320-lex-c": [
+      {
+        "cask": "clec-320-lex-c",
+        "count": "1"
+      }
+    ],
+    "clementine": [
+      {
+        "cask": "clementine",
+        "count": "1,018"
+      }
+    ],
+    "clementine-latest": [
+      {
+        "cask": "clementine-latest",
+        "count": "35"
+      }
+    ],
+    "clementine-rc": [
+      {
+        "cask": "clementine-rc",
+        "count": "1"
+      }
+    ],
+    "clickcharts": [
+      {
+        "cask": "clickcharts",
+        "count": "14"
+      }
+    ],
+    "clickup": [
+      {
+        "cask": "clickup",
+        "count": "247"
+      }
+    ],
+    "clion": [
+      {
+        "cask": "clion",
+        "count": "4,978"
+      }
+    ],
+    "clip-studio-paint": [
+      {
+        "cask": "clip-studio-paint",
+        "count": "166"
+      }
+    ],
+    "clipbuddy": [
+      {
+        "cask": "clipbuddy",
+        "count": "12"
+      }
+    ],
+    "clipgrab": [
+      {
+        "cask": "clipgrab",
+        "count": "803"
+      }
+    ],
+    "clipy": [
+      {
+        "cask": "clipy",
+        "count": "6,832"
+      }
+    ],
+    "cliqz": [
+      {
+        "cask": "cliqz",
+        "count": "96"
+      }
+    ],
+    "clix": [
+      {
+        "cask": "clix",
+        "count": "19"
+      }
+    ],
+    "cljstyle": [
+      {
+        "cask": "cljstyle",
+        "count": "13"
+      }
+    ],
+    "clock": [
+      {
+        "cask": "clock",
+        "count": "70"
+      }
+    ],
+    "clock-bar": [
+      {
+        "cask": "clock-bar",
+        "count": "966"
+      }
+    ],
+    "clock-signal": [
+      {
+        "cask": "clock-signal",
+        "count": "6"
+      }
+    ],
+    "clockify": [
+      {
+        "cask": "clockify",
+        "count": "691"
+      }
+    ],
+    "clocksaver": [
+      {
+        "cask": "clocksaver",
+        "count": "347"
+      }
+    ],
+    "clone-hero": [
+      {
+        "cask": "clone-hero",
+        "count": "43"
+      }
+    ],
+    "clonk": [
+      {
+        "cask": "clonk",
+        "count": "35"
+      }
+    ],
+    "cloud-pbx": [
+      {
+        "cask": "cloud-pbx",
+        "count": "8"
+      }
+    ],
+    "cloud_sql_proxy": [
+      {
+        "cask": "cloud_sql_proxy",
+        "count": "8"
+      }
+    ],
+    "cloudapp": [
+      {
+        "cask": "cloudapp",
+        "count": "917"
+      }
+    ],
+    "cloudcompare": [
+      {
+        "cask": "cloudcompare",
+        "count": "128"
+      }
+    ],
+    "cloudera-hive-odbc": [
+      {
+        "cask": "cloudera-hive-odbc",
+        "count": "5"
+      }
+    ],
+    "cloudera-impala-odbc": [
+      {
+        "cask": "cloudera-impala-odbc",
+        "count": "7"
+      }
+    ],
+    "cloudlibrary": [
+      {
+        "cask": "cloudlibrary",
+        "count": "4"
+      }
+    ],
+    "cloudmounter": [
+      {
+        "cask": "cloudmounter",
+        "count": "276"
+      }
+    ],
+    "cloudposse-tfenv": [
+      {
+        "cask": "cloudposse-tfenv",
+        "count": "2"
+      }
+    ],
+    "cloudtv": [
+      {
+        "cask": "cloudtv",
+        "count": "86"
+      }
+    ],
+    "cloudup": [
+      {
+        "cask": "cloudup",
+        "count": "29"
+      }
+    ],
+    "cloudytabs": [
+      {
+        "cask": "cloudytabs",
+        "count": "217"
+      }
+    ],
+    "clover-configurator": [
+      {
+        "cask": "clover-configurator",
+        "count": "1,717"
+      }
+    ],
+    "cluster": [
+      {
+        "cask": "cluster",
+        "count": "1"
+      }
+    ],
+    "clusters": [
+      {
+        "cask": "clusters",
+        "count": "3"
+      }
+    ],
+    "clyang-welly": [
+      {
+        "cask": "clyang-welly",
+        "count": "84"
+      }
+    ],
+    "cmake": [
+      {
+        "cask": "cmake",
+        "count": "6,171"
+      }
+    ],
+    "cmake310": [
+      {
+        "cask": "cmake310",
+        "count": "6"
+      }
+    ],
+    "cmake313": [
+      {
+        "cask": "cmake313",
+        "count": "8"
+      }
+    ],
+    "cmake315": [
+      {
+        "cask": "cmake315",
+        "count": "34"
+      }
+    ],
+    "cmc-menulet": [
+      {
+        "cask": "cmc-menulet",
+        "count": "2"
+      }
+    ],
+    "cmd-eikana": [
+      {
+        "cask": "cmd-eikana",
+        "count": "275"
+      }
+    ],
+    "cmdtap": [
+      {
+        "cask": "cmdtap",
+        "count": "27"
+      }
+    ],
+    "cmpl": [
+      {
+        "cask": "cmpl",
+        "count": "10"
+      }
+    ],
+    "cmpxat": [
+      {
+        "cask": "cmpxat",
+        "count": "5"
+      }
+    ],
+    "cmucl": [
+      {
+        "cask": "cmucl",
+        "count": "47"
+      }
+    ],
+    "cn-wps": [
+      {
+        "cask": "cn-wps",
+        "count": "4"
+      }
+    ],
+    "cncjs": [
+      {
+        "cask": "cncjs",
+        "count": "30"
+      }
+    ],
+    "cncnet": [
+      {
+        "cask": "cncnet",
+        "count": "48"
+      }
+    ],
+    "coccinellida": [
+      {
+        "cask": "coccinellida",
+        "count": "53"
+      }
+    ],
+    "coccoc": [
+      {
+        "cask": "coccoc",
+        "count": "34"
+      }
+    ],
+    "cockatrice": [
+      {
+        "cask": "cockatrice",
+        "count": "75"
+      }
+    ],
+    "cocktail": [
+      {
+        "cask": "cocktail",
+        "count": "344"
+      }
+    ],
+    "cocoapods": [
+      {
+        "cask": "cocoapods",
+        "count": "1,277"
+      }
+    ],
+    "cocoapods-app": [
+      {
+        "cask": "cocoapods-app",
+        "count": "2"
+      }
+    ],
+    "cocoarestclient": [
+      {
+        "cask": "cocoarestclient",
+        "count": "413"
+      }
+    ],
+    "cocoaspell": [
+      {
+        "cask": "cocoaspell",
+        "count": "195"
+      }
+    ],
+    "coconutbattery": [
+      {
+        "cask": "coconutbattery",
+        "count": "6,898"
+      }
+    ],
+    "cocoscreator": [
+      {
+        "cask": "cocoscreator",
+        "count": "297"
+      }
+    ],
+    "coda": [
+      {
+        "cask": "coda",
+        "count": "668"
+      }
+    ],
+    "code-42smb": [
+      {
+        "cask": "code-42smb",
+        "count": "1"
+      }
+    ],
+    "code-connection-for-minecraft": [
+      {
+        "cask": "code-connection-for-minecraft",
+        "count": "4"
+      }
+    ],
+    "code-notes": [
+      {
+        "cask": "code-notes",
+        "count": "65"
+      }
+    ],
+    "code42-crashplan": [
+      {
+        "cask": "code42-crashplan",
+        "count": "12,341"
+      }
+    ],
+    "code42-smb": [
+      {
+        "cask": "code42-smb",
+        "count": "1"
+      }
+    ],
+    "codeblocks": [
+      {
+        "cask": "codeblocks",
+        "count": "1"
+      }
+    ],
+    "codeexpander": [
+      {
+        "cask": "codeexpander",
+        "count": "5"
+      }
+    ],
+    "codekit": [
+      {
+        "cask": "codekit",
+        "count": "346"
+      }
+    ],
+    "codelite": [
+      {
+        "cask": "codelite",
+        "count": "361"
+      }
+    ],
+    "codeql": [
+      {
+        "cask": "codeql",
+        "count": "5"
+      }
+    ],
+    "coderunner": [
+      {
+        "cask": "coderunner",
+        "count": "903"
+      }
+    ],
+    "cold-turkey-blocker": [
+      {
+        "cask": "cold-turkey-blocker",
+        "count": "142"
+      }
+    ],
+    "collabshot": [
+      {
+        "cask": "collabshot",
+        "count": "1"
+      }
+    ],
+    "colloquy": [
+      {
+        "cask": "colloquy",
+        "count": "538"
+      }
+    ],
+    "color-oracle": [
+      {
+        "cask": "color-oracle",
+        "count": "110"
+      }
+    ],
+    "colormunki-display": [
+      {
+        "cask": "colormunki-display",
+        "count": "19"
+      }
+    ],
+    "colormunki-photo": [
+      {
+        "cask": "colormunki-photo",
+        "count": "6"
+      }
+    ],
+    "colorpicker": [
+      {
+        "cask": "colorpicker",
+        "count": "1"
+      }
+    ],
+    "colorpicker-antetype": [
+      {
+        "cask": "colorpicker-antetype",
+        "count": "15"
+      }
+    ],
+    "colorpicker-developer": [
+      {
+        "cask": "colorpicker-developer",
+        "count": "274"
+      }
+    ],
+    "colorpicker-launcher": [
+      {
+        "cask": "colorpicker-launcher",
+        "count": "7"
+      }
+    ],
+    "colorpicker-materialdesign": [
+      {
+        "cask": "colorpicker-materialdesign",
+        "count": "111"
+      }
+    ],
+    "colorpicker-propicker": [
+      {
+        "cask": "colorpicker-propicker",
+        "count": "102"
+      }
+    ],
+    "colorpicker-rcwebcolorpicker": [
+      {
+        "cask": "colorpicker-rcwebcolorpicker",
+        "count": "21"
+      }
+    ],
+    "colorpicker-skalacolor": [
+      {
+        "cask": "colorpicker-skalacolor",
+        "count": "464"
+      }
+    ],
+    "colors": [
+      {
+        "cask": "colors",
+        "count": "5"
+      }
+    ],
+    "colorsnapper": [
+      {
+        "cask": "colorsnapper",
+        "count": "172"
+      }
+    ],
+    "colortester": [
+      {
+        "cask": "colortester",
+        "count": "35"
+      }
+    ],
+    "colossus": [
+      {
+        "cask": "colossus",
+        "count": "8"
+      }
+    ],
+    "colour-contrast-analyser": [
+      {
+        "cask": "colour-contrast-analyser",
+        "count": "69"
+      }
+    ],
+    "combine-pdfs": [
+      {
+        "cask": "combine-pdfs",
+        "count": "146"
+      }
+    ],
+    "comictagger": [
+      {
+        "cask": "comictagger",
+        "count": "95"
+      }
+    ],
+    "comma-chameleon": [
+      {
+        "cask": "comma-chameleon",
+        "count": "36"
+      }
+    ],
+    "comma-ide-community-edition": [
+      {
+        "cask": "comma-ide-community-edition",
+        "count": "3"
+      }
+    ],
+    "command-tab-plus": [
+      {
+        "cask": "command-tab-plus",
+        "count": "143"
+      }
+    ],
+    "commander-one": [
+      {
+        "cask": "commander-one",
+        "count": "1,766"
+      }
+    ],
+    "commandpost": [
+      {
+        "cask": "commandpost",
+        "count": "1"
+      }
+    ],
+    "commandq": [
+      {
+        "cask": "commandq",
+        "count": "60"
+      }
+    ],
+    "comparemerge": [
+      {
+        "cask": "comparemerge",
+        "count": "218"
+      }
+    ],
+    "composercat": [
+      {
+        "cask": "composercat",
+        "count": "41"
+      }
+    ],
+    "compositor": [
+      {
+        "cask": "compositor",
+        "count": "72"
+      }
+    ],
+    "concept2-utility": [
+      {
+        "cask": "concept2-utility",
+        "count": "2"
+      }
+    ],
+    "concepta": [
+      {
+        "cask": "concepta",
+        "count": "1"
+      }
+    ],
+    "conductor": [
+      {
+        "cask": "conductor",
+        "count": "1"
+      }
+    ],
+    "confcrypt": [
+      {
+        "cask": "confcrypt",
+        "count": "31"
+      }
+    ],
+    "conferences": [
+      {
+        "cask": "conferences",
+        "count": "13"
+      }
+    ],
+    "conferencesdigital": [
+      {
+        "cask": "conferencesdigital",
+        "count": "3"
+      }
+    ],
+    "configure-application-dock-tile": [
+      {
+        "cask": "configure-application-dock-tile",
+        "count": "2"
+      }
+    ],
+    "confluent-hub-client": [
+      {
+        "cask": "confluent-hub-client",
+        "count": "2,172"
+      }
+    ],
+    "connectiq": [
+      {
+        "cask": "connectiq",
+        "count": "35"
+      }
+    ],
+    "connectmenow": [
+      {
+        "cask": "connectmenow",
+        "count": "18"
+      }
+    ],
+    "connector": [
+      {
+        "cask": "connector",
+        "count": "1"
+      }
+    ],
+    "consider": [
+      {
+        "cask": "consider",
+        "count": "3"
+      }
+    ],
+    "consolation2": [
+      {
+        "cask": "consolation2",
+        "count": "1"
+      }
+    ],
+    "consolation3": [
+      {
+        "cask": "consolation3",
+        "count": "18"
+      }
+    ],
+    "console": [
+      {
+        "cask": "console",
+        "count": "100"
+      }
+    ],
+    "consul-cli": [
+      {
+        "cask": "consul-cli",
+        "count": "31"
+      }
+    ],
+    "container-bzip2": [
+      {
+        "cask": "container-bzip2",
+        "count": "1"
+      }
+    ],
+    "container-dmg": [
+      {
+        "cask": "container-dmg",
+        "count": "1"
+      }
+    ],
+    "container-gzip": [
+      {
+        "cask": "container-gzip",
+        "count": "1"
+      }
+    ],
+    "container-pkg": [
+      {
+        "cask": "container-pkg",
+        "count": "1"
+      }
+    ],
+    "container-ps": [
+      {
+        "cask": "container-ps",
+        "count": "9"
+      }
+    ],
+    "container-structure-test": [
+      {
+        "cask": "container-structure-test",
+        "count": "2"
+      }
+    ],
+    "container-tar-gz": [
+      {
+        "cask": "container-tar-gz",
+        "count": "2"
+      }
+    ],
+    "container-xar": [
+      {
+        "cask": "container-xar",
+        "count": "1"
+      }
+    ],
+    "content-manager-assistant": [
+      {
+        "cask": "content-manager-assistant",
+        "count": "9"
+      }
+    ],
+    "context-free": [
+      {
+        "cask": "context-free",
+        "count": "11"
+      }
+    ],
+    "contexts": [
+      {
+        "cask": "contexts",
+        "count": "1,046"
+      }
+    ],
+    "continuity-activation-tool": [
+      {
+        "cask": "continuity-activation-tool",
+        "count": "8"
+      }
+    ],
+    "contraste": [
+      {
+        "cask": "contraste",
+        "count": "37"
+      }
+    ],
+    "controllermate": [
+      {
+        "cask": "controllermate",
+        "count": "119"
+      }
+    ],
+    "controlplane": [
+      {
+        "cask": "controlplane",
+        "count": "416"
+      }
+    ],
+    "cookie": [
+      {
+        "cask": "cookie",
+        "count": "131"
+      }
+    ],
+    "cool-retro-term": [
+      {
+        "cask": "cool-retro-term",
+        "count": "4,350"
+      }
+    ],
+    "coolbeans": [
+      {
+        "cask": "coolbeans",
+        "count": "9"
+      }
+    ],
+    "coolretroterm": [
+      {
+        "cask": "coolretroterm",
+        "count": "1"
+      }
+    ],
+    "coolterm": [
+      {
+        "cask": "coolterm",
+        "count": "699"
+      }
+    ],
+    "cooviewer": [
+      {
+        "cask": "cooviewer",
+        "count": "1"
+      }
+    ],
+    "copyclip": [
+      {
+        "cask": "copyclip",
+        "count": "558"
+      }
+    ],
+    "copyclip-helper": [
+      {
+        "cask": "copyclip-helper",
+        "count": "7"
+      }
+    ],
+    "copyq": [
+      {
+        "cask": "copyq",
+        "count": "2,973"
+      }
+    ],
+    "copytranslator": [
+      {
+        "cask": "copytranslator",
+        "count": "1"
+      }
+    ],
+    "coqide": [
+      {
+        "cask": "coqide",
+        "count": "710"
+      }
+    ],
+    "coral": [
+      {
+        "cask": "coral",
+        "count": "6"
+      }
+    ],
+    "cord": [
+      {
+        "cask": "cord",
+        "count": "635"
+      }
+    ],
+    "core-data-editor": [
+      {
+        "cask": "core-data-editor",
+        "count": "40"
+      }
+    ],
+    "corelocationcli": [
+      {
+        "cask": "corelocationcli",
+        "count": "396"
+      }
+    ],
+    "cornercal": [
+      {
+        "cask": "cornercal",
+        "count": "36"
+      }
+    ],
+    "cornerstone": [
+      {
+        "cask": "cornerstone",
+        "count": "224"
+      }
+    ],
+    "corona-tracker": [
+      {
+        "cask": "corona-tracker",
+        "count": "933"
+      }
+    ],
+    "coronasdk": [
+      {
+        "cask": "coronasdk",
+        "count": "37"
+      }
+    ],
+    "corretto": [
+      {
+        "cask": "corretto",
+        "count": "3,322"
+      }
+    ],
+    "corretto-8": [
+      {
+        "cask": "corretto-8",
+        "count": "2"
+      }
+    ],
+    "corretto11": [
+      {
+        "cask": "corretto11",
+        "count": "1"
+      }
+    ],
+    "corretto8": [
+      {
+        "cask": "corretto8",
+        "count": "3,940"
+      }
+    ],
+    "corretto@8": [
+      {
+        "cask": "corretto@8",
+        "count": "1"
+      }
+    ],
+    "corsair-icue": [
+      {
+        "cask": "corsair-icue",
+        "count": "113"
+      }
+    ],
+    "coteditor": [
+      {
+        "cask": "coteditor",
+        "count": "2,527"
+      }
+    ],
+    "couchbase-server-community": [
+      {
+        "cask": "couchbase-server-community",
+        "count": "337"
+      }
+    ],
+    "couchbase-server-enterprise": [
+      {
+        "cask": "couchbase-server-enterprise",
+        "count": "70"
+      }
+    ],
+    "couchpotato": [
+      {
+        "cask": "couchpotato",
+        "count": "78"
+      }
+    ],
+    "couleurs": [
+      {
+        "cask": "couleurs",
+        "count": "127"
+      }
+    ],
+    "coverload": [
+      {
+        "cask": "coverload",
+        "count": "47"
+      }
+    ],
+    "covfefe": [
+      {
+        "cask": "covfefe",
+        "count": "5"
+      }
+    ],
+    "coyim": [
+      {
+        "cask": "coyim",
+        "count": "58"
+      }
+    ],
+    "cozy-drive": [
+      {
+        "cask": "cozy-drive",
+        "count": "44"
+      }
+    ],
+    "cpuinfo": [
+      {
+        "cask": "cpuinfo",
+        "count": "439"
+      }
+    ],
+    "cr": [
+      {
+        "cask": "cr",
+        "count": "13"
+      }
+    ],
+    "cracked": [
+      {
+        "cask": "cracked",
+        "count": "14"
+      }
+    ],
+    "craftmanager": [
+      {
+        "cask": "craftmanager",
+        "count": "330"
+      }
+    ],
+    "craftos-pc": [
+      {
+        "cask": "craftos-pc",
+        "count": "8"
+      }
+    ],
+    "create-recovery-partition-installer": [
+      {
+        "cask": "create-recovery-partition-installer",
+        "count": "53"
+      }
+    ],
+    "createuserpkg": [
+      {
+        "cask": "createuserpkg",
+        "count": "82"
+      }
+    ],
+    "creepy": [
+      {
+        "cask": "creepy",
+        "count": "41"
+      }
+    ],
+    "crescendo": [
+      {
+        "cask": "crescendo",
+        "count": "2"
+      }
+    ],
+    "cricut-design-space": [
+      {
+        "cask": "cricut-design-space",
+        "count": "42"
+      }
+    ],
+    "criptext": [
+      {
+        "cask": "criptext",
+        "count": "24"
+      }
+    ],
+    "crisp": [
+      {
+        "cask": "crisp",
+        "count": "3"
+      }
+    ],
+    "cronnix": [
+      {
+        "cask": "cronnix",
+        "count": "311"
+      }
+    ],
+    "crossover": [
+      {
+        "cask": "crossover",
+        "count": "823"
+      }
+    ],
+    "crosspack-avr": [
+      {
+        "cask": "crosspack-avr",
+        "count": "593"
+      }
+    ],
+    "crunch": [
+      {
+        "cask": "crunch",
+        "count": "285"
+      }
+    ],
+    "crushftp": [
+      {
+        "cask": "crushftp",
+        "count": "142"
+      }
+    ],
+    "crypt": [
+      {
+        "cask": "crypt",
+        "count": "254"
+      }
+    ],
+    "crypter": [
+      {
+        "cask": "crypter",
+        "count": "42"
+      }
+    ],
+    "cryptobridge": [
+      {
+        "cask": "cryptobridge",
+        "count": "3"
+      }
+    ],
+    "cryptomator": [
+      {
+        "cask": "cryptomator",
+        "count": "2,202"
+      }
+    ],
+    "cryptoplugin": [
+      {
+        "cask": "cryptoplugin",
+        "count": "8"
+      }
+    ],
+    "cryptr": [
+      {
+        "cask": "cryptr",
+        "count": "366"
+      }
+    ],
+    "crystal": [
+      {
+        "cask": "crystal",
+        "count": "6"
+      }
+    ],
+    "crystalmaker": [
+      {
+        "cask": "crystalmaker",
+        "count": "18"
+      }
+    ],
+    "crystax-ndk": [
+      {
+        "cask": "crystax-ndk",
+        "count": "55"
+      }
+    ],
+    "cscreen": [
+      {
+        "cask": "cscreen",
+        "count": "4,070"
+      }
+    ],
+    "csvq": [
+      {
+        "cask": "csvq",
+        "count": "1"
+      }
+    ],
+    "ctivo": [
+      {
+        "cask": "ctivo",
+        "count": "11"
+      }
+    ],
+    "cube": [
+      {
+        "cask": "cube",
+        "count": "8"
+      }
+    ],
+    "cubicsdr": [
+      {
+        "cask": "cubicsdr",
+        "count": "438"
+      }
+    ],
+    "cuda": [
+      {
+        "cask": "cuda",
+        "count": "1"
+      }
+    ],
+    "cuda-z": [
+      {
+        "cask": "cuda-z",
+        "count": "662"
+      }
+    ],
+    "cuda-z-beta": [
+      {
+        "cask": "cuda-z-beta",
+        "count": "7"
+      }
+    ],
+    "cumulus": [
+      {
+        "cask": "cumulus",
+        "count": "39"
+      }
+    ],
+    "cuppa": [
+      {
+        "cask": "cuppa",
+        "count": "3"
+      }
+    ],
+    "cura-lulzbot": [
+      {
+        "cask": "cura-lulzbot",
+        "count": "124"
+      }
+    ],
+    "curecon-qt": [
+      {
+        "cask": "curecon-qt",
+        "count": "1"
+      }
+    ],
+    "curio": [
+      {
+        "cask": "curio",
+        "count": "35"
+      }
+    ],
+    "cursorcerer": [
+      {
+        "cask": "cursorcerer",
+        "count": "110"
+      }
+    ],
+    "cursorsense": [
+      {
+        "cask": "cursorsense",
+        "count": "90"
+      }
+    ],
+    "cutbox": [
+      {
+        "cask": "cutbox",
+        "count": "77"
+      }
+    ],
+    "cuteclips": [
+      {
+        "cask": "cuteclips",
+        "count": "2"
+      }
+    ],
+    "cutesdr": [
+      {
+        "cask": "cutesdr",
+        "count": "75"
+      }
+    ],
+    "cutter": [
+      {
+        "cask": "cutter",
+        "count": "2,107"
+      }
+    ],
+    "cyberduck": [
+      {
+        "cask": "cyberduck",
+        "count": "25,120"
+      }
+    ],
+    "cyberduck-custom": [
+      {
+        "cask": "cyberduck-custom",
+        "count": "3"
+      }
+    ],
+    "cyberghost-vpn": [
+      {
+        "cask": "cyberghost-vpn",
+        "count": "192"
+      }
+    ],
+    "cycling74-max": [
+      {
+        "cask": "cycling74-max",
+        "count": "217"
+      }
+    ],
+    "cydia-impactor": [
+      {
+        "cask": "cydia-impactor",
+        "count": "1"
+      }
+    ],
+    "cydownload": [
+      {
+        "cask": "cydownload",
+        "count": "4"
+      }
+    ],
+    "cypress": [
+      {
+        "cask": "cypress",
+        "count": "1"
+      }
+    ],
+    "cypress-desktop": [
+      {
+        "cask": "cypress-desktop",
+        "count": "1"
+      }
+    ],
+    "cytomic-the-drop": [
+      {
+        "cask": "cytomic-the-drop",
+        "count": "1"
+      }
+    ],
+    "cytomic-the-glue": [
+      {
+        "cask": "cytomic-the-glue",
+        "count": "1"
+      }
+    ],
+    "cytoscape": [
+      {
+        "cask": "cytoscape",
+        "count": "137"
+      }
+    ],
+    "d3visualizer": [
+      {
+        "cask": "d3visualizer",
+        "count": "1"
+      }
+    ],
+    "dada-life-sausage-fattener": [
+      {
+        "cask": "dada-life-sausage-fattener",
+        "count": "1"
+      }
+    ],
+    "daedalus": [
+      {
+        "cask": "daedalus",
+        "count": "40"
+      }
+    ],
+    "daemon-tools": [
+      {
+        "cask": "daemon-tools",
+        "count": "143"
+      }
+    ],
+    "dafont-helldorado": [
+      {
+        "cask": "dafont-helldorado",
+        "count": "1"
+      }
+    ],
+    "dafont-star-jedi": [
+      {
+        "cask": "dafont-star-jedi",
+        "count": "1"
+      }
+    ],
+    "dafont-typo-negative": [
+      {
+        "cask": "dafont-typo-negative",
+        "count": "1"
+      }
+    ],
+    "daily-english-listening": [
+      {
+        "cask": "daily-english-listening",
+        "count": "13"
+      }
+    ],
+    "daily-wall": [
+      {
+        "cask": "daily-wall",
+        "count": "1"
+      }
+    ],
+    "daisydisk": [
+      {
+        "cask": "daisydisk",
+        "count": "4,357"
+      }
+    ],
+    "dangerzone": [
+      {
+        "cask": "dangerzone",
+        "count": "3"
+      }
+    ],
+    "darkj": [
+      {
+        "cask": "darkj",
+        "count": "1"
+      }
+    ],
+    "darkmode": [
+      {
+        "cask": "darkmode",
+        "count": "3"
+      }
+    ],
+    "darktable": [
+      {
+        "cask": "darktable",
+        "count": "4,320"
+      }
+    ],
+    "darktable-dev": [
+      {
+        "cask": "darktable-dev",
+        "count": "15"
+      }
+    ],
+    "dart": [
+      {
+        "cask": "dart",
+        "count": "1"
+      }
+    ],
+    "darwiinremoteosc": [
+      {
+        "cask": "darwiinremoteosc",
+        "count": "10"
+      }
+    ],
+    "darwindumper": [
+      {
+        "cask": "darwindumper",
+        "count": "38"
+      }
+    ],
+    "dash": [
+      {
+        "cask": "dash",
+        "count": "17,047"
+      }
+    ],
+    "dash-dash": [
+      {
+        "cask": "dash-dash",
+        "count": "19"
+      }
+    ],
+    "dash2": [
+      {
+        "cask": "dash2",
+        "count": "69"
+      }
+    ],
+    "dash3": [
+      {
+        "cask": "dash3",
+        "count": "143"
+      }
+    ],
+    "dash4": [
+      {
+        "cask": "dash4",
+        "count": "172"
+      }
+    ],
+    "dashcam-viewer": [
+      {
+        "cask": "dashcam-viewer",
+        "count": "18"
+      }
+    ],
+    "dashlane": [
+      {
+        "cask": "dashlane",
+        "count": "2,231"
+      }
+    ],
+    "dat": [
+      {
+        "cask": "dat",
+        "count": "88"
+      }
+    ],
+    "dat-weather-doe": [
+      {
+        "cask": "dat-weather-doe",
+        "count": "2"
+      }
+    ],
+    "data-integration": [
+      {
+        "cask": "data-integration",
+        "count": "661"
+      }
+    ],
+    "data-rescue": [
+      {
+        "cask": "data-rescue",
+        "count": "55"
+      }
+    ],
+    "data-science-studio": [
+      {
+        "cask": "data-science-studio",
+        "count": "200"
+      }
+    ],
+    "datacolor-spyder-elite": [
+      {
+        "cask": "datacolor-spyder-elite",
+        "count": "14"
+      }
+    ],
+    "datadog-agent": [
+      {
+        "cask": "datadog-agent",
+        "count": "1,951"
+      }
+    ],
+    "datagraph": [
+      {
+        "cask": "datagraph",
+        "count": "75"
+      }
+    ],
+    "datagrip": [
+      {
+        "cask": "datagrip",
+        "count": "6,523"
+      }
+    ],
+    "dataloader": [
+      {
+        "cask": "dataloader",
+        "count": "33"
+      }
+    ],
+    "datazenit": [
+      {
+        "cask": "datazenit",
+        "count": "16"
+      }
+    ],
+    "datovka": [
+      {
+        "cask": "datovka",
+        "count": "57"
+      }
+    ],
+    "datweatherdoe": [
+      {
+        "cask": "datweatherdoe",
+        "count": "35"
+      }
+    ],
+    "davinci-resolve-1611": [
+      {
+        "cask": "davinci-resolve-1611",
+        "count": "8"
+      }
+    ],
+    "davmail": [
+      {
+        "cask": "davmail",
+        "count": "118"
+      }
+    ],
+    "dawnlabs-alchemy": [
+      {
+        "cask": "dawnlabs-alchemy",
+        "count": "17"
+      }
+    ],
+    "day-o": [
+      {
+        "cask": "day-o",
+        "count": "557"
+      }
+    ],
+    "daylite": [
+      {
+        "cask": "daylite",
+        "count": "8"
+      }
+    ],
+    "db-browser-for-sqlite": [
+      {
+        "cask": "db-browser-for-sqlite",
+        "count": "32,382"
+      }
+    ],
+    "dbaudio-arraycalc": [
+      {
+        "cask": "dbaudio-arraycalc",
+        "count": "1"
+      }
+    ],
+    "dbaudio-r1": [
+      {
+        "cask": "dbaudio-r1",
+        "count": "1"
+      }
+    ],
+    "dbeaver-community": [
+      {
+        "cask": "dbeaver-community",
+        "count": "37,562"
+      }
+    ],
+    "dbeaver-enterprise": [
+      {
+        "cask": "dbeaver-enterprise",
+        "count": "466"
+      }
+    ],
+    "dbglass": [
+      {
+        "cask": "dbglass",
+        "count": "103"
+      }
+    ],
+    "dbkoda": [
+      {
+        "cask": "dbkoda",
+        "count": "136"
+      }
+    ],
+    "dbngin": [
+      {
+        "cask": "dbngin",
+        "count": "372"
+      }
+    ],
+    "dbschema": [
+      {
+        "cask": "dbschema",
+        "count": "151"
+      }
+    ],
+    "dbvisualizer": [
+      {
+        "cask": "dbvisualizer",
+        "count": "1,954"
+      }
+    ],
+    "dbvisualizer-custom": [
+      {
+        "cask": "dbvisualizer-custom",
+        "count": "1"
+      }
+    ],
+    "dbvisualizer9": [
+      {
+        "cask": "dbvisualizer9",
+        "count": "1"
+      }
+    ],
+    "dcd": [
+      {
+        "cask": "dcd",
+        "count": "1"
+      }
+    ],
+    "dcommander": [
+      {
+        "cask": "dcommander",
+        "count": "110"
+      }
+    ],
+    "dcp-o-matic": [
+      {
+        "cask": "dcp-o-matic",
+        "count": "25"
+      }
+    ],
+    "dcp-o-matic-batch-converter": [
+      {
+        "cask": "dcp-o-matic-batch-converter",
+        "count": "10"
+      }
+    ],
+    "dcp-o-matic-encode-server": [
+      {
+        "cask": "dcp-o-matic-encode-server",
+        "count": "4"
+      }
+    ],
+    "dcp-o-matic-kdm-creator": [
+      {
+        "cask": "dcp-o-matic-kdm-creator",
+        "count": "8"
+      }
+    ],
+    "dcp-o-matic-player": [
+      {
+        "cask": "dcp-o-matic-player",
+        "count": "33"
+      }
+    ],
+    "dcv-viewer": [
+      {
+        "cask": "dcv-viewer",
+        "count": "9"
+      }
+    ],
+    "dd-utility": [
+      {
+        "cask": "dd-utility",
+        "count": "140"
+      }
+    ],
+    "ddev": [
+      {
+        "cask": "ddev",
+        "count": "4"
+      }
+    ],
+    "deadbeef": [
+      {
+        "cask": "deadbeef",
+        "count": "1"
+      }
+    ],
+    "deadbeef-devel": [
+      {
+        "cask": "deadbeef-devel",
+        "count": "122"
+      }
+    ],
+    "deadbolt": [
+      {
+        "cask": "deadbolt",
+        "count": "11"
+      }
+    ],
+    "deathtodsstore": [
+      {
+        "cask": "deathtodsstore",
+        "count": "45"
+      }
+    ],
+    "debookee": [
+      {
+        "cask": "debookee",
+        "count": "146"
+      }
+    ],
+    "decibel": [
+      {
+        "cask": "decibel",
+        "count": "8"
+      }
+    ],
+    "deckset": [
+      {
+        "cask": "deckset",
+        "count": "604"
+      }
+    ],
+    "deco": [
+      {
+        "cask": "deco",
+        "count": "40"
+      }
+    ],
+    "decrediton": [
+      {
+        "cask": "decrediton",
+        "count": "16"
+      }
+    ],
+    "deep-dreamer": [
+      {
+        "cask": "deep-dreamer",
+        "count": "1"
+      }
+    ],
+    "deeper": [
+      {
+        "cask": "deeper",
+        "count": "328"
+      }
+    ],
+    "deepgit": [
+      {
+        "cask": "deepgit",
+        "count": "76"
+      }
+    ],
+    "deepl": [
+      {
+        "cask": "deepl",
+        "count": "1,933"
+      }
+    ],
+    "deepstream": [
+      {
+        "cask": "deepstream",
+        "count": "71"
+      }
+    ],
+    "deeptools": [
+      {
+        "cask": "deeptools",
+        "count": "7"
+      }
+    ],
+    "deepvacuum": [
+      {
+        "cask": "deepvacuum",
+        "count": "2"
+      }
+    ],
+    "deezer": [
+      {
+        "cask": "deezer",
+        "count": "1,386"
+      }
+    ],
+    "default-folder-x": [
+      {
+        "cask": "default-folder-x",
+        "count": "334"
+      }
+    ],
+    "deflemask": [
+      {
+        "cask": "deflemask",
+        "count": "1"
+      }
+    ],
+    "dejalu": [
+      {
+        "cask": "dejalu",
+        "count": "31"
+      }
+    ],
+    "delayedlauncher": [
+      {
+        "cask": "delayedlauncher",
+        "count": "24"
+      }
+    ],
+    "delibar": [
+      {
+        "cask": "delibar",
+        "count": "163"
+      }
+    ],
+    "delicious-library": [
+      {
+        "cask": "delicious-library",
+        "count": "40"
+      }
+    ],
+    "delighted": [
+      {
+        "cask": "delighted",
+        "count": "10"
+      }
+    ],
+    "delta": [
+      {
+        "cask": "delta",
+        "count": "54"
+      }
+    ],
+    "deltawalker": [
+      {
+        "cask": "deltawalker",
+        "count": "241"
+      }
+    ],
+    "deluge": [
+      {
+        "cask": "deluge",
+        "count": "3,161"
+      }
+    ],
+    "dendroscope": [
+      {
+        "cask": "dendroscope",
+        "count": "22"
+      }
+    ],
+    "denemo": [
+      {
+        "cask": "denemo",
+        "count": "38"
+      }
+    ],
+    "denpo": [
+      {
+        "cask": "denpo",
+        "count": "1"
+      }
+    ],
+    "denpo-cask": [
+      {
+        "cask": "denpo-cask",
+        "count": "1"
+      }
+    ],
+    "deploystudio": [
+      {
+        "cask": "deploystudio",
+        "count": "25"
+      }
+    ],
+    "deputy": [
+      {
+        "cask": "deputy",
+        "count": "5"
+      }
+    ],
+    "descript": [
+      {
+        "cask": "descript",
+        "count": "10"
+      }
+    ],
+    "desktop-curtain": [
+      {
+        "cask": "desktop-curtain",
+        "count": "2"
+      }
+    ],
+    "desktop-presenter": [
+      {
+        "cask": "desktop-presenter",
+        "count": "3"
+      }
+    ],
+    "desktoputility": [
+      {
+        "cask": "desktoputility",
+        "count": "84"
+      }
+    ],
+    "desmume": [
+      {
+        "cask": "desmume",
+        "count": "184"
+      }
+    ],
+    "detectx-swift": [
+      {
+        "cask": "detectx-swift",
+        "count": "56"
+      }
+    ],
+    "detexify": [
+      {
+        "cask": "detexify",
+        "count": "361"
+      }
+    ],
+    "detox-instruments": [
+      {
+        "cask": "detox-instruments",
+        "count": "1,258"
+      }
+    ],
+    "devcolor": [
+      {
+        "cask": "devcolor",
+        "count": "1"
+      }
+    ],
+    "devdocs": [
+      {
+        "cask": "devdocs",
+        "count": "573"
+      }
+    ],
+    "devdocs-macos": [
+      {
+        "cask": "devdocs-macos",
+        "count": "244"
+      }
+    ],
+    "developerexcuses": [
+      {
+        "cask": "developerexcuses",
+        "count": "48"
+      }
+    ],
+    "devhub": [
+      {
+        "cask": "devhub",
+        "count": "325"
+      }
+    ],
+    "devolo-cockpit": [
+      {
+        "cask": "devolo-cockpit",
+        "count": "16"
+      }
+    ],
+    "devonagent": [
+      {
+        "cask": "devonagent",
+        "count": "103"
+      }
+    ],
+    "devonthink": [
+      {
+        "cask": "devonthink",
+        "count": "490"
+      }
+    ],
+    "devonthink-pro": [
+      {
+        "cask": "devonthink-pro",
+        "count": "40"
+      }
+    ],
+    "devonthink-pro-office": [
+      {
+        "cask": "devonthink-pro-office",
+        "count": "61"
+      }
+    ],
+    "devrantron": [
+      {
+        "cask": "devrantron",
+        "count": "1"
+      }
+    ],
+    "dexed": [
+      {
+        "cask": "dexed",
+        "count": "54"
+      }
+    ],
+    "dfontsplitter": [
+      {
+        "cask": "dfontsplitter",
+        "count": "15"
+      }
+    ],
+    "dhs": [
+      {
+        "cask": "dhs",
+        "count": "200"
+      }
+    ],
+    "dia": [
+      {
+        "cask": "dia",
+        "count": "2,411"
+      }
+    ],
+    "dialpad": [
+      {
+        "cask": "dialpad",
+        "count": "205"
+      }
+    ],
+    "diashapes": [
+      {
+        "cask": "diashapes",
+        "count": "114"
+      }
+    ],
+    "dictater": [
+      {
+        "cask": "dictater",
+        "count": "22"
+      }
+    ],
+    "dictcc-en-de-dictionary-plugin": [
+      {
+        "cask": "dictcc-en-de-dictionary-plugin",
+        "count": "42"
+      }
+    ],
+    "dictionaries": [
+      {
+        "cask": "dictionaries",
+        "count": "201"
+      }
+    ],
+    "dictunifier": [
+      {
+        "cask": "dictunifier",
+        "count": "371"
+      }
+    ],
+    "difffork": [
+      {
+        "cask": "difffork",
+        "count": "70"
+      }
+    ],
+    "diffmerge": [
+      {
+        "cask": "diffmerge",
+        "count": "5,066"
+      }
+    ],
+    "digikam": [
+      {
+        "cask": "digikam",
+        "count": "777"
+      }
+    ],
+    "digikam-beta": [
+      {
+        "cask": "digikam-beta",
+        "count": "2"
+      }
+    ],
+    "digital": [
+      {
+        "cask": "digital",
+        "count": "10"
+      }
+    ],
+    "digital-paper-app": [
+      {
+        "cask": "digital-paper-app",
+        "count": "7"
+      }
+    ],
+    "dingtalk": [
+      {
+        "cask": "dingtalk",
+        "count": "2,747"
+      }
+    ],
+    "dingtalk-beta": [
+      {
+        "cask": "dingtalk-beta",
+        "count": "1"
+      }
+    ],
+    "dintch": [
+      {
+        "cask": "dintch",
+        "count": "1"
+      }
+    ],
+    "diptrace": [
+      {
+        "cask": "diptrace",
+        "count": "14"
+      }
+    ],
+    "disablemonitor": [
+      {
+        "cask": "disablemonitor",
+        "count": "176"
+      }
+    ],
+    "discord": [
+      {
+        "cask": "discord",
+        "count": "30,018"
+      }
+    ],
+    "discord-canary": [
+      {
+        "cask": "discord-canary",
+        "count": "248"
+      }
+    ],
+    "discord-ptb": [
+      {
+        "cask": "discord-ptb",
+        "count": "102"
+      }
+    ],
+    "discretescroll": [
+      {
+        "cask": "discretescroll",
+        "count": "61"
+      }
+    ],
+    "disk-arbitrator": [
+      {
+        "cask": "disk-arbitrator",
+        "count": "240"
+      }
+    ],
+    "disk-drill": [
+      {
+        "cask": "disk-drill",
+        "count": "994"
+      }
+    ],
+    "disk-inventory-x": [
+      {
+        "cask": "disk-inventory-x",
+        "count": "4,876"
+      }
+    ],
+    "disk-sensei": [
+      {
+        "cask": "disk-sensei",
+        "count": "63"
+      }
+    ],
+    "diskcatalogmaker": [
+      {
+        "cask": "diskcatalogmaker",
+        "count": "31"
+      }
+    ],
+    "diskmaker-x": [
+      {
+        "cask": "diskmaker-x",
+        "count": "696"
+      }
+    ],
+    "diskwave": [
+      {
+        "cask": "diskwave",
+        "count": "231"
+      }
+    ],
+    "displaperture": [
+      {
+        "cask": "displaperture",
+        "count": "47"
+      }
+    ],
+    "displaycal": [
+      {
+        "cask": "displaycal",
+        "count": "458"
+      }
+    ],
+    "displaylink": [
+      {
+        "cask": "displaylink",
+        "count": "814"
+      }
+    ],
+    "displaylink-beta": [
+      {
+        "cask": "displaylink-beta",
+        "count": "2"
+      }
+    ],
+    "displays": [
+      {
+        "cask": "displays",
+        "count": "6"
+      }
+    ],
+    "dissenter-browser": [
+      {
+        "cask": "dissenter-browser",
+        "count": "97"
+      }
+    ],
+    "divvy": [
+      {
+        "cask": "divvy",
+        "count": "1,186"
+      }
+    ],
+    "djay-pro": [
+      {
+        "cask": "djay-pro",
+        "count": "76"
+      }
+    ],
+    "dji-assistant2-mavic": [
+      {
+        "cask": "dji-assistant2-mavic",
+        "count": "1"
+      }
+    ],
+    "djv": [
+      {
+        "cask": "djv",
+        "count": "110"
+      }
+    ],
+    "djview": [
+      {
+        "cask": "djview",
+        "count": "1,080"
+      }
+    ],
+    "dlan-cockpit": [
+      {
+        "cask": "dlan-cockpit",
+        "count": "5"
+      }
+    ],
+    "dmenu": [
+      {
+        "cask": "dmenu",
+        "count": "9"
+      }
+    ],
+    "dmenu-mac": [
+      {
+        "cask": "dmenu-mac",
+        "count": "17"
+      }
+    ],
+    "dmg-audio-compassion": [
+      {
+        "cask": "dmg-audio-compassion",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-dualism": [
+      {
+        "cask": "dmg-audio-dualism",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-equality": [
+      {
+        "cask": "dmg-audio-equality",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-equick": [
+      {
+        "cask": "dmg-audio-equick",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-equilibrium": [
+      {
+        "cask": "dmg-audio-equilibrium",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-essence": [
+      {
+        "cask": "dmg-audio-essence",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-expurgate": [
+      {
+        "cask": "dmg-audio-expurgate",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-limitless": [
+      {
+        "cask": "dmg-audio-limitless",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-pitchfunk": [
+      {
+        "cask": "dmg-audio-pitchfunk",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-trackcomp": [
+      {
+        "cask": "dmg-audio-trackcomp",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-trackcontrol": [
+      {
+        "cask": "dmg-audio-trackcontrol",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-trackds": [
+      {
+        "cask": "dmg-audio-trackds",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-trackgate": [
+      {
+        "cask": "dmg-audio-trackgate",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-tracklimit": [
+      {
+        "cask": "dmg-audio-tracklimit",
+        "count": "1"
+      }
+    ],
+    "dmg-audio-trackmeter": [
+      {
+        "cask": "dmg-audio-trackmeter",
+        "count": "1"
+      }
+    ],
+    "dmisc-virtualbox": [
+      {
+        "cask": "dmisc-virtualbox",
+        "count": "1"
+      }
+    ],
+    "dmm-game-player": [
+      {
+        "cask": "dmm-game-player",
+        "count": "1"
+      }
+    ],
+    "dmm-player": [
+      {
+        "cask": "dmm-player",
+        "count": "80"
+      }
+    ],
+    "dmm-player-for-chrome": [
+      {
+        "cask": "dmm-player-for-chrome",
+        "count": "27"
+      }
+    ],
+    "dmmbookviewer": [
+      {
+        "cask": "dmmbookviewer",
+        "count": "2"
+      }
+    ],
+    "dnie": [
+      {
+        "cask": "dnie",
+        "count": "3"
+      }
+    ],
+    "do-not-disturb": [
+      {
+        "cask": "do-not-disturb",
+        "count": "264"
+      }
+    ],
+    "do365-navicat-premium-12.0.24": [
+      {
+        "cask": "do365-navicat-premium-12.0.24",
+        "count": "8"
+      }
+    ],
+    "docear": [
+      {
+        "cask": "docear",
+        "count": "87"
+      }
+    ],
+    "dock-manager": [
+      {
+        "cask": "dock-manager",
+        "count": "3"
+      }
+    ],
+    "docker": [
+      {
+        "cask": "docker",
+        "count": "240,291"
+      }
+    ],
+    "docker-2_1": [
+      {
+        "cask": "docker-2_1",
+        "count": "11"
+      }
+    ],
+    "docker-desktop": [
+      {
+        "cask": "docker-desktop",
+        "count": "4"
+      }
+    ],
+    "docker-desktop@26764": [
+      {
+        "cask": "docker-desktop@26764",
+        "count": "2"
+      }
+    ],
+    "docker-edge": [
+      {
+        "cask": "docker-edge",
+        "count": "2,527"
+      }
+    ],
+    "docker-toolbox": [
+      {
+        "cask": "docker-toolbox",
+        "count": "5,107"
+      }
+    ],
+    "docker.old": [
+      {
+        "cask": "docker.old",
+        "count": "1"
+      }
+    ],
+    "docker@20": [
+      {
+        "cask": "docker@20",
+        "count": "1"
+      }
+    ],
+    "dockey": [
+      {
+        "cask": "dockey",
+        "count": "125"
+      }
+    ],
+    "dockstation": [
+      {
+        "cask": "dockstation",
+        "count": "485"
+      }
+    ],
+    "dockutil": [
+      {
+        "cask": "dockutil",
+        "count": "1"
+      }
+    ],
+    "docuworks-viewer-light": [
+      {
+        "cask": "docuworks-viewer-light",
+        "count": "4"
+      }
+    ],
+    "dofus": [
+      {
+        "cask": "dofus",
+        "count": "23"
+      }
+    ],
+    "dogecoin": [
+      {
+        "cask": "dogecoin",
+        "count": "40"
+      }
+    ],
+    "dolphin": [
+      {
+        "cask": "dolphin",
+        "count": "710"
+      }
+    ],
+    "dolphin-dev": [
+      {
+        "cask": "dolphin-dev",
+        "count": "83"
+      }
+    ],
+    "dolphin-emu": [
+      {
+        "cask": "dolphin-emu",
+        "count": "1"
+      }
+    ],
+    "doly": [
+      {
+        "cask": "doly",
+        "count": "5"
+      }
+    ],
+    "domainbrain": [
+      {
+        "cask": "domainbrain",
+        "count": "3"
+      }
+    ],
+    "doomrl": [
+      {
+        "cask": "doomrl",
+        "count": "65"
+      }
+    ],
+    "doomsday-engine": [
+      {
+        "cask": "doomsday-engine",
+        "count": "30"
+      }
+    ],
+    "dosbox": [
+      {
+        "cask": "dosbox",
+        "count": "1,165"
+      }
+    ],
+    "dosbox-svn": [
+      {
+        "cask": "dosbox-svn",
+        "count": "4"
+      }
+    ],
+    "dosbox-x": [
+      {
+        "cask": "dosbox-x",
+        "count": "242"
+      }
+    ],
+    "doteditor": [
+      {
+        "cask": "doteditor",
+        "count": "84"
+      }
+    ],
+    "dotnet": [
+      {
+        "cask": "dotnet",
+        "count": "8,424"
+      }
+    ],
+    "dotnet-preview": [
+      {
+        "cask": "dotnet-preview",
+        "count": "52"
+      }
+    ],
+    "dotnet-sdk": [
+      {
+        "cask": "dotnet-sdk",
+        "count": "17,694"
+      }
+    ],
+    "dotnet-sdk-2.1.400": [
+      {
+        "cask": "dotnet-sdk-2.1.400",
+        "count": "39"
+      }
+    ],
+    "dotnet-sdk-2.1.500": [
+      {
+        "cask": "dotnet-sdk-2.1.500",
+        "count": "31"
+      }
+    ],
+    "dotnet-sdk-2.1.800": [
+      {
+        "cask": "dotnet-sdk-2.1.800",
+        "count": "291"
+      }
+    ],
+    "dotnet-sdk-2.1.802": [
+      {
+        "cask": "dotnet-sdk-2.1.802",
+        "count": "2"
+      }
+    ],
+    "dotnet-sdk-2.2": [
+      {
+        "cask": "dotnet-sdk-2.2",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-2.2.100": [
+      {
+        "cask": "dotnet-sdk-2.2.100",
+        "count": "354"
+      }
+    ],
+    "dotnet-sdk-2.2.107": [
+      {
+        "cask": "dotnet-sdk-2.2.107",
+        "count": "2"
+      }
+    ],
+    "dotnet-sdk-2.2.200": [
+      {
+        "cask": "dotnet-sdk-2.2.200",
+        "count": "33"
+      }
+    ],
+    "dotnet-sdk-2.2.207": [
+      {
+        "cask": "dotnet-sdk-2.2.207",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-2.2.300": [
+      {
+        "cask": "dotnet-sdk-2.2.300",
+        "count": "70"
+      }
+    ],
+    "dotnet-sdk-2.2.301": [
+      {
+        "cask": "dotnet-sdk-2.2.301",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-2.2.400": [
+      {
+        "cask": "dotnet-sdk-2.2.400",
+        "count": "543"
+      }
+    ],
+    "dotnet-sdk-3-0": [
+      {
+        "cask": "dotnet-sdk-3-0",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-3.0.100": [
+      {
+        "cask": "dotnet-sdk-3.0.100",
+        "count": "124"
+      }
+    ],
+    "dotnet-sdk-3.1.100": [
+      {
+        "cask": "dotnet-sdk-3.1.100",
+        "count": "156"
+      }
+    ],
+    "dotnet-sdk-3.1.200": [
+      {
+        "cask": "dotnet-sdk-3.1.200",
+        "count": "62"
+      }
+    ],
+    "dotnet-sdk-latest": [
+      {
+        "cask": "dotnet-sdk-latest",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-pinned": [
+      {
+        "cask": "dotnet-sdk-pinned",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-preview": [
+      {
+        "cask": "dotnet-sdk-preview",
+        "count": "455"
+      }
+    ],
+    "dotnet-sdk2": [
+      {
+        "cask": "dotnet-sdk2",
+        "count": "4"
+      }
+    ],
+    "dotnet-sdk2.x": [
+      {
+        "cask": "dotnet-sdk2.x",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk21": [
+      {
+        "cask": "dotnet-sdk21",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk22": [
+      {
+        "cask": "dotnet-sdk22",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk@2.1": [
+      {
+        "cask": "dotnet-sdk@2.1",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk@2.2": [
+      {
+        "cask": "dotnet-sdk@2.2",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk@22": [
+      {
+        "cask": "dotnet-sdk@22",
+        "count": "3"
+      }
+    ],
+    "double-commander": [
+      {
+        "cask": "double-commander",
+        "count": "1,607"
+      }
+    ],
+    "double-commander-qt": [
+      {
+        "cask": "double-commander-qt",
+        "count": "3"
+      }
+    ],
+    "doubletwist": [
+      {
+        "cask": "doubletwist",
+        "count": "360"
+      }
+    ],
+    "downie": [
+      {
+        "cask": "downie",
+        "count": "1,843"
+      }
+    ],
+    "doxie": [
+      {
+        "cask": "doxie",
+        "count": "232"
+      }
+    ],
+    "doxygen": [
+      {
+        "cask": "doxygen",
+        "count": "431"
+      }
+    ],
+    "dozer": [
+      {
+        "cask": "dozer",
+        "count": "8,699"
+      }
+    ],
+    "dradio": [
+      {
+        "cask": "dradio",
+        "count": "21"
+      }
+    ],
+    "dragondisk-custom": [
+      {
+        "cask": "dragondisk-custom",
+        "count": "2"
+      }
+    ],
+    "dragonfly-reverb": [
+      {
+        "cask": "dragonfly-reverb",
+        "count": "4"
+      }
+    ],
+    "dragthing": [
+      {
+        "cask": "dragthing",
+        "count": "9"
+      }
+    ],
+    "drake": [
+      {
+        "cask": "drake",
+        "count": "15"
+      }
+    ],
+    "drama": [
+      {
+        "cask": "drama",
+        "count": "43"
+      }
+    ],
+    "drawbot": [
+      {
+        "cask": "drawbot",
+        "count": "42"
+      }
+    ],
+    "drawio": [
+      {
+        "cask": "drawio",
+        "count": "8,794"
+      }
+    ],
+    "dremel-slicer": [
+      {
+        "cask": "dremel-slicer",
+        "count": "1"
+      }
+    ],
+    "dripcap": [
+      {
+        "cask": "dripcap",
+        "count": "6"
+      }
+    ],
+    "drivedx": [
+      {
+        "cask": "drivedx",
+        "count": "481"
+      }
+    ],
+    "drivethrurpg": [
+      {
+        "cask": "drivethrurpg",
+        "count": "50"
+      }
+    ],
+    "drjava": [
+      {
+        "cask": "drjava",
+        "count": "1"
+      }
+    ],
+    "drmr": [
+      {
+        "cask": "drmr",
+        "count": "1"
+      }
+    ],
+    "drobo-dashboard": [
+      {
+        "cask": "drobo-dashboard",
+        "count": "123"
+      }
+    ],
+    "droidid": [
+      {
+        "cask": "droidid",
+        "count": "49"
+      }
+    ],
+    "drop-to-gif": [
+      {
+        "cask": "drop-to-gif",
+        "count": "179"
+      }
+    ],
+    "dropbox": [
+      {
+        "cask": "dropbox",
+        "count": "30,094"
+      }
+    ],
+    "dropbox-beta": [
+      {
+        "cask": "dropbox-beta",
+        "count": "207"
+      }
+    ],
+    "dropbox-encore": [
+      {
+        "cask": "dropbox-encore",
+        "count": "41"
+      }
+    ],
+    "dropbox-installer": [
+      {
+        "cask": "dropbox-installer",
+        "count": "2"
+      }
+    ],
+    "dropdmg": [
+      {
+        "cask": "dropdmg",
+        "count": "90"
+      }
+    ],
+    "dropletmanager": [
+      {
+        "cask": "dropletmanager",
+        "count": "29"
+      }
+    ],
+    "droplr": [
+      {
+        "cask": "droplr",
+        "count": "332"
+      }
+    ],
+    "dropshare": [
+      {
+        "cask": "dropshare",
+        "count": "222"
+      }
+    ],
+    "dropzone": [
+      {
+        "cask": "dropzone",
+        "count": "119"
+      }
+    ],
+    "duckietv": [
+      {
+        "cask": "duckietv",
+        "count": "29"
+      }
+    ],
+    "duefocus": [
+      {
+        "cask": "duefocus",
+        "count": "12"
+      }
+    ],
+    "duet": [
+      {
+        "cask": "duet",
+        "count": "3,157"
+      }
+    ],
+    "dukto": [
+      {
+        "cask": "dukto",
+        "count": "292"
+      }
+    ],
+    "dungeon-crawl-stone-soup-console": [
+      {
+        "cask": "dungeon-crawl-stone-soup-console",
+        "count": "152"
+      }
+    ],
+    "dungeon-crawl-stone-soup-tiles": [
+      {
+        "cask": "dungeon-crawl-stone-soup-tiles",
+        "count": "187"
+      }
+    ],
+    "duo-connect": [
+      {
+        "cask": "duo-connect",
+        "count": "38"
+      }
+    ],
+    "duo-desktop": [
+      {
+        "cask": "duo-desktop",
+        "count": "2"
+      }
+    ],
+    "duoconnect": [
+      {
+        "cask": "duoconnect",
+        "count": "1"
+      }
+    ],
+    "dupeguru": [
+      {
+        "cask": "dupeguru",
+        "count": "674"
+      }
+    ],
+    "dupin": [
+      {
+        "cask": "dupin",
+        "count": "3"
+      }
+    ],
+    "duplicacy": [
+      {
+        "cask": "duplicacy",
+        "count": "118"
+      }
+    ],
+    "duplicacy-web-edition": [
+      {
+        "cask": "duplicacy-web-edition",
+        "count": "22"
+      }
+    ],
+    "duplicate-annihilator": [
+      {
+        "cask": "duplicate-annihilator",
+        "count": "21"
+      }
+    ],
+    "duplicate-annihilator-for-photos": [
+      {
+        "cask": "duplicate-annihilator-for-photos",
+        "count": "25"
+      }
+    ],
+    "duplicati": [
+      {
+        "cask": "duplicati",
+        "count": "467"
+      }
+    ],
+    "dupscanub": [
+      {
+        "cask": "dupscanub",
+        "count": "8"
+      }
+    ],
+    "dust3d": [
+      {
+        "cask": "dust3d",
+        "count": "48"
+      }
+    ],
+    "dusty": [
+      {
+        "cask": "dusty",
+        "count": "46"
+      }
+    ],
+    "dvc": [
+      {
+        "cask": "dvc",
+        "count": "115"
+      }
+    ],
+    "dvdstyler": [
+      {
+        "cask": "dvdstyler",
+        "count": "103"
+      }
+    ],
+    "dwarf-fortress": [
+      {
+        "cask": "dwarf-fortress",
+        "count": "744"
+      }
+    ],
+    "dwarf-fortress-lmp": [
+      {
+        "cask": "dwarf-fortress-lmp",
+        "count": "193"
+      }
+    ],
+    "dwgsee": [
+      {
+        "cask": "dwgsee",
+        "count": "120"
+      }
+    ],
+    "dwihn0r-keepassx": [
+      {
+        "cask": "dwihn0r-keepassx",
+        "count": "59"
+      }
+    ],
+    "dymo-label": [
+      {
+        "cask": "dymo-label",
+        "count": "99"
+      }
+    ],
+    "dyn-updater": [
+      {
+        "cask": "dyn-updater",
+        "count": "35"
+      }
+    ],
+    "dynalist": [
+      {
+        "cask": "dynalist",
+        "count": "321"
+      }
+    ],
+    "dynamic-dark-mode": [
+      {
+        "cask": "dynamic-dark-mode",
+        "count": "494"
+      }
+    ],
+    "dynamiclyrics": [
+      {
+        "cask": "dynamiclyrics",
+        "count": "8"
+      }
+    ],
+    "dynamodb-local": [
+      {
+        "cask": "dynamodb-local",
+        "count": "1,150"
+      }
+    ],
+    "dynobase": [
+      {
+        "cask": "dynobase",
+        "count": "6"
+      }
+    ],
+    "dystextia": [
+      {
+        "cask": "dystextia",
+        "count": "7"
+      }
+    ],
+    "eaccess": [
+      {
+        "cask": "eaccess",
+        "count": "5"
+      }
+    ],
+    "eaccess-desktop": [
+      {
+        "cask": "eaccess-desktop",
+        "count": "4"
+      }
+    ],
+    "eagle": [
+      {
+        "cask": "eagle",
+        "count": "653"
+      }
+    ],
+    "eaglefiler": [
+      {
+        "cask": "eaglefiler",
+        "count": "139"
+      }
+    ],
+    "ealeksandrov-cd-to": [
+      {
+        "cask": "ealeksandrov-cd-to",
+        "count": "44"
+      }
+    ],
+    "easy-move-plus-resize": [
+      {
+        "cask": "easy-move-plus-resize",
+        "count": "919"
+      }
+    ],
+    "easyabc": [
+      {
+        "cask": "easyabc",
+        "count": "1"
+      }
+    ],
+    "easycrop": [
+      {
+        "cask": "easycrop",
+        "count": "2"
+      }
+    ],
+    "easyeda": [
+      {
+        "cask": "easyeda",
+        "count": "121"
+      }
+    ],
+    "easyfind": [
+      {
+        "cask": "easyfind",
+        "count": "1,048"
+      }
+    ],
+    "easysimbl": [
+      {
+        "cask": "easysimbl",
+        "count": "1"
+      }
+    ],
+    "easytether": [
+      {
+        "cask": "easytether",
+        "count": "66"
+      }
+    ],
+    "ebibookreader": [
+      {
+        "cask": "ebibookreader",
+        "count": "19"
+      }
+    ],
+    "ebmac": [
+      {
+        "cask": "ebmac",
+        "count": "78"
+      }
+    ],
+    "echobase": [
+      {
+        "cask": "echobase",
+        "count": "3"
+      }
+    ],
+    "eclipse-cpp": [
+      {
+        "cask": "eclipse-cpp",
+        "count": "1,254"
+      }
+    ],
+    "eclipse-dsl": [
+      {
+        "cask": "eclipse-dsl",
+        "count": "63"
+      }
+    ],
+    "eclipse-ide": [
+      {
+        "cask": "eclipse-ide",
+        "count": "4,673"
+      }
+    ],
+    "eclipse-installer": [
+      {
+        "cask": "eclipse-installer",
+        "count": "712"
+      }
+    ],
+    "eclipse-java": [
+      {
+        "cask": "eclipse-java",
+        "count": "6,533"
+      }
+    ],
+    "eclipse-java@4.10": [
+      {
+        "cask": "eclipse-java@4.10",
+        "count": "3"
+      }
+    ],
+    "eclipse-javascript": [
+      {
+        "cask": "eclipse-javascript",
+        "count": "203"
+      }
+    ],
+    "eclipse-jee": [
+      {
+        "cask": "eclipse-jee",
+        "count": "8,304"
+      }
+    ],
+    "eclipse-modeling": [
+      {
+        "cask": "eclipse-modeling",
+        "count": "219"
+      }
+    ],
+    "eclipse-php": [
+      {
+        "cask": "eclipse-php",
+        "count": "274"
+      }
+    ],
+    "eclipse-platform": [
+      {
+        "cask": "eclipse-platform",
+        "count": "216"
+      }
+    ],
+    "eclipse-ptp": [
+      {
+        "cask": "eclipse-ptp",
+        "count": "47"
+      }
+    ],
+    "eclipse-rcp": [
+      {
+        "cask": "eclipse-rcp",
+        "count": "108"
+      }
+    ],
+    "eclipse-rust": [
+      {
+        "cask": "eclipse-rust",
+        "count": "1"
+      }
+    ],
+    "eclipse-scout": [
+      {
+        "cask": "eclipse-scout",
+        "count": "36"
+      }
+    ],
+    "eclipse-testing": [
+      {
+        "cask": "eclipse-testing",
+        "count": "55"
+      }
+    ],
+    "eclipse_formatter_intellij": [
+      {
+        "cask": "eclipse_formatter_intellij",
+        "count": "1"
+      }
+    ],
+    "eddie": [
+      {
+        "cask": "eddie",
+        "count": "108"
+      }
+    ],
+    "edex-ui": [
+      {
+        "cask": "edex-ui",
+        "count": "688"
+      }
+    ],
+    "edfbrowser": [
+      {
+        "cask": "edfbrowser",
+        "count": "51"
+      }
+    ],
+    "edge": [
+      {
+        "cask": "edge",
+        "count": "8"
+      }
+    ],
+    "edgecontrol": [
+      {
+        "cask": "edgecontrol",
+        "count": "4"
+      }
+    ],
+    "edgegui": [
+      {
+        "cask": "edgegui",
+        "count": "9"
+      }
+    ],
+    "edison-mail": [
+      {
+        "cask": "edison-mail",
+        "count": "2"
+      }
+    ],
+    "editaro": [
+      {
+        "cask": "editaro",
+        "count": "33"
+      }
+    ],
+    "editready": [
+      {
+        "cask": "editready",
+        "count": "5"
+      }
+    ],
+    "edm": [
+      {
+        "cask": "edm",
+        "count": "1"
+      }
+    ],
+    "edrawmax": [
+      {
+        "cask": "edrawmax",
+        "count": "224"
+      }
+    ],
+    "eggplant": [
+      {
+        "cask": "eggplant",
+        "count": "36"
+      }
+    ],
+    "eid-be": [
+      {
+        "cask": "eid-be",
+        "count": "23"
+      }
+    ],
+    "eid-be-viewer": [
+      {
+        "cask": "eid-be-viewer",
+        "count": "9"
+      }
+    ],
+    "eid-ee": [
+      {
+        "cask": "eid-ee",
+        "count": "6"
+      }
+    ],
+    "eim": [
+      {
+        "cask": "eim",
+        "count": "13"
+      }
+    ],
+    "eintopf": [
+      {
+        "cask": "eintopf",
+        "count": "1"
+      }
+    ],
+    "eiskaltdcpp": [
+      {
+        "cask": "eiskaltdcpp",
+        "count": "188"
+      }
+    ],
+    "ejectionseat": [
+      {
+        "cask": "ejectionseat",
+        "count": "8"
+      }
+    ],
+    "ejector": [
+      {
+        "cask": "ejector",
+        "count": "30"
+      }
+    ],
+    "elan": [
+      {
+        "cask": "elan",
+        "count": "10"
+      }
+    ],
+    "elan-avfx": [
+      {
+        "cask": "elan-avfx",
+        "count": "6"
+      }
+    ],
+    "elasticwolf": [
+      {
+        "cask": "elasticwolf",
+        "count": "36"
+      }
+    ],
+    "electerm": [
+      {
+        "cask": "electerm",
+        "count": "162"
+      }
+    ],
+    "electorrent": [
+      {
+        "cask": "electorrent",
+        "count": "275"
+      }
+    ],
+    "electric-sheep": [
+      {
+        "cask": "electric-sheep",
+        "count": "144"
+      }
+    ],
+    "electrocrud": [
+      {
+        "cask": "electrocrud",
+        "count": "21"
+      }
+    ],
+    "electron": [
+      {
+        "cask": "electron",
+        "count": "2,048"
+      }
+    ],
+    "electron-api-demos": [
+      {
+        "cask": "electron-api-demos",
+        "count": "49"
+      }
+    ],
+    "electron-beta": [
+      {
+        "cask": "electron-beta",
+        "count": "1"
+      }
+    ],
+    "electron-cash": [
+      {
+        "cask": "electron-cash",
+        "count": "129"
+      }
+    ],
+    "electron-fiddle": [
+      {
+        "cask": "electron-fiddle",
+        "count": "178"
+      }
+    ],
+    "electronic-wechat": [
+      {
+        "cask": "electronic-wechat",
+        "count": "138"
+      }
+    ],
+    "electronmail": [
+      {
+        "cask": "electronmail",
+        "count": "35"
+      }
+    ],
+    "electrum": [
+      {
+        "cask": "electrum",
+        "count": "1,294"
+      }
+    ],
+    "electrum-ltc": [
+      {
+        "cask": "electrum-ltc",
+        "count": "95"
+      }
+    ],
+    "electrum-mona": [
+      {
+        "cask": "electrum-mona",
+        "count": "1"
+      }
+    ],
+    "electrumsv": [
+      {
+        "cask": "electrumsv",
+        "count": "16"
+      }
+    ],
+    "electsys-utility": [
+      {
+        "cask": "electsys-utility",
+        "count": "5"
+      }
+    ],
+    "elektriktrick": [
+      {
+        "cask": "elektriktrick",
+        "count": "15"
+      }
+    ],
+    "elektron-overbridge": [
+      {
+        "cask": "elektron-overbridge",
+        "count": "8"
+      }
+    ],
+    "elektron-transfer": [
+      {
+        "cask": "elektron-transfer",
+        "count": "2"
+      }
+    ],
+    "elgato-control-center": [
+      {
+        "cask": "elgato-control-center",
+        "count": "9"
+      }
+    ],
+    "elgato-game-capture-hd": [
+      {
+        "cask": "elgato-game-capture-hd",
+        "count": "103"
+      }
+    ],
+    "elgato-stream-deck": [
+      {
+        "cask": "elgato-stream-deck",
+        "count": "81"
+      }
+    ],
+    "elgato-thunderbolt-dock": [
+      {
+        "cask": "elgato-thunderbolt-dock",
+        "count": "66"
+      }
+    ],
+    "elgato-video-capture": [
+      {
+        "cask": "elgato-video-capture",
+        "count": "20"
+      }
+    ],
+    "elgiganten-jotta": [
+      {
+        "cask": "elgiganten-jotta",
+        "count": "16"
+      }
+    ],
+    "elgigantencloud": [
+      {
+        "cask": "elgigantencloud",
+        "count": "8"
+      }
+    ],
+    "elmedia-player": [
+      {
+        "cask": "elmedia-player",
+        "count": "974"
+      }
+    ],
+    "eloston-chromium": [
+      {
+        "cask": "eloston-chromium",
+        "count": "3,551"
+      }
+    ],
+    "elpass": [
+      {
+        "cask": "elpass",
+        "count": "43"
+      }
+    ],
+    "emacs": [
+      {
+        "cask": "emacs",
+        "count": "49,122"
+      }
+    ],
+    "emacs-inlinepatched": [
+      {
+        "cask": "emacs-inlinepatched",
+        "count": "1"
+      }
+    ],
+    "emacs-mac": [
+      {
+        "cask": "emacs-mac",
+        "count": "3,049"
+      }
+    ],
+    "emacs-mac-snapshot": [
+      {
+        "cask": "emacs-mac-snapshot",
+        "count": "4"
+      }
+    ],
+    "emacs-mac-spacemacs-icon": [
+      {
+        "cask": "emacs-mac-spacemacs-icon",
+        "count": "814"
+      }
+    ],
+    "emacs-nightly": [
+      {
+        "cask": "emacs-nightly",
+        "count": "359"
+      }
+    ],
+    "emacs-pretest": [
+      {
+        "cask": "emacs-pretest",
+        "count": "93"
+      }
+    ],
+    "emacsclient": [
+      {
+        "cask": "emacsclient",
+        "count": "519"
+      }
+    ],
+    "emailchemy": [
+      {
+        "cask": "emailchemy",
+        "count": "8"
+      }
+    ],
+    "emby-server": [
+      {
+        "cask": "emby-server",
+        "count": "212"
+      }
+    ],
+    "emclient": [
+      {
+        "cask": "emclient",
+        "count": "87"
+      }
+    ],
+    "eme": [
+      {
+        "cask": "eme",
+        "count": "2"
+      }
+    ],
+    "emin-webpquicklook": [
+      {
+        "cask": "emin-webpquicklook",
+        "count": "1"
+      }
+    ],
+    "emojify": [
+      {
+        "cask": "emojify",
+        "count": "10"
+      }
+    ],
+    "emojipedia": [
+      {
+        "cask": "emojipedia",
+        "count": "91"
+      }
+    ],
+    "empoche": [
+      {
+        "cask": "empoche",
+        "count": "5"
+      }
+    ],
+    "ems-qart": [
+      {
+        "cask": "ems-qart",
+        "count": "1"
+      }
+    ],
+    "encryptme": [
+      {
+        "cask": "encryptme",
+        "count": "264"
+      }
+    ],
+    "encryptr": [
+      {
+        "cask": "encryptr",
+        "count": "46"
+      }
+    ],
+    "endless-sky": [
+      {
+        "cask": "endless-sky",
+        "count": "44"
+      }
+    ],
+    "endless-sky-cloud": [
+      {
+        "cask": "endless-sky-cloud",
+        "count": "1"
+      }
+    ],
+    "endlesssky": [
+      {
+        "cask": "endlesssky",
+        "count": "38"
+      }
+    ],
+    "endnote": [
+      {
+        "cask": "endnote",
+        "count": "225"
+      }
+    ],
+    "endpoint_security_vpn": [
+      {
+        "cask": "endpoint_security_vpn",
+        "count": "1"
+      }
+    ],
+    "endurance": [
+      {
+        "cask": "endurance",
+        "count": "162"
+      }
+    ],
+    "energybar": [
+      {
+        "cask": "energybar",
+        "count": "316"
+      }
+    ],
+    "enervee-vpn": [
+      {
+        "cask": "enervee-vpn",
+        "count": "2"
+      }
+    ],
+    "enfusegui": [
+      {
+        "cask": "enfusegui",
+        "count": "36"
+      }
+    ],
+    "engine-prime": [
+      {
+        "cask": "engine-prime",
+        "count": "13"
+      }
+    ],
+    "english-persian-dictionary": [
+      {
+        "cask": "english-persian-dictionary",
+        "count": "1"
+      }
+    ],
+    "enjoyable": [
+      {
+        "cask": "enjoyable",
+        "count": "197"
+      }
+    ],
+    "enolsoft-chm-view": [
+      {
+        "cask": "enolsoft-chm-view",
+        "count": "110"
+      }
+    ],
+    "enpass": [
+      {
+        "cask": "enpass",
+        "count": "1,686"
+      }
+    ],
+    "entropy": [
+      {
+        "cask": "entropy",
+        "count": "88"
+      }
+    ],
+    "envkey": [
+      {
+        "cask": "envkey",
+        "count": "49"
+      }
+    ],
+    "enzymex": [
+      {
+        "cask": "enzymex",
+        "count": "12"
+      }
+    ],
+    "epi2me-agent": [
+      {
+        "cask": "epi2me-agent",
+        "count": "4"
+      }
+    ],
+    "epi2me-agent@staging": [
+      {
+        "cask": "epi2me-agent@staging",
+        "count": "1"
+      }
+    ],
+    "epi2me-cli": [
+      {
+        "cask": "epi2me-cli",
+        "count": "14"
+      }
+    ],
+    "epi2me-cli@staging": [
+      {
+        "cask": "epi2me-cli@staging",
+        "count": "3"
+      }
+    ],
+    "epic": [
+      {
+        "cask": "epic",
+        "count": "287"
+      }
+    ],
+    "epic-games": [
+      {
+        "cask": "epic-games",
+        "count": "2,409"
+      }
+    ],
+    "epichrome": [
+      {
+        "cask": "epichrome",
+        "count": "211"
+      }
+    ],
+    "epictask": [
+      {
+        "cask": "epictask",
+        "count": "1"
+      }
+    ],
+    "epoccam-drivers": [
+      {
+        "cask": "epoccam-drivers",
+        "count": "4"
+      }
+    ],
+    "epoch-flip-clock": [
+      {
+        "cask": "epoch-flip-clock",
+        "count": "51"
+      }
+    ],
+    "epub-services": [
+      {
+        "cask": "epub-services",
+        "count": "220"
+      }
+    ],
+    "epub-to-pdf": [
+      {
+        "cask": "epub-to-pdf",
+        "count": "165"
+      }
+    ],
+    "epubmdimporter": [
+      {
+        "cask": "epubmdimporter",
+        "count": "94"
+      }
+    ],
+    "epubquicklook": [
+      {
+        "cask": "epubquicklook",
+        "count": "1,142"
+      }
+    ],
+    "eqmac": [
+      {
+        "cask": "eqmac",
+        "count": "2,016"
+      }
+    ],
+    "eqmac-beta": [
+      {
+        "cask": "eqmac-beta",
+        "count": "8"
+      }
+    ],
+    "eset-cyber-security": [
+      {
+        "cask": "eset-cyber-security",
+        "count": "2"
+      }
+    ],
+    "eset-cyber-security-pro": [
+      {
+        "cask": "eset-cyber-security-pro",
+        "count": "30"
+      }
+    ],
+    "eset-endpoint-security": [
+      {
+        "cask": "eset-endpoint-security",
+        "count": "971"
+      }
+    ],
+    "eshelper": [
+      {
+        "cask": "eshelper",
+        "count": "1"
+      }
+    ],
+    "espresso": [
+      {
+        "cask": "espresso",
+        "count": "136"
+      }
+    ],
+    "etcher": [
+      {
+        "cask": "etcher",
+        "count": "27"
+      }
+    ],
+    "ethereum-wallet": [
+      {
+        "cask": "ethereum-wallet",
+        "count": "122"
+      }
+    ],
+    "etrecheckpro": [
+      {
+        "cask": "etrecheckpro",
+        "count": "520"
+      }
+    ],
+    "eudic": [
+      {
+        "cask": "eudic",
+        "count": "911"
+      }
+    ],
+    "eurkey": [
+      {
+        "cask": "eurkey",
+        "count": "39"
+      }
+    ],
+    "eve": [
+      {
+        "cask": "eve",
+        "count": "88"
+      }
+    ],
+    "eve-launcher": [
+      {
+        "cask": "eve-launcher",
+        "count": "136"
+      }
+    ],
+    "eventide-2016-stereo-room": [
+      {
+        "cask": "eventide-2016-stereo-room",
+        "count": "1"
+      }
+    ],
+    "eventstore": [
+      {
+        "cask": "eventstore",
+        "count": "573"
+      }
+    ],
+    "evernote": [
+      {
+        "cask": "evernote",
+        "count": "11,140"
+      }
+    ],
+    "everweb": [
+      {
+        "cask": "everweb",
+        "count": "10"
+      }
+    ],
+    "evoluent-vertical-mouse-device-controller": [
+      {
+        "cask": "evoluent-vertical-mouse-device-controller",
+        "count": "23"
+      }
+    ],
+    "evolv-escribe-suite": [
+      {
+        "cask": "evolv-escribe-suite",
+        "count": "12"
+      }
+    ],
+    "evolve-ip-uc-one": [
+      {
+        "cask": "evolve-ip-uc-one",
+        "count": "4"
+      }
+    ],
+    "evom": [
+      {
+        "cask": "evom",
+        "count": "15"
+      }
+    ],
+    "exactscan": [
+      {
+        "cask": "exactscan",
+        "count": "52"
+      }
+    ],
+    "exfalso": [
+      {
+        "cask": "exfalso",
+        "count": "46"
+      }
+    ],
+    "exifrenamer": [
+      {
+        "cask": "exifrenamer",
+        "count": "209"
+      }
+    ],
+    "exist-db": [
+      {
+        "cask": "exist-db",
+        "count": "147"
+      }
+    ],
+    "exist-db-rc": [
+      {
+        "cask": "exist-db-rc",
+        "count": "1"
+      }
+    ],
+    "exmancmd": [
+      {
+        "cask": "exmancmd",
+        "count": "641"
+      }
+    ],
+    "exodus": [
+      {
+        "cask": "exodus",
+        "count": "725"
+      }
+    ],
+    "expandrive": [
+      {
+        "cask": "expandrive",
+        "count": "580"
+      }
+    ],
+    "explorer": [
+      {
+        "cask": "explorer",
+        "count": "22"
+      }
+    ],
+    "expo-xde": [
+      {
+        "cask": "expo-xde",
+        "count": "289"
+      }
+    ],
+    "expressions": [
+      {
+        "cask": "expressions",
+        "count": "145"
+      }
+    ],
+    "expressscribe": [
+      {
+        "cask": "expressscribe",
+        "count": "20"
+      }
+    ],
+    "expressvpn": [
+      {
+        "cask": "expressvpn",
+        "count": "2,615"
+      }
+    ],
+    "extraterm": [
+      {
+        "cask": "extraterm",
+        "count": "173"
+      }
+    ],
+    "ezip": [
+      {
+        "cask": "ezip",
+        "count": "1,877"
+      }
+    ],
+    "f-bar": [
+      {
+        "cask": "f-bar",
+        "count": "2"
+      }
+    ],
+    "f-secure-anti-virus": [
+      {
+        "cask": "f-secure-anti-virus",
+        "count": "22"
+      }
+    ],
+    "f0nt-abc-aschariya": [
+      {
+        "cask": "f0nt-abc-aschariya",
+        "count": "1"
+      }
+    ],
+    "facebook-ios-sdk": [
+      {
+        "cask": "facebook-ios-sdk",
+        "count": "134"
+      }
+    ],
+    "facilis-client-720": [
+      {
+        "cask": "facilis-client-720",
+        "count": "13"
+      }
+    ],
+    "facilis-client-721": [
+      {
+        "cask": "facilis-client-721",
+        "count": "6"
+      }
+    ],
+    "factor": [
+      {
+        "cask": "factor",
+        "count": "262"
+      }
+    ],
+    "fake": [
+      {
+        "cask": "fake",
+        "count": "173"
+      }
+    ],
+    "fakethunder": [
+      {
+        "cask": "fakethunder",
+        "count": "19"
+      }
+    ],
+    "falcon-sql-client": [
+      {
+        "cask": "falcon-sql-client",
+        "count": "195"
+      }
+    ],
+    "family-tree-builder": [
+      {
+        "cask": "family-tree-builder",
+        "count": "30"
+      }
+    ],
+    "famitracker": [
+      {
+        "cask": "famitracker",
+        "count": "1"
+      }
+    ],
+    "fanny": [
+      {
+        "cask": "fanny",
+        "count": "706"
+      }
+    ],
+    "fantastical": [
+      {
+        "cask": "fantastical",
+        "count": "3,314"
+      }
+    ],
+    "fantasy-grounds": [
+      {
+        "cask": "fantasy-grounds",
+        "count": "13"
+      }
+    ],
+    "fantasy-map-generator": [
+      {
+        "cask": "fantasy-map-generator",
+        "count": "19"
+      }
+    ],
+    "fantasygrounds": [
+      {
+        "cask": "fantasygrounds",
+        "count": "1"
+      }
+    ],
+    "farrago": [
+      {
+        "cask": "farrago",
+        "count": "87"
+      }
+    ],
+    "fastlane": [
+      {
+        "cask": "fastlane",
+        "count": "63,080"
+      }
+    ],
+    "fastlane_cask": [
+      {
+        "cask": "fastlane_cask",
+        "count": "3"
+      }
+    ],
+    "fastonosql": [
+      {
+        "cask": "fastonosql",
+        "count": "88"
+      }
+    ],
+    "fastrawviewer": [
+      {
+        "cask": "fastrawviewer",
+        "count": "63"
+      }
+    ],
+    "fastscripts": [
+      {
+        "cask": "fastscripts",
+        "count": "139"
+      }
+    ],
+    "fauxpas": [
+      {
+        "cask": "fauxpas",
+        "count": "289"
+      }
+    ],
+    "favro": [
+      {
+        "cask": "favro",
+        "count": "40"
+      }
+    ],
+    "faxbot": [
+      {
+        "cask": "faxbot",
+        "count": "16"
+      }
+    ],
+    "fb-rotate": [
+      {
+        "cask": "fb-rotate",
+        "count": "1"
+      }
+    ],
+    "fb3100": [
+      {
+        "cask": "fb3100",
+        "count": "5"
+      }
+    ],
+    "fb3200": [
+      {
+        "cask": "fb3200",
+        "count": "5"
+      }
+    ],
+    "fb3300": [
+      {
+        "cask": "fb3300",
+        "count": "7"
+      }
+    ],
+    "fbreader": [
+      {
+        "cask": "fbreader",
+        "count": "419"
+      }
+    ],
+    "fbvc": [
+      {
+        "cask": "fbvc",
+        "count": "4"
+      }
+    ],
+    "fdr": [
+      {
+        "cask": "fdr",
+        "count": "8"
+      }
+    ],
+    "fedora-media-writer": [
+      {
+        "cask": "fedora-media-writer",
+        "count": "223"
+      }
+    ],
+    "feed-the-beast": [
+      {
+        "cask": "feed-the-beast",
+        "count": "59"
+      }
+    ],
+    "feeder": [
+      {
+        "cask": "feeder",
+        "count": "16"
+      }
+    ],
+    "feeds": [
+      {
+        "cask": "feeds",
+        "count": "17"
+      }
+    ],
+    "feem": [
+      {
+        "cask": "feem",
+        "count": "58"
+      }
+    ],
+    "feishu": [
+      {
+        "cask": "feishu",
+        "count": "510"
+      }
+    ],
+    "fender-fuse": [
+      {
+        "cask": "fender-fuse",
+        "count": "6"
+      }
+    ],
+    "fenix": [
+      {
+        "cask": "fenix",
+        "count": "39"
+      }
+    ],
+    "ferdi": [
+      {
+        "cask": "ferdi",
+        "count": "848"
+      }
+    ],
+    "ferdi-beta": [
+      {
+        "cask": "ferdi-beta",
+        "count": "22"
+      }
+    ],
+    "fetch": [
+      {
+        "cask": "fetch",
+        "count": "593"
+      }
+    ],
+    "ff-works": [
+      {
+        "cask": "ff-works",
+        "count": "160"
+      }
+    ],
+    "fiddler": [
+      {
+        "cask": "fiddler",
+        "count": "4"
+      }
+    ],
+    "figma": [
+      {
+        "cask": "figma",
+        "count": "5,806"
+      }
+    ],
+    "figmadaemon": [
+      {
+        "cask": "figmadaemon",
+        "count": "65"
+      }
+    ],
+    "figtree": [
+      {
+        "cask": "figtree",
+        "count": "180"
+      }
+    ],
+    "fiji": [
+      {
+        "cask": "fiji",
+        "count": "377"
+      }
+    ],
+    "file-juicer": [
+      {
+        "cask": "file-juicer",
+        "count": "70"
+      }
+    ],
+    "filebot": [
+      {
+        "cask": "filebot",
+        "count": "1,854"
+      }
+    ],
+    "filebot-beta": [
+      {
+        "cask": "filebot-beta",
+        "count": "8"
+      }
+    ],
+    "filedrop": [
+      {
+        "cask": "filedrop",
+        "count": "53"
+      }
+    ],
+    "filemaker-pro-advanced": [
+      {
+        "cask": "filemaker-pro-advanced",
+        "count": "109"
+      }
+    ],
+    "filemon": [
+      {
+        "cask": "filemon",
+        "count": "76"
+      }
+    ],
+    "filepane": [
+      {
+        "cask": "filepane",
+        "count": "30"
+      }
+    ],
+    "filezilla": [
+      {
+        "cask": "filezilla",
+        "count": "25"
+      }
+    ],
+    "filmora": [
+      {
+        "cask": "filmora",
+        "count": "2"
+      }
+    ],
+    "filmora9": [
+      {
+        "cask": "filmora9",
+        "count": "1"
+      }
+    ],
+    "final-cut-library-manager": [
+      {
+        "cask": "final-cut-library-manager",
+        "count": "22"
+      }
+    ],
+    "find-any-file": [
+      {
+        "cask": "find-any-file",
+        "count": "239"
+      }
+    ],
+    "find-empty-folders": [
+      {
+        "cask": "find-empty-folders",
+        "count": "41"
+      }
+    ],
+    "findbugs-intellij": [
+      {
+        "cask": "findbugs-intellij",
+        "count": "1"
+      }
+    ],
+    "findergo": [
+      {
+        "cask": "findergo",
+        "count": "209"
+      }
+    ],
+    "finderminder": [
+      {
+        "cask": "finderminder",
+        "count": "2"
+      }
+    ],
+    "findings": [
+      {
+        "cask": "findings",
+        "count": "24"
+      }
+    ],
+    "finereader": [
+      {
+        "cask": "finereader",
+        "count": "143"
+      }
+    ],
+    "finetune": [
+      {
+        "cask": "finetune",
+        "count": "2"
+      }
+    ],
+    "fing": [
+      {
+        "cask": "fing",
+        "count": "1,588"
+      }
+    ],
+    "finicky": [
+      {
+        "cask": "finicky",
+        "count": "609"
+      }
+    ],
+    "fips": [
+      {
+        "cask": "fips",
+        "count": "3"
+      }
+    ],
+    "fira-code-regular-symbol": [
+      {
+        "cask": "fira-code-regular-symbol",
+        "count": "1"
+      }
+    ],
+    "firealpaca": [
+      {
+        "cask": "firealpaca",
+        "count": "402"
+      }
+    ],
+    "firebase-admin": [
+      {
+        "cask": "firebase-admin",
+        "count": "145"
+      }
+    ],
+    "firebird-emu": [
+      {
+        "cask": "firebird-emu",
+        "count": "36"
+      }
+    ],
+    "firecamp": [
+      {
+        "cask": "firecamp",
+        "count": "711"
+      }
+    ],
+    "firefox": [
+      {
+        "cask": "firefox",
+        "count": "157,107"
+      }
+    ],
+    "firefox-34": [
+      {
+        "cask": "firefox-34",
+        "count": "1"
+      }
+    ],
+    "firefox-35": [
+      {
+        "cask": "firefox-35",
+        "count": "1"
+      }
+    ],
+    "firefox-36": [
+      {
+        "cask": "firefox-36",
+        "count": "1"
+      }
+    ],
+    "firefox-37": [
+      {
+        "cask": "firefox-37",
+        "count": "3"
+      }
+    ],
+    "firefox-38": [
+      {
+        "cask": "firefox-38",
+        "count": "1"
+      }
+    ],
+    "firefox-40": [
+      {
+        "cask": "firefox-40",
+        "count": "8"
+      }
+    ],
+    "firefox-42": [
+      {
+        "cask": "firefox-42",
+        "count": "1"
+      }
+    ],
+    "firefox-45": [
+      {
+        "cask": "firefox-45",
+        "count": "220"
+      }
+    ],
+    "firefox-46": [
+      {
+        "cask": "firefox-46",
+        "count": "5"
+      }
+    ],
+    "firefox-48": [
+      {
+        "cask": "firefox-48",
+        "count": "2"
+      }
+    ],
+    "firefox-49": [
+      {
+        "cask": "firefox-49",
+        "count": "1"
+      }
+    ],
+    "firefox-50": [
+      {
+        "cask": "firefox-50",
+        "count": "1"
+      }
+    ],
+    "firefox-52-9-0esr": [
+      {
+        "cask": "firefox-52-9-0esr",
+        "count": "1"
+      }
+    ],
+    "firefox-beta": [
+      {
+        "cask": "firefox-beta",
+        "count": "894"
+      }
+    ],
+    "firefox-custom": [
+      {
+        "cask": "firefox-custom",
+        "count": "3"
+      }
+    ],
+    "firefox-developer-edition": [
+      {
+        "cask": "firefox-developer-edition",
+        "count": "7,785"
+      }
+    ],
+    "firefox-esr": [
+      {
+        "cask": "firefox-esr",
+        "count": "878"
+      }
+    ],
+    "firefox-esr-459": [
+      {
+        "cask": "firefox-esr-459",
+        "count": "667"
+      }
+    ],
+    "firefox-esr-52-2-1": [
+      {
+        "cask": "firefox-esr-52-2-1",
+        "count": "1"
+      }
+    ],
+    "firefox-esr52": [
+      {
+        "cask": "firefox-esr52",
+        "count": "11"
+      }
+    ],
+    "firefox-nightly": [
+      {
+        "cask": "firefox-nightly",
+        "count": "2,365"
+      }
+    ],
+    "firefoxdeveloperedition": [
+      {
+        "cask": "firefoxdeveloperedition",
+        "count": "2"
+      }
+    ],
+    "firefoxold": [
+      {
+        "cask": "firefoxold",
+        "count": "1"
+      }
+    ],
+    "firestorm": [
+      {
+        "cask": "firestorm",
+        "count": "98"
+      }
+    ],
+    "firestorm-opensim": [
+      {
+        "cask": "firestorm-opensim",
+        "count": "2"
+      }
+    ],
+    "firestormos": [
+      {
+        "cask": "firestormos",
+        "count": "18"
+      }
+    ],
+    "fiscript": [
+      {
+        "cask": "fiscript",
+        "count": "322"
+      }
+    ],
+    "fission": [
+      {
+        "cask": "fission",
+        "count": "291"
+      }
+    ],
+    "fitbit-connect": [
+      {
+        "cask": "fitbit-connect",
+        "count": "58"
+      }
+    ],
+    "fitbit-os-simulator": [
+      {
+        "cask": "fitbit-os-simulator",
+        "count": "20"
+      }
+    ],
+    "fl-studio": [
+      {
+        "cask": "fl-studio",
+        "count": "269"
+      }
+    ],
+    "flame": [
+      {
+        "cask": "flame",
+        "count": "41"
+      }
+    ],
+    "flanders-ip-utility": [
+      {
+        "cask": "flanders-ip-utility",
+        "count": "3"
+      }
+    ],
+    "flash-decompiler-trillix": [
+      {
+        "cask": "flash-decompiler-trillix",
+        "count": "20"
+      }
+    ],
+    "flash-npapi": [
+      {
+        "cask": "flash-npapi",
+        "count": "18,718"
+      }
+    ],
+    "flash-player": [
+      {
+        "cask": "flash-player",
+        "count": "64,439"
+      }
+    ],
+    "flash-player-debugger": [
+      {
+        "cask": "flash-player-debugger",
+        "count": "62"
+      }
+    ],
+    "flash-player-debugger-npapi": [
+      {
+        "cask": "flash-player-debugger-npapi",
+        "count": "36"
+      }
+    ],
+    "flash-player-debugger-ppapi": [
+      {
+        "cask": "flash-player-debugger-ppapi",
+        "count": "35"
+      }
+    ],
+    "flash-ppapi": [
+      {
+        "cask": "flash-ppapi",
+        "count": "15,788"
+      }
+    ],
+    "flashforge-flashprint": [
+      {
+        "cask": "flashforge-flashprint",
+        "count": "4"
+      }
+    ],
+    "flashlight": [
+      {
+        "cask": "flashlight",
+        "count": "1"
+      }
+    ],
+    "flashlighttool": [
+      {
+        "cask": "flashlighttool",
+        "count": "118"
+      }
+    ],
+    "flashprint": [
+      {
+        "cask": "flashprint",
+        "count": "1"
+      }
+    ],
+    "fldigi": [
+      {
+        "cask": "fldigi",
+        "count": "138"
+      }
+    ],
+    "flexiglass": [
+      {
+        "cask": "flexiglass",
+        "count": "58"
+      }
+    ],
+    "flic": [
+      {
+        "cask": "flic",
+        "count": "16"
+      }
+    ],
+    "flickr-uploadr": [
+      {
+        "cask": "flickr-uploadr",
+        "count": "29"
+      }
+    ],
+    "flightgear": [
+      {
+        "cask": "flightgear",
+        "count": "116"
+      }
+    ],
+    "flinto": [
+      {
+        "cask": "flinto",
+        "count": "80"
+      }
+    ],
+    "flip4mac": [
+      {
+        "cask": "flip4mac",
+        "count": "122"
+      }
+    ],
+    "flipper": [
+      {
+        "cask": "flipper",
+        "count": "757"
+      }
+    ],
+    "fliqlo": [
+      {
+        "cask": "fliqlo",
+        "count": "1,926"
+      }
+    ],
+    "flirc": [
+      {
+        "cask": "flirc",
+        "count": "66"
+      }
+    ],
+    "flixtools": [
+      {
+        "cask": "flixtools",
+        "count": "173"
+      }
+    ],
+    "floaty": [
+      {
+        "cask": "floaty",
+        "count": "3"
+      }
+    ],
+    "flock": [
+      {
+        "cask": "flock",
+        "count": "380"
+      }
+    ],
+    "flock-agent": [
+      {
+        "cask": "flock-agent",
+        "count": "48"
+      }
+    ],
+    "flotato": [
+      {
+        "cask": "flotato",
+        "count": "982"
+      }
+    ],
+    "flow": [
+      {
+        "cask": "flow",
+        "count": "56"
+      }
+    ],
+    "flowdock": [
+      {
+        "cask": "flowdock",
+        "count": "243"
+      }
+    ],
+    "flowsync": [
+      {
+        "cask": "flowsync",
+        "count": "68"
+      }
+    ],
+    "fluid": [
+      {
+        "cask": "fluid",
+        "count": "895"
+      }
+    ],
+    "flume": [
+      {
+        "cask": "flume",
+        "count": "789"
+      }
+    ],
+    "fluor": [
+      {
+        "cask": "fluor",
+        "count": "1,171"
+      }
+    ],
+    "flutter": [
+      {
+        "cask": "flutter",
+        "count": "1,138"
+      }
+    ],
+    "flux": [
+      {
+        "cask": "flux",
+        "count": "12,180"
+      }
+    ],
+    "fluxcenter": [
+      {
+        "cask": "fluxcenter",
+        "count": "7"
+      }
+    ],
+    "flvcd-bigrats": [
+      {
+        "cask": "flvcd-bigrats",
+        "count": "17"
+      }
+    ],
+    "fly": [
+      {
+        "cask": "fly",
+        "count": "2,474"
+      }
+    ],
+    "flycut": [
+      {
+        "cask": "flycut",
+        "count": "5,861"
+      }
+    ],
+    "flymaster-designer": [
+      {
+        "cask": "flymaster-designer",
+        "count": "3"
+      }
+    ],
+    "flywheel-developer": [
+      {
+        "cask": "flywheel-developer",
+        "count": "1"
+      }
+    ],
+    "fm3-edit": [
+      {
+        "cask": "fm3-edit",
+        "count": "1"
+      }
+    ],
+    "fman": [
+      {
+        "cask": "fman",
+        "count": "434"
+      }
+    ],
+    "fme-desktop": [
+      {
+        "cask": "fme-desktop",
+        "count": "2"
+      }
+    ],
+    "focus": [
+      {
+        "cask": "focus",
+        "count": "419"
+      }
+    ],
+    "focus-booster": [
+      {
+        "cask": "focus-booster",
+        "count": "63"
+      }
+    ],
+    "focusatwill": [
+      {
+        "cask": "focusatwill",
+        "count": "49"
+      }
+    ],
+    "focused": [
+      {
+        "cask": "focused",
+        "count": "58"
+      }
+    ],
+    "focusrite-clarett-thunderbolt": [
+      {
+        "cask": "focusrite-clarett-thunderbolt",
+        "count": "7"
+      }
+    ],
+    "focusrite-control": [
+      {
+        "cask": "focusrite-control",
+        "count": "97"
+      }
+    ],
+    "focusrite-red-plugin-suite": [
+      {
+        "cask": "focusrite-red-plugin-suite",
+        "count": "1"
+      }
+    ],
+    "focusrite-saffire-mixcontrol": [
+      {
+        "cask": "focusrite-saffire-mixcontrol",
+        "count": "14"
+      }
+    ],
+    "focuswriter": [
+      {
+        "cask": "focuswriter",
+        "count": "199"
+      }
+    ],
+    "fog": [
+      {
+        "cask": "fog",
+        "count": "83"
+      }
+    ],
+    "fogpad": [
+      {
+        "cask": "fogpad",
+        "count": "3"
+      }
+    ],
+    "folding-at-home": [
+      {
+        "cask": "folding-at-home",
+        "count": "1,249"
+      }
+    ],
+    "foldingtext": [
+      {
+        "cask": "foldingtext",
+        "count": "48"
+      }
+    ],
+    "foldit": [
+      {
+        "cask": "foldit",
+        "count": "50"
+      }
+    ],
+    "folx": [
+      {
+        "cask": "folx",
+        "count": "3,509"
+      }
+    ],
+    "font-3270": [
+      {
+        "cask": "font-3270",
+        "count": "203"
+      }
+    ],
+    "font-3270-nerd-font": [
+      {
+        "cask": "font-3270-nerd-font",
+        "count": "586"
+      }
+    ],
+    "font-3270-nerd-font-mono": [
+      {
+        "cask": "font-3270-nerd-font-mono",
+        "count": "370"
+      }
+    ],
+    "font-abeezee": [
+      {
+        "cask": "font-abeezee",
+        "count": "105"
+      }
+    ],
+    "font-abel": [
+      {
+        "cask": "font-abel",
+        "count": "81"
+      }
+    ],
+    "font-aboriginal-sans": [
+      {
+        "cask": "font-aboriginal-sans",
+        "count": "75"
+      }
+    ],
+    "font-aboriginal-serif": [
+      {
+        "cask": "font-aboriginal-serif",
+        "count": "72"
+      }
+    ],
+    "font-abril-fatface": [
+      {
+        "cask": "font-abril-fatface",
+        "count": "89"
+      }
+    ],
+    "font-academicons": [
+      {
+        "cask": "font-academicons",
+        "count": "79"
+      }
+    ],
+    "font-accordance": [
+      {
+        "cask": "font-accordance",
+        "count": "41"
+      }
+    ],
+    "font-aclonica": [
+      {
+        "cask": "font-aclonica",
+        "count": "79"
+      }
+    ],
+    "font-acme": [
+      {
+        "cask": "font-acme",
+        "count": "102"
+      }
+    ],
+    "font-actor": [
+      {
+        "cask": "font-actor",
+        "count": "66"
+      }
+    ],
+    "font-adamina": [
+      {
+        "cask": "font-adamina",
+        "count": "86"
+      }
+    ],
+    "font-adinatha-tamil-brahmi": [
+      {
+        "cask": "font-adinatha-tamil-brahmi",
+        "count": "56"
+      }
+    ],
+    "font-advent-pro": [
+      {
+        "cask": "font-advent-pro",
+        "count": "91"
+      }
+    ],
+    "font-aegean": [
+      {
+        "cask": "font-aegean",
+        "count": "5"
+      }
+    ],
+    "font-african-sans": [
+      {
+        "cask": "font-african-sans",
+        "count": "59"
+      }
+    ],
+    "font-african-serif": [
+      {
+        "cask": "font-african-serif",
+        "count": "59"
+      }
+    ],
+    "font-agave-nerd-font": [
+      {
+        "cask": "font-agave-nerd-font",
+        "count": "39"
+      }
+    ],
+    "font-aguafina-script": [
+      {
+        "cask": "font-aguafina-script",
+        "count": "58"
+      }
+    ],
+    "font-ahuramzda": [
+      {
+        "cask": "font-ahuramzda",
+        "count": "52"
+      }
+    ],
+    "font-aileron": [
+      {
+        "cask": "font-aileron",
+        "count": "84"
+      }
+    ],
+    "font-akronim": [
+      {
+        "cask": "font-akronim",
+        "count": "81"
+      }
+    ],
+    "font-aladin": [
+      {
+        "cask": "font-aladin",
+        "count": "54"
+      }
+    ],
+    "font-aldrich": [
+      {
+        "cask": "font-aldrich",
+        "count": "80"
+      }
+    ],
+    "font-alef": [
+      {
+        "cask": "font-alef",
+        "count": "63"
+      }
+    ],
+    "font-alegreya": [
+      {
+        "cask": "font-alegreya",
+        "count": "153"
+      }
+    ],
+    "font-alegreya-sans": [
+      {
+        "cask": "font-alegreya-sans",
+        "count": "134"
+      }
+    ],
+    "font-alex-brush": [
+      {
+        "cask": "font-alex-brush",
+        "count": "57"
+      }
+    ],
+    "font-alfa-slab-one": [
+      {
+        "cask": "font-alfa-slab-one",
+        "count": "85"
+      }
+    ],
+    "font-alice": [
+      {
+        "cask": "font-alice",
+        "count": "95"
+      }
+    ],
+    "font-alike": [
+      {
+        "cask": "font-alike",
+        "count": "77"
+      }
+    ],
+    "font-alike-angular": [
+      {
+        "cask": "font-alike-angular",
+        "count": "77"
+      }
+    ],
+    "font-allan": [
+      {
+        "cask": "font-allan",
+        "count": "65"
+      }
+    ],
+    "font-allerta": [
+      {
+        "cask": "font-allerta",
+        "count": "54"
+      }
+    ],
+    "font-allerta-stencil": [
+      {
+        "cask": "font-allerta-stencil",
+        "count": "56"
+      }
+    ],
+    "font-allura": [
+      {
+        "cask": "font-allura",
+        "count": "57"
+      }
+    ],
+    "font-almendra": [
+      {
+        "cask": "font-almendra",
+        "count": "116"
+      }
+    ],
+    "font-almendra-display": [
+      {
+        "cask": "font-almendra-display",
+        "count": "75"
+      }
+    ],
+    "font-almendra-sc": [
+      {
+        "cask": "font-almendra-sc",
+        "count": "86"
+      }
+    ],
+    "font-amarante": [
+      {
+        "cask": "font-amarante",
+        "count": "75"
+      }
+    ],
+    "font-amaranth": [
+      {
+        "cask": "font-amaranth",
+        "count": "69"
+      }
+    ],
+    "font-amatic-sc": [
+      {
+        "cask": "font-amatic-sc",
+        "count": "105"
+      }
+    ],
+    "font-amethysta": [
+      {
+        "cask": "font-amethysta",
+        "count": "76"
+      }
+    ],
+    "font-amiri": [
+      {
+        "cask": "font-amiri",
+        "count": "81"
+      }
+    ],
+    "font-anaheim": [
+      {
+        "cask": "font-anaheim",
+        "count": "54"
+      }
+    ],
+    "font-andada": [
+      {
+        "cask": "font-andada",
+        "count": "97"
+      }
+    ],
+    "font-andada-sc": [
+      {
+        "cask": "font-andada-sc",
+        "count": "95"
+      }
+    ],
+    "font-andagii": [
+      {
+        "cask": "font-andagii",
+        "count": "50"
+      }
+    ],
+    "font-andale-mono": [
+      {
+        "cask": "font-andale-mono",
+        "count": "115"
+      }
+    ],
+    "font-andika": [
+      {
+        "cask": "font-andika",
+        "count": "59"
+      }
+    ],
+    "font-andron-scriptor-web": [
+      {
+        "cask": "font-andron-scriptor-web",
+        "count": "43"
+      }
+    ],
+    "font-angkor": [
+      {
+        "cask": "font-angkor",
+        "count": "48"
+      }
+    ],
+    "font-anka-coder": [
+      {
+        "cask": "font-anka-coder",
+        "count": "110"
+      }
+    ],
+    "font-anka-coder-condensed": [
+      {
+        "cask": "font-anka-coder-condensed",
+        "count": "2"
+      }
+    ],
+    "font-annie-use-your-telescope": [
+      {
+        "cask": "font-annie-use-your-telescope",
+        "count": "77"
+      }
+    ],
+    "font-anonymice-nerd-font": [
+      {
+        "cask": "font-anonymice-nerd-font",
+        "count": "37"
+      }
+    ],
+    "font-anonymice-powerline": [
+      {
+        "cask": "font-anonymice-powerline",
+        "count": "709"
+      }
+    ],
+    "font-anonymous-pro": [
+      {
+        "cask": "font-anonymous-pro",
+        "count": "769"
+      }
+    ],
+    "font-anonymouspro-nerd-font": [
+      {
+        "cask": "font-anonymouspro-nerd-font",
+        "count": "485"
+      }
+    ],
+    "font-anonymouspro-nerd-font-mono": [
+      {
+        "cask": "font-anonymouspro-nerd-font-mono",
+        "count": "461"
+      }
+    ],
+    "font-antic": [
+      {
+        "cask": "font-antic",
+        "count": "54"
+      }
+    ],
+    "font-antic-didone": [
+      {
+        "cask": "font-antic-didone",
+        "count": "55"
+      }
+    ],
+    "font-antic-slab": [
+      {
+        "cask": "font-antic-slab",
+        "count": "56"
+      }
+    ],
+    "font-antinoou": [
+      {
+        "cask": "font-antinoou",
+        "count": "28"
+      }
+    ],
+    "font-anton": [
+      {
+        "cask": "font-anton",
+        "count": "64"
+      }
+    ],
+    "font-arapey": [
+      {
+        "cask": "font-arapey",
+        "count": "66"
+      }
+    ],
+    "font-arbutus": [
+      {
+        "cask": "font-arbutus",
+        "count": "75"
+      }
+    ],
+    "font-arbutus-slab": [
+      {
+        "cask": "font-arbutus-slab",
+        "count": "75"
+      }
+    ],
+    "font-architects-daughter": [
+      {
+        "cask": "font-architects-daughter",
+        "count": "90"
+      }
+    ],
+    "font-architype-renner": [
+      {
+        "cask": "font-architype-renner",
+        "count": "41"
+      }
+    ],
+    "font-archivo-black": [
+      {
+        "cask": "font-archivo-black",
+        "count": "93"
+      }
+    ],
+    "font-archivo-narrow": [
+      {
+        "cask": "font-archivo-narrow",
+        "count": "101"
+      }
+    ],
+    "font-arial": [
+      {
+        "cask": "font-arial",
+        "count": "121"
+      }
+    ],
+    "font-arial-black": [
+      {
+        "cask": "font-arial-black",
+        "count": "70"
+      }
+    ],
+    "font-arimo": [
+      {
+        "cask": "font-arimo",
+        "count": "109"
+      }
+    ],
+    "font-arimo-nerd-font": [
+      {
+        "cask": "font-arimo-nerd-font",
+        "count": "301"
+      }
+    ],
+    "font-arimo-nerd-font-mono": [
+      {
+        "cask": "font-arimo-nerd-font-mono",
+        "count": "261"
+      }
+    ],
+    "font-arizonia": [
+      {
+        "cask": "font-arizonia",
+        "count": "85"
+      }
+    ],
+    "font-armata": [
+      {
+        "cask": "font-armata",
+        "count": "54"
+      }
+    ],
+    "font-artifika": [
+      {
+        "cask": "font-artifika",
+        "count": "74"
+      }
+    ],
+    "font-arvo": [
+      {
+        "cask": "font-arvo",
+        "count": "111"
+      }
+    ],
+    "font-asap": [
+      {
+        "cask": "font-asap",
+        "count": "59"
+      }
+    ],
+    "font-asset": [
+      {
+        "cask": "font-asset",
+        "count": "70"
+      }
+    ],
+    "font-astloch": [
+      {
+        "cask": "font-astloch",
+        "count": "59"
+      }
+    ],
+    "font-asul": [
+      {
+        "cask": "font-asul",
+        "count": "82"
+      }
+    ],
+    "font-atma": [
+      {
+        "cask": "font-atma",
+        "count": "3"
+      }
+    ],
+    "font-atomic-age": [
+      {
+        "cask": "font-atomic-age",
+        "count": "81"
+      }
+    ],
+    "font-aubrey": [
+      {
+        "cask": "font-aubrey",
+        "count": "69"
+      }
+    ],
+    "font-audiowide": [
+      {
+        "cask": "font-audiowide",
+        "count": "74"
+      }
+    ],
+    "font-aurulentsansmono-nerd-font": [
+      {
+        "cask": "font-aurulentsansmono-nerd-font",
+        "count": "296"
+      }
+    ],
+    "font-aurulentsansmono-nerd-font-mono": [
+      {
+        "cask": "font-aurulentsansmono-nerd-font-mono",
+        "count": "240"
+      }
+    ],
+    "font-autour-one": [
+      {
+        "cask": "font-autour-one",
+        "count": "46"
+      }
+    ],
+    "font-average": [
+      {
+        "cask": "font-average",
+        "count": "82"
+      }
+    ],
+    "font-average-mono": [
+      {
+        "cask": "font-average-mono",
+        "count": "94"
+      }
+    ],
+    "font-average-sans": [
+      {
+        "cask": "font-average-sans",
+        "count": "73"
+      }
+    ],
+    "font-averia-gruesa-libre": [
+      {
+        "cask": "font-averia-gruesa-libre",
+        "count": "79"
+      }
+    ],
+    "font-averia-libre": [
+      {
+        "cask": "font-averia-libre",
+        "count": "98"
+      }
+    ],
+    "font-averia-sans-libre": [
+      {
+        "cask": "font-averia-sans-libre",
+        "count": "78"
+      }
+    ],
+    "font-averia-serif-libre": [
+      {
+        "cask": "font-averia-serif-libre",
+        "count": "81"
+      }
+    ],
+    "font-awesome-5-pro": [
+      {
+        "cask": "font-awesome-5-pro",
+        "count": "13"
+      }
+    ],
+    "font-awesome-terminal-fonts": [
+      {
+        "cask": "font-awesome-terminal-fonts",
+        "count": "1,926"
+      }
+    ],
+    "font-azukifont": [
+      {
+        "cask": "font-azukifont",
+        "count": "2"
+      }
+    ],
+    "font-azukifont-b": [
+      {
+        "cask": "font-azukifont-b",
+        "count": "2"
+      }
+    ],
+    "font-azukifont-l": [
+      {
+        "cask": "font-azukifont-l",
+        "count": "3"
+      }
+    ],
+    "font-azukifont-lb": [
+      {
+        "cask": "font-azukifont-lb",
+        "count": "2"
+      }
+    ],
+    "font-azukifont-lp": [
+      {
+        "cask": "font-azukifont-lp",
+        "count": "2"
+      }
+    ],
+    "font-azukifont-p": [
+      {
+        "cask": "font-azukifont-p",
+        "count": "2"
+      }
+    ],
+    "font-b612": [
+      {
+        "cask": "font-b612",
+        "count": "86"
+      }
+    ],
+    "font-babelstone-han": [
+      {
+        "cask": "font-babelstone-han",
+        "count": "1"
+      }
+    ],
+    "font-bad-script": [
+      {
+        "cask": "font-bad-script",
+        "count": "77"
+      }
+    ],
+    "font-bahnschrift": [
+      {
+        "cask": "font-bahnschrift",
+        "count": "22"
+      }
+    ],
+    "font-baloo": [
+      {
+        "cask": "font-baloo",
+        "count": "67"
+      }
+    ],
+    "font-balsamiq-sans": [
+      {
+        "cask": "font-balsamiq-sans",
+        "count": "4"
+      }
+    ],
+    "font-balthazar": [
+      {
+        "cask": "font-balthazar",
+        "count": "72"
+      }
+    ],
+    "font-bananaslip": [
+      {
+        "cask": "font-bananaslip",
+        "count": "1"
+      }
+    ],
+    "font-bangers": [
+      {
+        "cask": "font-bangers",
+        "count": "76"
+      }
+    ],
+    "font-bariol": [
+      {
+        "cask": "font-bariol",
+        "count": "1"
+      }
+    ],
+    "font-barlow": [
+      {
+        "cask": "font-barlow",
+        "count": "110"
+      }
+    ],
+    "font-basic": [
+      {
+        "cask": "font-basic",
+        "count": "45"
+      }
+    ],
+    "font-battambang": [
+      {
+        "cask": "font-battambang",
+        "count": "57"
+      }
+    ],
+    "font-baumans": [
+      {
+        "cask": "font-baumans",
+        "count": "69"
+      }
+    ],
+    "font-bayon": [
+      {
+        "cask": "font-bayon",
+        "count": "40"
+      }
+    ],
+    "font-beattingvile": [
+      {
+        "cask": "font-beattingvile",
+        "count": "2"
+      }
+    ],
+    "font-belgrano": [
+      {
+        "cask": "font-belgrano",
+        "count": "67"
+      }
+    ],
+    "font-belleza": [
+      {
+        "cask": "font-belleza",
+        "count": "66"
+      }
+    ],
+    "font-benchnine": [
+      {
+        "cask": "font-benchnine",
+        "count": "78"
+      }
+    ],
+    "font-bentham": [
+      {
+        "cask": "font-bentham",
+        "count": "69"
+      }
+    ],
+    "font-berkshire-swash": [
+      {
+        "cask": "font-berkshire-swash",
+        "count": "105"
+      }
+    ],
+    "font-bevan": [
+      {
+        "cask": "font-bevan",
+        "count": "69"
+      }
+    ],
+    "font-bigblue-terminal-nerd-font": [
+      {
+        "cask": "font-bigblue-terminal-nerd-font",
+        "count": "18"
+      }
+    ],
+    "font-bigelow-rules": [
+      {
+        "cask": "font-bigelow-rules",
+        "count": "66"
+      }
+    ],
+    "font-bigshot-one": [
+      {
+        "cask": "font-bigshot-one",
+        "count": "66"
+      }
+    ],
+    "font-bilbo": [
+      {
+        "cask": "font-bilbo",
+        "count": "67"
+      }
+    ],
+    "font-bilbo-swash-caps": [
+      {
+        "cask": "font-bilbo-swash-caps",
+        "count": "68"
+      }
+    ],
+    "font-bitstream-vera": [
+      {
+        "cask": "font-bitstream-vera",
+        "count": "147"
+      }
+    ],
+    "font-bitstreamverasansmono-nerd-font": [
+      {
+        "cask": "font-bitstreamverasansmono-nerd-font",
+        "count": "377"
+      }
+    ],
+    "font-bitstreamverasansmono-nerd-font-mono": [
+      {
+        "cask": "font-bitstreamverasansmono-nerd-font-mono",
+        "count": "306"
+      }
+    ],
+    "font-bitter": [
+      {
+        "cask": "font-bitter",
+        "count": "105"
+      }
+    ],
+    "font-black-ops-one": [
+      {
+        "cask": "font-black-ops-one",
+        "count": "51"
+      }
+    ],
+    "font-blackout": [
+      {
+        "cask": "font-blackout",
+        "count": "45"
+      }
+    ],
+    "font-blexmono-nerd-font": [
+      {
+        "cask": "font-blexmono-nerd-font",
+        "count": "40"
+      }
+    ],
+    "font-blokk-neue": [
+      {
+        "cask": "font-blokk-neue",
+        "count": "77"
+      }
+    ],
+    "font-bodoni": [
+      {
+        "cask": "font-bodoni",
+        "count": "1"
+      }
+    ],
+    "font-bokor": [
+      {
+        "cask": "font-bokor",
+        "count": "41"
+      }
+    ],
+    "font-bonbon": [
+      {
+        "cask": "font-bonbon",
+        "count": "69"
+      }
+    ],
+    "font-boogaloo": [
+      {
+        "cask": "font-boogaloo",
+        "count": "44"
+      }
+    ],
+    "font-bowlby-one": [
+      {
+        "cask": "font-bowlby-one",
+        "count": "68"
+      }
+    ],
+    "font-bowlby-one-sc": [
+      {
+        "cask": "font-bowlby-one-sc",
+        "count": "69"
+      }
+    ],
+    "font-brawler": [
+      {
+        "cask": "font-brawler",
+        "count": "69"
+      }
+    ],
+    "font-bree-serif": [
+      {
+        "cask": "font-bree-serif",
+        "count": "80"
+      }
+    ],
+    "font-brill": [
+      {
+        "cask": "font-brill",
+        "count": "70"
+      }
+    ],
+    "font-bubblegum-sans": [
+      {
+        "cask": "font-bubblegum-sans",
+        "count": "71"
+      }
+    ],
+    "font-bubbler-one": [
+      {
+        "cask": "font-bubbler-one",
+        "count": "43"
+      }
+    ],
+    "font-buda": [
+      {
+        "cask": "font-buda",
+        "count": "68"
+      }
+    ],
+    "font-buenard": [
+      {
+        "cask": "font-buenard",
+        "count": "78"
+      }
+    ],
+    "font-bukyvede-bold": [
+      {
+        "cask": "font-bukyvede-bold",
+        "count": "41"
+      }
+    ],
+    "font-bukyvede-italic": [
+      {
+        "cask": "font-bukyvede-italic",
+        "count": "43"
+      }
+    ],
+    "font-bukyvede-regular": [
+      {
+        "cask": "font-bukyvede-regular",
+        "count": "43"
+      }
+    ],
+    "font-bungee": [
+      {
+        "cask": "font-bungee",
+        "count": "52"
+      }
+    ],
+    "font-butcherman": [
+      {
+        "cask": "font-butcherman",
+        "count": "65"
+      }
+    ],
+    "font-butterfly-kids": [
+      {
+        "cask": "font-butterfly-kids",
+        "count": "64"
+      }
+    ],
+    "font-cabin": [
+      {
+        "cask": "font-cabin",
+        "count": "113"
+      }
+    ],
+    "font-cabin-condensed": [
+      {
+        "cask": "font-cabin-condensed",
+        "count": "82"
+      }
+    ],
+    "font-cabin-sketch": [
+      {
+        "cask": "font-cabin-sketch",
+        "count": "87"
+      }
+    ],
+    "font-caesar-dressing": [
+      {
+        "cask": "font-caesar-dressing",
+        "count": "43"
+      }
+    ],
+    "font-cagliostro": [
+      {
+        "cask": "font-cagliostro",
+        "count": "66"
+      }
+    ],
+    "font-caladea": [
+      {
+        "cask": "font-caladea",
+        "count": "1"
+      }
+    ],
+    "font-calligraffitti": [
+      {
+        "cask": "font-calligraffitti",
+        "count": "69"
+      }
+    ],
+    "font-cambo": [
+      {
+        "cask": "font-cambo",
+        "count": "68"
+      }
+    ],
+    "font-camingocode": [
+      {
+        "cask": "font-camingocode",
+        "count": "161"
+      }
+    ],
+    "font-candal": [
+      {
+        "cask": "font-candal",
+        "count": "67"
+      }
+    ],
+    "font-cantarell": [
+      {
+        "cask": "font-cantarell",
+        "count": "88"
+      }
+    ],
+    "font-cantata-one": [
+      {
+        "cask": "font-cantata-one",
+        "count": "66"
+      }
+    ],
+    "font-cantora-one": [
+      {
+        "cask": "font-cantora-one",
+        "count": "66"
+      }
+    ],
+    "font-capriola": [
+      {
+        "cask": "font-capriola",
+        "count": "44"
+      }
+    ],
+    "font-cardo": [
+      {
+        "cask": "font-cardo",
+        "count": "98"
+      }
+    ],
+    "font-carlito": [
+      {
+        "cask": "font-carlito",
+        "count": "1"
+      }
+    ],
+    "font-carme": [
+      {
+        "cask": "font-carme",
+        "count": "67"
+      }
+    ],
+    "font-carrois-gothic": [
+      {
+        "cask": "font-carrois-gothic",
+        "count": "68"
+      }
+    ],
+    "font-carrois-gothic-sc": [
+      {
+        "cask": "font-carrois-gothic-sc",
+        "count": "70"
+      }
+    ],
+    "font-carter-one": [
+      {
+        "cask": "font-carter-one",
+        "count": "66"
+      }
+    ],
+    "font-cascadia": [
+      {
+        "cask": "font-cascadia",
+        "count": "2,574"
+      }
+    ],
+    "font-cascadia-code": [
+      {
+        "cask": "font-cascadia-code",
+        "count": "2"
+      }
+    ],
+    "font-cascadia-mono": [
+      {
+        "cask": "font-cascadia-mono",
+        "count": "402"
+      }
+    ],
+    "font-cascadia-mono-pl": [
+      {
+        "cask": "font-cascadia-mono-pl",
+        "count": "226"
+      }
+    ],
+    "font-cascadia-nerd-font": [
+      {
+        "cask": "font-cascadia-nerd-font",
+        "count": "91"
+      }
+    ],
+    "font-cascadia-nerd-font-mono": [
+      {
+        "cask": "font-cascadia-nerd-font-mono",
+        "count": "67"
+      }
+    ],
+    "font-cascadia-pl": [
+      {
+        "cask": "font-cascadia-pl",
+        "count": "285"
+      }
+    ],
+    "font-cascadiacode-nerd-font": [
+      {
+        "cask": "font-cascadiacode-nerd-font",
+        "count": "2"
+      }
+    ],
+    "font-cascadiacode-nerd-font-mono": [
+      {
+        "cask": "font-cascadiacode-nerd-font-mono",
+        "count": "1"
+      }
+    ],
+    "font-caskaydiacove-nerd-font": [
+      {
+        "cask": "font-caskaydiacove-nerd-font",
+        "count": "51"
+      }
+    ],
+    "font-caudex": [
+      {
+        "cask": "font-caudex",
+        "count": "68"
+      }
+    ],
+    "font-cedarville-cursive": [
+      {
+        "cask": "font-cedarville-cursive",
+        "count": "46"
+      }
+    ],
+    "font-ceviche-one": [
+      {
+        "cask": "font-ceviche-one",
+        "count": "43"
+      }
+    ],
+    "font-chalet": [
+      {
+        "cask": "font-chalet",
+        "count": "1"
+      }
+    ],
+    "font-changa-one": [
+      {
+        "cask": "font-changa-one",
+        "count": "70"
+      }
+    ],
+    "font-chango": [
+      {
+        "cask": "font-chango",
+        "count": "73"
+      }
+    ],
+    "font-chapbook": [
+      {
+        "cask": "font-chapbook",
+        "count": "72"
+      }
+    ],
+    "font-charis-sil": [
+      {
+        "cask": "font-charis-sil",
+        "count": "102"
+      }
+    ],
+    "font-charter": [
+      {
+        "cask": "font-charter",
+        "count": "138"
+      }
+    ],
+    "font-chau-philomene-one": [
+      {
+        "cask": "font-chau-philomene-one",
+        "count": "67"
+      }
+    ],
+    "font-chela-one": [
+      {
+        "cask": "font-chela-one",
+        "count": "66"
+      }
+    ],
+    "font-chelsea-market": [
+      {
+        "cask": "font-chelsea-market",
+        "count": "68"
+      }
+    ],
+    "font-chenla": [
+      {
+        "cask": "font-chenla",
+        "count": "45"
+      }
+    ],
+    "font-cherry-cream-soda": [
+      {
+        "cask": "font-cherry-cream-soda",
+        "count": "70"
+      }
+    ],
+    "font-cherry-swash": [
+      {
+        "cask": "font-cherry-swash",
+        "count": "65"
+      }
+    ],
+    "font-chewy": [
+      {
+        "cask": "font-chewy",
+        "count": "48"
+      }
+    ],
+    "font-chicle": [
+      {
+        "cask": "font-chicle",
+        "count": "45"
+      }
+    ],
+    "font-chivo": [
+      {
+        "cask": "font-chivo",
+        "count": "63"
+      }
+    ],
+    "font-church-slavonic": [
+      {
+        "cask": "font-church-slavonic",
+        "count": "23"
+      }
+    ],
+    "font-cica": [
+      {
+        "cask": "font-cica",
+        "count": "422"
+      }
+    ],
+    "font-cinzel": [
+      {
+        "cask": "font-cinzel",
+        "count": "75"
+      }
+    ],
+    "font-cinzel-decorative": [
+      {
+        "cask": "font-cinzel-decorative",
+        "count": "73"
+      }
+    ],
+    "font-clear-sans": [
+      {
+        "cask": "font-clear-sans",
+        "count": "289"
+      }
+    ],
+    "font-clicker-script": [
+      {
+        "cask": "font-clicker-script",
+        "count": "68"
+      }
+    ],
+    "font-cochineal": [
+      {
+        "cask": "font-cochineal",
+        "count": "41"
+      }
+    ],
+    "font-coda": [
+      {
+        "cask": "font-coda",
+        "count": "80"
+      }
+    ],
+    "font-coda-caption": [
+      {
+        "cask": "font-coda-caption",
+        "count": "50"
+      }
+    ],
+    "font-code2000": [
+      {
+        "cask": "font-code2000",
+        "count": "1"
+      }
+    ],
+    "font-code2001": [
+      {
+        "cask": "font-code2001",
+        "count": "1"
+      }
+    ],
+    "font-code2002": [
+      {
+        "cask": "font-code2002",
+        "count": "51"
+      }
+    ],
+    "font-codenewroman-nerd-font": [
+      {
+        "cask": "font-codenewroman-nerd-font",
+        "count": "385"
+      }
+    ],
+    "font-codenewroman-nerd-font-mono": [
+      {
+        "cask": "font-codenewroman-nerd-font-mono",
+        "count": "305"
+      }
+    ],
+    "font-codystar": [
+      {
+        "cask": "font-codystar",
+        "count": "68"
+      }
+    ],
+    "font-collection-cadson-demak": [
+      {
+        "cask": "font-collection-cadson-demak",
+        "count": "2"
+      }
+    ],
+    "font-collection-f0nt": [
+      {
+        "cask": "font-collection-f0nt",
+        "count": "1"
+      }
+    ],
+    "font-collection-js-technology": [
+      {
+        "cask": "font-collection-js-technology",
+        "count": "3"
+      }
+    ],
+    "font-collection-nectec-tlwg": [
+      {
+        "cask": "font-collection-nectec-tlwg",
+        "count": "1"
+      }
+    ],
+    "font-collection-sipa": [
+      {
+        "cask": "font-collection-sipa",
+        "count": "2"
+      }
+    ],
+    "font-collection-tepc": [
+      {
+        "cask": "font-collection-tepc",
+        "count": "2"
+      }
+    ],
+    "font-combo": [
+      {
+        "cask": "font-combo",
+        "count": "45"
+      }
+    ],
+    "font-comfortaa": [
+      {
+        "cask": "font-comfortaa",
+        "count": "100"
+      }
+    ],
+    "font-comic-neue": [
+      {
+        "cask": "font-comic-neue",
+        "count": "142"
+      }
+    ],
+    "font-comic-sans-ms": [
+      {
+        "cask": "font-comic-sans-ms",
+        "count": "78"
+      }
+    ],
+    "font-coming-soon": [
+      {
+        "cask": "font-coming-soon",
+        "count": "75"
+      }
+    ],
+    "font-computer-modern": [
+      {
+        "cask": "font-computer-modern",
+        "count": "540"
+      }
+    ],
+    "font-conakry": [
+      {
+        "cask": "font-conakry",
+        "count": "44"
+      }
+    ],
+    "font-concert-one": [
+      {
+        "cask": "font-concert-one",
+        "count": "45"
+      }
+    ],
+    "font-condiment": [
+      {
+        "cask": "font-condiment",
+        "count": "42"
+      }
+    ],
+    "font-consolas-for-powerline": [
+      {
+        "cask": "font-consolas-for-powerline",
+        "count": "1,471"
+      }
+    ],
+    "font-constructium": [
+      {
+        "cask": "font-constructium",
+        "count": "66"
+      }
+    ],
+    "font-content": [
+      {
+        "cask": "font-content",
+        "count": "42"
+      }
+    ],
+    "font-contrail-one": [
+      {
+        "cask": "font-contrail-one",
+        "count": "65"
+      }
+    ],
+    "font-convergence": [
+      {
+        "cask": "font-convergence",
+        "count": "44"
+      }
+    ],
+    "font-cookie": [
+      {
+        "cask": "font-cookie",
+        "count": "70"
+      }
+    ],
+    "font-cooper-hewitt": [
+      {
+        "cask": "font-cooper-hewitt",
+        "count": "95"
+      }
+    ],
+    "font-copse": [
+      {
+        "cask": "font-copse",
+        "count": "44"
+      }
+    ],
+    "font-corben": [
+      {
+        "cask": "font-corben",
+        "count": "44"
+      }
+    ],
+    "font-cormorant": [
+      {
+        "cask": "font-cormorant",
+        "count": "82"
+      }
+    ],
+    "font-courgette": [
+      {
+        "cask": "font-courgette",
+        "count": "49"
+      }
+    ],
+    "font-courier-new": [
+      {
+        "cask": "font-courier-new",
+        "count": "66"
+      }
+    ],
+    "font-courier-prime": [
+      {
+        "cask": "font-courier-prime",
+        "count": "178"
+      }
+    ],
+    "font-courier-prime-code": [
+      {
+        "cask": "font-courier-prime-code",
+        "count": "179"
+      }
+    ],
+    "font-courier-prime-medium-and-semi-bold": [
+      {
+        "cask": "font-courier-prime-medium-and-semi-bold",
+        "count": "97"
+      }
+    ],
+    "font-courier-prime-sans": [
+      {
+        "cask": "font-courier-prime-sans",
+        "count": "121"
+      }
+    ],
+    "font-cousine": [
+      {
+        "cask": "font-cousine",
+        "count": "150"
+      }
+    ],
+    "font-cousine-nerd-font": [
+      {
+        "cask": "font-cousine-nerd-font",
+        "count": "368"
+      }
+    ],
+    "font-cousine-nerd-font-mono": [
+      {
+        "cask": "font-cousine-nerd-font-mono",
+        "count": "286"
+      }
+    ],
+    "font-coustard": [
+      {
+        "cask": "font-coustard",
+        "count": "46"
+      }
+    ],
+    "font-covered-by-your-grace": [
+      {
+        "cask": "font-covered-by-your-grace",
+        "count": "69"
+      }
+    ],
+    "font-cozette": [
+      {
+        "cask": "font-cozette",
+        "count": "26"
+      }
+    ],
+    "font-crafty-girls": [
+      {
+        "cask": "font-crafty-girls",
+        "count": "46"
+      }
+    ],
+    "font-creepster": [
+      {
+        "cask": "font-creepster",
+        "count": "45"
+      }
+    ],
+    "font-crete-round": [
+      {
+        "cask": "font-crete-round",
+        "count": "43"
+      }
+    ],
+    "font-crimson-pro": [
+      {
+        "cask": "font-crimson-pro",
+        "count": "6"
+      }
+    ],
+    "font-crimson-text": [
+      {
+        "cask": "font-crimson-text",
+        "count": "115"
+      }
+    ],
+    "font-croissant-one": [
+      {
+        "cask": "font-croissant-one",
+        "count": "66"
+      }
+    ],
+    "font-crushed": [
+      {
+        "cask": "font-crushed",
+        "count": "67"
+      }
+    ],
+    "font-cuprum": [
+      {
+        "cask": "font-cuprum",
+        "count": "69"
+      }
+    ],
+    "font-cutive": [
+      {
+        "cask": "font-cutive",
+        "count": "67"
+      }
+    ],
+    "font-cutive-mono": [
+      {
+        "cask": "font-cutive-mono",
+        "count": "110"
+      }
+    ],
+    "font-d2coding": [
+      {
+        "cask": "font-d2coding",
+        "count": "639"
+      }
+    ],
+    "font-daddytimemono-nerd-font": [
+      {
+        "cask": "font-daddytimemono-nerd-font",
+        "count": "29"
+      }
+    ],
+    "font-damion": [
+      {
+        "cask": "font-damion",
+        "count": "42"
+      }
+    ],
+    "font-dancing-script": [
+      {
+        "cask": "font-dancing-script",
+        "count": "74"
+      }
+    ],
+    "font-dangrek": [
+      {
+        "cask": "font-dangrek",
+        "count": "1"
+      }
+    ],
+    "font-dashicons": [
+      {
+        "cask": "font-dashicons",
+        "count": "101"
+      }
+    ],
+    "font-david-clm": [
+      {
+        "cask": "font-david-clm",
+        "count": "13"
+      }
+    ],
+    "font-davidodio-archivo": [
+      {
+        "cask": "font-davidodio-archivo",
+        "count": "1"
+      }
+    ],
+    "font-dawning-of-a-new-day": [
+      {
+        "cask": "font-dawning-of-a-new-day",
+        "count": "66"
+      }
+    ],
+    "font-days-one": [
+      {
+        "cask": "font-days-one",
+        "count": "65"
+      }
+    ],
+    "font-dejavu": [
+      {
+        "cask": "font-dejavu",
+        "count": "67"
+      }
+    ],
+    "font-dejavu-sans": [
+      {
+        "cask": "font-dejavu-sans",
+        "count": "1,020"
+      }
+    ],
+    "font-dejavu-sans-mono-for-powerline": [
+      {
+        "cask": "font-dejavu-sans-mono-for-powerline",
+        "count": "1,204"
+      }
+    ],
+    "font-dejavusansmono-nerd-font": [
+      {
+        "cask": "font-dejavusansmono-nerd-font",
+        "count": "918"
+      }
+    ],
+    "font-dejavusansmono-nerd-font-mono": [
+      {
+        "cask": "font-dejavusansmono-nerd-font-mono",
+        "count": "652"
+      }
+    ],
+    "font-delius": [
+      {
+        "cask": "font-delius",
+        "count": "67"
+      }
+    ],
+    "font-delius-swash-caps": [
+      {
+        "cask": "font-delius-swash-caps",
+        "count": "68"
+      }
+    ],
+    "font-delius-unicase": [
+      {
+        "cask": "font-delius-unicase",
+        "count": "66"
+      }
+    ],
+    "font-della-respira": [
+      {
+        "cask": "font-della-respira",
+        "count": "70"
+      }
+    ],
+    "font-denk-one": [
+      {
+        "cask": "font-denk-one",
+        "count": "47"
+      }
+    ],
+    "font-devicons": [
+      {
+        "cask": "font-devicons",
+        "count": "223"
+      }
+    ],
+    "font-devonshire": [
+      {
+        "cask": "font-devonshire",
+        "count": "67"
+      }
+    ],
+    "font-dhyana": [
+      {
+        "cask": "font-dhyana",
+        "count": "43"
+      }
+    ],
+    "font-didact-gothic": [
+      {
+        "cask": "font-didact-gothic",
+        "count": "70"
+      }
+    ],
+    "font-digohweli-old-do": [
+      {
+        "cask": "font-digohweli-old-do",
+        "count": "47"
+      }
+    ],
+    "font-diplomata": [
+      {
+        "cask": "font-diplomata",
+        "count": "74"
+      }
+    ],
+    "font-diplomata-sc": [
+      {
+        "cask": "font-diplomata-sc",
+        "count": "69"
+      }
+    ],
+    "font-domine": [
+      {
+        "cask": "font-domine",
+        "count": "76"
+      }
+    ],
+    "font-donegal-one": [
+      {
+        "cask": "font-donegal-one",
+        "count": "68"
+      }
+    ],
+    "font-doppio-one": [
+      {
+        "cask": "font-doppio-one",
+        "count": "45"
+      }
+    ],
+    "font-dorsa": [
+      {
+        "cask": "font-dorsa",
+        "count": "68"
+      }
+    ],
+    "font-dosis": [
+      {
+        "cask": "font-dosis",
+        "count": "169"
+      }
+    ],
+    "font-doulos-sil": [
+      {
+        "cask": "font-doulos-sil",
+        "count": "55"
+      }
+    ],
+    "font-dpcustommono2": [
+      {
+        "cask": "font-dpcustommono2",
+        "count": "1"
+      }
+    ],
+    "font-dr-sugiyama": [
+      {
+        "cask": "font-dr-sugiyama",
+        "count": "1"
+      }
+    ],
+    "font-droid-sans-mono-for-powerline": [
+      {
+        "cask": "font-droid-sans-mono-for-powerline",
+        "count": "1,225"
+      }
+    ],
+    "font-droidsansmono-nerd-font": [
+      {
+        "cask": "font-droidsansmono-nerd-font",
+        "count": "919"
+      }
+    ],
+    "font-droidsansmono-nerd-font-mono": [
+      {
+        "cask": "font-droidsansmono-nerd-font-mono",
+        "count": "512"
+      }
+    ],
+    "font-duru-sans": [
+      {
+        "cask": "font-duru-sans",
+        "count": "48"
+      }
+    ],
+    "font-dynalight": [
+      {
+        "cask": "font-dynalight",
+        "count": "71"
+      }
+    ],
+    "font-eagle-lake": [
+      {
+        "cask": "font-eagle-lake",
+        "count": "67"
+      }
+    ],
+    "font-eater": [
+      {
+        "cask": "font-eater",
+        "count": "47"
+      }
+    ],
+    "font-eb-garamond": [
+      {
+        "cask": "font-eb-garamond",
+        "count": "202"
+      }
+    ],
+    "font-economica": [
+      {
+        "cask": "font-economica",
+        "count": "70"
+      }
+    ],
+    "font-eczar": [
+      {
+        "cask": "font-eczar",
+        "count": "1"
+      }
+    ],
+    "font-edlo": [
+      {
+        "cask": "font-edlo",
+        "count": "64"
+      }
+    ],
+    "font-edmunds": [
+      {
+        "cask": "font-edmunds",
+        "count": "2"
+      }
+    ],
+    "font-eeyek-unicode": [
+      {
+        "cask": "font-eeyek-unicode",
+        "count": "30"
+      }
+    ],
+    "font-electrolize": [
+      {
+        "cask": "font-electrolize",
+        "count": "68"
+      }
+    ],
+    "font-elsie": [
+      {
+        "cask": "font-elsie",
+        "count": "65"
+      }
+    ],
+    "font-elsie-swash-caps": [
+      {
+        "cask": "font-elsie-swash-caps",
+        "count": "65"
+      }
+    ],
+    "font-emblema-one": [
+      {
+        "cask": "font-emblema-one",
+        "count": "1"
+      }
+    ],
+    "font-emilys-candy": [
+      {
+        "cask": "font-emilys-candy",
+        "count": "70"
+      }
+    ],
+    "font-encodesans": [
+      {
+        "cask": "font-encodesans",
+        "count": "73"
+      }
+    ],
+    "font-encodesans-condensed": [
+      {
+        "cask": "font-encodesans-condensed",
+        "count": "68"
+      }
+    ],
+    "font-encodesans-expanded": [
+      {
+        "cask": "font-encodesans-expanded",
+        "count": "63"
+      }
+    ],
+    "font-encodesans-semicondensed": [
+      {
+        "cask": "font-encodesans-semicondensed",
+        "count": "67"
+      }
+    ],
+    "font-encodesans-semiexpanded": [
+      {
+        "cask": "font-encodesans-semiexpanded",
+        "count": "65"
+      }
+    ],
+    "font-engagement": [
+      {
+        "cask": "font-engagement",
+        "count": "45"
+      }
+    ],
+    "font-englebert": [
+      {
+        "cask": "font-englebert",
+        "count": "67"
+      }
+    ],
+    "font-enriqueta": [
+      {
+        "cask": "font-enriqueta",
+        "count": "71"
+      }
+    ],
+    "font-envy-code-r": [
+      {
+        "cask": "font-envy-code-r",
+        "count": "160"
+      }
+    ],
+    "font-erica-one": [
+      {
+        "cask": "font-erica-one",
+        "count": "67"
+      }
+    ],
+    "font-esteban": [
+      {
+        "cask": "font-esteban",
+        "count": "66"
+      }
+    ],
+    "font-et-book": [
+      {
+        "cask": "font-et-book",
+        "count": "127"
+      }
+    ],
+    "font-euphoria-script": [
+      {
+        "cask": "font-euphoria-script",
+        "count": "69"
+      }
+    ],
+    "font-everson-mono": [
+      {
+        "cask": "font-everson-mono",
+        "count": "98"
+      }
+    ],
+    "font-ewert": [
+      {
+        "cask": "font-ewert",
+        "count": "66"
+      }
+    ],
+    "font-exo": [
+      {
+        "cask": "font-exo",
+        "count": "101"
+      }
+    ],
+    "font-exo2": [
+      {
+        "cask": "font-exo2",
+        "count": "125"
+      }
+    ],
+    "font-expletus-sans": [
+      {
+        "cask": "font-expletus-sans",
+        "count": "1"
+      }
+    ],
+    "font-ezra-sil": [
+      {
+        "cask": "font-ezra-sil",
+        "count": "50"
+      }
+    ],
+    "font-f0nt-arabica": [
+      {
+        "cask": "font-f0nt-arabica",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-atnoon": [
+      {
+        "cask": "font-f0nt-atnoon",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-atnoon-bighead": [
+      {
+        "cask": "font-f0nt-atnoon-bighead",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-bangna-new": [
+      {
+        "cask": "font-f0nt-bangna-new",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-bangnumpueng": [
+      {
+        "cask": "font-f0nt-bangnumpueng",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-blk-bangli-ko-sa-na": [
+      {
+        "cask": "font-f0nt-blk-bangli-ko-sa-na",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-book-r-lux-2006": [
+      {
+        "cask": "font-f0nt-book-r-lux-2006",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-iannnnnjpg": [
+      {
+        "cask": "font-f0nt-iannnnnjpg",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-iannnnnmtv": [
+      {
+        "cask": "font-f0nt-iannnnnmtv",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-kruengprung": [
+      {
+        "cask": "font-f0nt-kruengprung",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-layiji-mahaniyom-bao-1-2": [
+      {
+        "cask": "font-f0nt-layiji-mahaniyom-bao-1-2",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-layiji-sarangheyo": [
+      {
+        "cask": "font-f0nt-layiji-sarangheyo",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-lzk03-b2campus": [
+      {
+        "cask": "font-f0nt-lzk03-b2campus",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-nongaor": [
+      {
+        "cask": "font-f0nt-nongaor",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-pahnto": [
+      {
+        "cask": "font-f0nt-pahnto",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-rukdeaw": [
+      {
+        "cask": "font-f0nt-rukdeaw",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-sanamdeklen-chaya": [
+      {
+        "cask": "font-f0nt-sanamdeklen-chaya",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-saruns-manorah": [
+      {
+        "cask": "font-f0nt-saruns-manorah",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-sov-apo": [
+      {
+        "cask": "font-f0nt-sov-apo",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-sov-baanhook": [
+      {
+        "cask": "font-f0nt-sov-baanhook",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-supermarket": [
+      {
+        "cask": "font-f0nt-supermarket",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-tlu-huatoo0": [
+      {
+        "cask": "font-f0nt-tlu-huatoo0",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-tlu-jiumjium": [
+      {
+        "cask": "font-f0nt-tlu-jiumjium",
+        "count": "1"
+      }
+    ],
+    "font-f0nt-waffle": [
+      {
+        "cask": "font-f0nt-waffle",
+        "count": "1"
+      }
+    ],
+    "font-fairfax": [
+      {
+        "cask": "font-fairfax",
+        "count": "69"
+      }
+    ],
+    "font-fandol": [
+      {
+        "cask": "font-fandol",
+        "count": "47"
+      }
+    ],
+    "font-fantasque-sans-mono": [
+      {
+        "cask": "font-fantasque-sans-mono",
+        "count": "1,268"
+      }
+    ],
+    "font-fantasque-sans-mono-noligatures": [
+      {
+        "cask": "font-fantasque-sans-mono-noligatures",
+        "count": "1"
+      }
+    ],
+    "font-fantasque-sans-mono-noloopk": [
+      {
+        "cask": "font-fantasque-sans-mono-noloopk",
+        "count": "22"
+      }
+    ],
+    "font-fantasque-sans-mono-noloopk-noligatures": [
+      {
+        "cask": "font-fantasque-sans-mono-noloopk-noligatures",
+        "count": "1"
+      }
+    ],
+    "font-fantasquesansmono-nerd-font": [
+      {
+        "cask": "font-fantasquesansmono-nerd-font",
+        "count": "507"
+      }
+    ],
+    "font-fantasquesansmono-nerd-font-mono": [
+      {
+        "cask": "font-fantasquesansmono-nerd-font-mono",
+        "count": "421"
+      }
+    ],
+    "font-fanwood-text": [
+      {
+        "cask": "font-fanwood-text",
+        "count": "75"
+      }
+    ],
+    "font-fascinate": [
+      {
+        "cask": "font-fascinate",
+        "count": "70"
+      }
+    ],
+    "font-fascinate-inline": [
+      {
+        "cask": "font-fascinate-inline",
+        "count": "70"
+      }
+    ],
+    "font-faster-one": [
+      {
+        "cask": "font-faster-one",
+        "count": "44"
+      }
+    ],
+    "font-fasthand": [
+      {
+        "cask": "font-fasthand",
+        "count": "43"
+      }
+    ],
+    "font-fauna-one": [
+      {
+        "cask": "font-fauna-one",
+        "count": "75"
+      }
+    ],
+    "font-federant": [
+      {
+        "cask": "font-federant",
+        "count": "66"
+      }
+    ],
+    "font-federo": [
+      {
+        "cask": "font-federo",
+        "count": "65"
+      }
+    ],
+    "font-felipa": [
+      {
+        "cask": "font-felipa",
+        "count": "65"
+      }
+    ],
+    "font-fenix": [
+      {
+        "cask": "font-fenix",
+        "count": "70"
+      }
+    ],
+    "font-finger-paint": [
+      {
+        "cask": "font-finger-paint",
+        "count": "70"
+      }
+    ],
+    "font-fira-code": [
+      {
+        "cask": "font-fira-code",
+        "count": "47,031"
+      }
+    ],
+    "font-fira-code-regular-symbol": [
+      {
+        "cask": "font-fira-code-regular-symbol",
+        "count": "2"
+      }
+    ],
+    "font-fira-go": [
+      {
+        "cask": "font-fira-go",
+        "count": "1"
+      }
+    ],
+    "font-fira-mono": [
+      {
+        "cask": "font-fira-mono",
+        "count": "2,852"
+      }
+    ],
+    "font-fira-mono-for-powerline": [
+      {
+        "cask": "font-fira-mono-for-powerline",
+        "count": "3,271"
+      }
+    ],
+    "font-fira-sans": [
+      {
+        "cask": "font-fira-sans",
+        "count": "1,977"
+      }
+    ],
+    "font-firacode-nerd-font": [
+      {
+        "cask": "font-firacode-nerd-font",
+        "count": "6,944"
+      }
+    ],
+    "font-firacode-nerd-font-mono": [
+      {
+        "cask": "font-firacode-nerd-font-mono",
+        "count": "2,401"
+      }
+    ],
+    "font-firamono-nerd-font": [
+      {
+        "cask": "font-firamono-nerd-font",
+        "count": "1,034"
+      }
+    ],
+    "font-firamono-nerd-font-mono": [
+      {
+        "cask": "font-firamono-nerd-font-mono",
+        "count": "669"
+      }
+    ],
+    "font-fixedsys": [
+      {
+        "cask": "font-fixedsys",
+        "count": "2"
+      }
+    ],
+    "font-fixedsys-excelsior": [
+      {
+        "cask": "font-fixedsys-excelsior",
+        "count": "1"
+      }
+    ],
+    "font-fjalla-one": [
+      {
+        "cask": "font-fjalla-one",
+        "count": "75"
+      }
+    ],
+    "font-fjord-one": [
+      {
+        "cask": "font-fjord-one",
+        "count": "66"
+      }
+    ],
+    "font-flamenco": [
+      {
+        "cask": "font-flamenco",
+        "count": "67"
+      }
+    ],
+    "font-flavors": [
+      {
+        "cask": "font-flavors",
+        "count": "64"
+      }
+    ],
+    "font-fondamento": [
+      {
+        "cask": "font-fondamento",
+        "count": "63"
+      }
+    ],
+    "font-fontawesome": [
+      {
+        "cask": "font-fontawesome",
+        "count": "2,618"
+      }
+    ],
+    "font-fontdiner-swanky": [
+      {
+        "cask": "font-fontdiner-swanky",
+        "count": "66"
+      }
+    ],
+    "font-forum": [
+      {
+        "cask": "font-forum",
+        "count": "72"
+      }
+    ],
+    "font-foundation-icons": [
+      {
+        "cask": "font-foundation-icons",
+        "count": "62"
+      }
+    ],
+    "font-foundry-sterling": [
+      {
+        "cask": "font-foundry-sterling",
+        "count": "33"
+      }
+    ],
+    "font-francois-one": [
+      {
+        "cask": "font-francois-one",
+        "count": "69"
+      }
+    ],
+    "font-freckle-face": [
+      {
+        "cask": "font-freckle-face",
+        "count": "41"
+      }
+    ],
+    "font-fredericka-the-great": [
+      {
+        "cask": "font-fredericka-the-great",
+        "count": "69"
+      }
+    ],
+    "font-fredoka-one": [
+      {
+        "cask": "font-fredoka-one",
+        "count": "66"
+      }
+    ],
+    "font-freehand": [
+      {
+        "cask": "font-freehand",
+        "count": "45"
+      }
+    ],
+    "font-freesans": [
+      {
+        "cask": "font-freesans",
+        "count": "73"
+      }
+    ],
+    "font-fresca": [
+      {
+        "cask": "font-fresca",
+        "count": "65"
+      }
+    ],
+    "font-frijole": [
+      {
+        "cask": "font-frijole",
+        "count": "65"
+      }
+    ],
+    "font-fruktur": [
+      {
+        "cask": "font-fruktur",
+        "count": "40"
+      }
+    ],
+    "font-fugaz-one": [
+      {
+        "cask": "font-fugaz-one",
+        "count": "1"
+      }
+    ],
+    "font-fzshusong-z01": [
+      {
+        "cask": "font-fzshusong-z01",
+        "count": "55"
+      }
+    ],
+    "font-fzshusong-z01s": [
+      {
+        "cask": "font-fzshusong-z01s",
+        "count": "8"
+      }
+    ],
+    "font-gabriela": [
+      {
+        "cask": "font-gabriela",
+        "count": "63"
+      }
+    ],
+    "font-gafata": [
+      {
+        "cask": "font-gafata",
+        "count": "64"
+      }
+    ],
+    "font-galdeano": [
+      {
+        "cask": "font-galdeano",
+        "count": "63"
+      }
+    ],
+    "font-galindo": [
+      {
+        "cask": "font-galindo",
+        "count": "41"
+      }
+    ],
+    "font-gandhi-sans": [
+      {
+        "cask": "font-gandhi-sans",
+        "count": "18"
+      }
+    ],
+    "font-genjyuugothic": [
+      {
+        "cask": "font-genjyuugothic",
+        "count": "40"
+      }
+    ],
+    "font-genjyuugothic-l": [
+      {
+        "cask": "font-genjyuugothic-l",
+        "count": "1"
+      }
+    ],
+    "font-genjyuugothic-x": [
+      {
+        "cask": "font-genjyuugothic-x",
+        "count": "32"
+      }
+    ],
+    "font-genryumin": [
+      {
+        "cask": "font-genryumin",
+        "count": "3"
+      }
+    ],
+    "font-gensekigothic": [
+      {
+        "cask": "font-gensekigothic",
+        "count": "2"
+      }
+    ],
+    "font-gensenrounded": [
+      {
+        "cask": "font-gensenrounded",
+        "count": "4"
+      }
+    ],
+    "font-genshingothic": [
+      {
+        "cask": "font-genshingothic",
+        "count": "52"
+      }
+    ],
+    "font-gentium-basic": [
+      {
+        "cask": "font-gentium-basic",
+        "count": "97"
+      }
+    ],
+    "font-gentium-book-basic": [
+      {
+        "cask": "font-gentium-book-basic",
+        "count": "101"
+      }
+    ],
+    "font-gentium-plus": [
+      {
+        "cask": "font-gentium-plus",
+        "count": "121"
+      }
+    ],
+    "font-genwanmin": [
+      {
+        "cask": "font-genwanmin",
+        "count": "3"
+      }
+    ],
+    "font-genyogothic": [
+      {
+        "cask": "font-genyogothic",
+        "count": "3"
+      }
+    ],
+    "font-genyomin": [
+      {
+        "cask": "font-genyomin",
+        "count": "3"
+      }
+    ],
+    "font-geo": [
+      {
+        "cask": "font-geo",
+        "count": "62"
+      }
+    ],
+    "font-georgia": [
+      {
+        "cask": "font-georgia",
+        "count": "46"
+      }
+    ],
+    "font-geostar": [
+      {
+        "cask": "font-geostar",
+        "count": "61"
+      }
+    ],
+    "font-geostar-fill": [
+      {
+        "cask": "font-geostar-fill",
+        "count": "61"
+      }
+    ],
+    "font-germania-one": [
+      {
+        "cask": "font-germania-one",
+        "count": "65"
+      }
+    ],
+    "font-gfs-didot": [
+      {
+        "cask": "font-gfs-didot",
+        "count": "51"
+      }
+    ],
+    "font-gfs-neohellenic": [
+      {
+        "cask": "font-gfs-neohellenic",
+        "count": "41"
+      }
+    ],
+    "font-gidole": [
+      {
+        "cask": "font-gidole",
+        "count": "51"
+      }
+    ],
+    "font-gilbert": [
+      {
+        "cask": "font-gilbert",
+        "count": "41"
+      }
+    ],
+    "font-gilda-display": [
+      {
+        "cask": "font-gilda-display",
+        "count": "60"
+      }
+    ],
+    "font-give-you-glory": [
+      {
+        "cask": "font-give-you-glory",
+        "count": "61"
+      }
+    ],
+    "font-glass-antiqua": [
+      {
+        "cask": "font-glass-antiqua",
+        "count": "63"
+      }
+    ],
+    "font-glegoo": [
+      {
+        "cask": "font-glegoo",
+        "count": "62"
+      }
+    ],
+    "font-gloria-hallelujah": [
+      {
+        "cask": "font-gloria-hallelujah",
+        "count": "44"
+      }
+    ],
+    "font-gnu-unifont": [
+      {
+        "cask": "font-gnu-unifont",
+        "count": "92"
+      }
+    ],
+    "font-go": [
+      {
+        "cask": "font-go",
+        "count": "155"
+      }
+    ],
+    "font-go-medium": [
+      {
+        "cask": "font-go-medium",
+        "count": "73"
+      }
+    ],
+    "font-go-mono": [
+      {
+        "cask": "font-go-mono",
+        "count": "236"
+      }
+    ],
+    "font-go-mono-nerd-font": [
+      {
+        "cask": "font-go-mono-nerd-font",
+        "count": "421"
+      }
+    ],
+    "font-go-mono-nerd-font-mono": [
+      {
+        "cask": "font-go-mono-nerd-font-mono",
+        "count": "321"
+      }
+    ],
+    "font-goblin-one": [
+      {
+        "cask": "font-goblin-one",
+        "count": "61"
+      }
+    ],
+    "font-gochi-hand": [
+      {
+        "cask": "font-gochi-hand",
+        "count": "42"
+      }
+    ],
+    "font-gohu-nerd-font": [
+      {
+        "cask": "font-gohu-nerd-font",
+        "count": "273"
+      }
+    ],
+    "font-gohu-nerd-font-mono": [
+      {
+        "cask": "font-gohu-nerd-font-mono",
+        "count": "269"
+      }
+    ],
+    "font-gohufont-nerd-font": [
+      {
+        "cask": "font-gohufont-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-gomono-nerd-font": [
+      {
+        "cask": "font-gomono-nerd-font",
+        "count": "34"
+      }
+    ],
+    "font-gorditas": [
+      {
+        "cask": "font-gorditas",
+        "count": "36"
+      }
+    ],
+    "font-goudy-bookletter1911": [
+      {
+        "cask": "font-goudy-bookletter1911",
+        "count": "70"
+      }
+    ],
+    "font-graduate": [
+      {
+        "cask": "font-graduate",
+        "count": "38"
+      }
+    ],
+    "font-grand-hotel": [
+      {
+        "cask": "font-grand-hotel",
+        "count": "64"
+      }
+    ],
+    "font-gravitas-one": [
+      {
+        "cask": "font-gravitas-one",
+        "count": "62"
+      }
+    ],
+    "font-great-vibes": [
+      {
+        "cask": "font-great-vibes",
+        "count": "104"
+      }
+    ],
+    "font-grenze": [
+      {
+        "cask": "font-grenze",
+        "count": "25"
+      }
+    ],
+    "font-griffy": [
+      {
+        "cask": "font-griffy",
+        "count": "62"
+      }
+    ],
+    "font-gruppo": [
+      {
+        "cask": "font-gruppo",
+        "count": "62"
+      }
+    ],
+    "font-gt-walsheim": [
+      {
+        "cask": "font-gt-walsheim",
+        "count": "3"
+      }
+    ],
+    "font-gudea": [
+      {
+        "cask": "font-gudea",
+        "count": "63"
+      }
+    ],
+    "font-habibi": [
+      {
+        "cask": "font-habibi",
+        "count": "62"
+      }
+    ],
+    "font-hack": [
+      {
+        "cask": "font-hack",
+        "count": "4,129"
+      }
+    ],
+    "font-hack-nerd-font": [
+      {
+        "cask": "font-hack-nerd-font",
+        "count": "49,080"
+      }
+    ],
+    "font-hack-nerd-font-mono": [
+      {
+        "cask": "font-hack-nerd-font-mono",
+        "count": "1,480"
+      }
+    ],
+    "font-hackgen": [
+      {
+        "cask": "font-hackgen",
+        "count": "773"
+      }
+    ],
+    "font-halant": [
+      {
+        "cask": "font-halant",
+        "count": "40"
+      }
+    ],
+    "font-hammersmith-one": [
+      {
+        "cask": "font-hammersmith-one",
+        "count": "67"
+      }
+    ],
+    "font-han-nom-a": [
+      {
+        "cask": "font-han-nom-a",
+        "count": "42"
+      }
+    ],
+    "font-hanalei": [
+      {
+        "cask": "font-hanalei",
+        "count": "40"
+      }
+    ],
+    "font-hanalei-fill": [
+      {
+        "cask": "font-hanalei-fill",
+        "count": "40"
+      }
+    ],
+    "font-hanamina": [
+      {
+        "cask": "font-hanamina",
+        "count": "78"
+      }
+    ],
+    "font-handlee": [
+      {
+        "cask": "font-handlee",
+        "count": "57"
+      }
+    ],
+    "font-hanuman": [
+      {
+        "cask": "font-hanuman",
+        "count": "38"
+      }
+    ],
+    "font-happy-monkey": [
+      {
+        "cask": "font-happy-monkey",
+        "count": "41"
+      }
+    ],
+    "font-harmonia-sans": [
+      {
+        "cask": "font-harmonia-sans",
+        "count": "1"
+      }
+    ],
+    "font-hasklig": [
+      {
+        "cask": "font-hasklig",
+        "count": "1,081"
+      }
+    ],
+    "font-hasklig-nerd-font": [
+      {
+        "cask": "font-hasklig-nerd-font",
+        "count": "749"
+      }
+    ],
+    "font-hasklig-nerd-font-mono": [
+      {
+        "cask": "font-hasklig-nerd-font-mono",
+        "count": "476"
+      }
+    ],
+    "font-hasklug-nerd-font": [
+      {
+        "cask": "font-hasklug-nerd-font",
+        "count": "44"
+      }
+    ],
+    "font-haskplex": [
+      {
+        "cask": "font-haskplex",
+        "count": "25"
+      }
+    ],
+    "font-haskplex-nerd": [
+      {
+        "cask": "font-haskplex-nerd",
+        "count": "29"
+      }
+    ],
+    "font-headland-one": [
+      {
+        "cask": "font-headland-one",
+        "count": "62"
+      }
+    ],
+    "font-heavydata-nerd-font": [
+      {
+        "cask": "font-heavydata-nerd-font",
+        "count": "286"
+      }
+    ],
+    "font-heavydata-nerd-font-mono": [
+      {
+        "cask": "font-heavydata-nerd-font-mono",
+        "count": "244"
+      }
+    ],
+    "font-henny-penny": [
+      {
+        "cask": "font-henny-penny",
+        "count": "65"
+      }
+    ],
+    "font-hermit": [
+      {
+        "cask": "font-hermit",
+        "count": "96"
+      }
+    ],
+    "font-hermit-nerd-font": [
+      {
+        "cask": "font-hermit-nerd-font",
+        "count": "288"
+      }
+    ],
+    "font-hermit-nerd-font-mono": [
+      {
+        "cask": "font-hermit-nerd-font-mono",
+        "count": "275"
+      }
+    ],
+    "font-herr-von-muellerhoff": [
+      {
+        "cask": "font-herr-von-muellerhoff",
+        "count": "62"
+      }
+    ],
+    "font-hind": [
+      {
+        "cask": "font-hind",
+        "count": "58"
+      }
+    ],
+    "font-holtwood-one-sc": [
+      {
+        "cask": "font-holtwood-one-sc",
+        "count": "62"
+      }
+    ],
+    "font-homemade-apple": [
+      {
+        "cask": "font-homemade-apple",
+        "count": "73"
+      }
+    ],
+    "font-homenaje": [
+      {
+        "cask": "font-homenaje",
+        "count": "38"
+      }
+    ],
+    "font-humor-sans": [
+      {
+        "cask": "font-humor-sans",
+        "count": "54"
+      }
+    ],
+    "font-hurmit-nerd-font": [
+      {
+        "cask": "font-hurmit-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-hyppolit": [
+      {
+        "cask": "font-hyppolit",
+        "count": "62"
+      }
+    ],
+    "font-ia-writer-duo": [
+      {
+        "cask": "font-ia-writer-duo",
+        "count": "163"
+      }
+    ],
+    "font-ia-writer-duospace": [
+      {
+        "cask": "font-ia-writer-duospace",
+        "count": "155"
+      }
+    ],
+    "font-ia-writer-mono": [
+      {
+        "cask": "font-ia-writer-mono",
+        "count": "241"
+      }
+    ],
+    "font-ia-writer-quattro": [
+      {
+        "cask": "font-ia-writer-quattro",
+        "count": "151"
+      }
+    ],
+    "font-ibm-plex": [
+      {
+        "cask": "font-ibm-plex",
+        "count": "1,610"
+      }
+    ],
+    "font-ibm-plex-nerd-font": [
+      {
+        "cask": "font-ibm-plex-nerd-font",
+        "count": "1"
+      }
+    ],
+    "font-ibmplexmono-nerd-font": [
+      {
+        "cask": "font-ibmplexmono-nerd-font",
+        "count": "27"
+      }
+    ],
+    "font-ibmplexmono-nerd-font-mono": [
+      {
+        "cask": "font-ibmplexmono-nerd-font-mono",
+        "count": "21"
+      }
+    ],
+    "font-iceberg": [
+      {
+        "cask": "font-iceberg",
+        "count": "69"
+      }
+    ],
+    "font-iceland": [
+      {
+        "cask": "font-iceland",
+        "count": "69"
+      }
+    ],
+    "font-icomoon": [
+      {
+        "cask": "font-icomoon",
+        "count": "47"
+      }
+    ],
+    "font-im-fell-types": [
+      {
+        "cask": "font-im-fell-types",
+        "count": "36"
+      }
+    ],
+    "font-impact": [
+      {
+        "cask": "font-impact",
+        "count": "73"
+      }
+    ],
+    "font-imprima": [
+      {
+        "cask": "font-imprima",
+        "count": "62"
+      }
+    ],
+    "font-imwriting-nerd-font": [
+      {
+        "cask": "font-imwriting-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-inconsolata": [
+      {
+        "cask": "font-inconsolata",
+        "count": "4,853"
+      }
+    ],
+    "font-inconsolata-dz": [
+      {
+        "cask": "font-inconsolata-dz",
+        "count": "257"
+      }
+    ],
+    "font-inconsolata-dz-for-powerline": [
+      {
+        "cask": "font-inconsolata-dz-for-powerline",
+        "count": "1,155"
+      }
+    ],
+    "font-inconsolata-for-powerline": [
+      {
+        "cask": "font-inconsolata-for-powerline",
+        "count": "1,909"
+      }
+    ],
+    "font-inconsolata-for-powerline-bold": [
+      {
+        "cask": "font-inconsolata-for-powerline-bold",
+        "count": "565"
+      }
+    ],
+    "font-inconsolata-g": [
+      {
+        "cask": "font-inconsolata-g",
+        "count": "214"
+      }
+    ],
+    "font-inconsolata-g-for-powerline": [
+      {
+        "cask": "font-inconsolata-g-for-powerline",
+        "count": "1,107"
+      }
+    ],
+    "font-inconsolata-lgc": [
+      {
+        "cask": "font-inconsolata-lgc",
+        "count": "251"
+      }
+    ],
+    "font-inconsolata-nerd-font": [
+      {
+        "cask": "font-inconsolata-nerd-font",
+        "count": "1,252"
+      }
+    ],
+    "font-inconsolata-nerd-font-mono": [
+      {
+        "cask": "font-inconsolata-nerd-font-mono",
+        "count": "675"
+      }
+    ],
+    "font-inconsolatago-nerd-font": [
+      {
+        "cask": "font-inconsolatago-nerd-font",
+        "count": "458"
+      }
+    ],
+    "font-inconsolatago-nerd-font-mono": [
+      {
+        "cask": "font-inconsolatago-nerd-font-mono",
+        "count": "336"
+      }
+    ],
+    "font-inconsolatalgc-nerd-font": [
+      {
+        "cask": "font-inconsolatalgc-nerd-font",
+        "count": "385"
+      }
+    ],
+    "font-inconsolatalgc-nerd-font-mono": [
+      {
+        "cask": "font-inconsolatalgc-nerd-font-mono",
+        "count": "294"
+      }
+    ],
+    "font-inder": [
+      {
+        "cask": "font-inder",
+        "count": "35"
+      }
+    ],
+    "font-indie-flower": [
+      {
+        "cask": "font-indie-flower",
+        "count": "69"
+      }
+    ],
+    "font-inika": [
+      {
+        "cask": "font-inika",
+        "count": "59"
+      }
+    ],
+    "font-input": [
+      {
+        "cask": "font-input",
+        "count": "1,088"
+      }
+    ],
+    "font-input-custom": [
+      {
+        "cask": "font-input-custom",
+        "count": "2"
+      }
+    ],
+    "font-inria": [
+      {
+        "cask": "font-inria",
+        "count": "41"
+      }
+    ],
+    "font-inter": [
+      {
+        "cask": "font-inter",
+        "count": "454"
+      }
+    ],
+    "font-ionicons": [
+      {
+        "cask": "font-ionicons",
+        "count": "103"
+      }
+    ],
+    "font-iosevka": [
+      {
+        "cask": "font-iosevka",
+        "count": "5,205"
+      }
+    ],
+    "font-iosevka-beta": [
+      {
+        "cask": "font-iosevka-beta",
+        "count": "2"
+      }
+    ],
+    "font-iosevka-nerd-font": [
+      {
+        "cask": "font-iosevka-nerd-font",
+        "count": "1,206"
+      }
+    ],
+    "font-iosevka-nerd-font-mono": [
+      {
+        "cask": "font-iosevka-nerd-font-mono",
+        "count": "652"
+      }
+    ],
+    "font-iosevka-slab": [
+      {
+        "cask": "font-iosevka-slab",
+        "count": "2,166"
+      }
+    ],
+    "font-iosevka-slab-beta": [
+      {
+        "cask": "font-iosevka-slab-beta",
+        "count": "2"
+      }
+    ],
+    "font-iosevka-sparkle-beta": [
+      {
+        "cask": "font-iosevka-sparkle-beta",
+        "count": "2"
+      }
+    ],
+    "font-ipaexfont": [
+      {
+        "cask": "font-ipaexfont",
+        "count": "90"
+      }
+    ],
+    "font-ipafont": [
+      {
+        "cask": "font-ipafont",
+        "count": "90"
+      }
+    ],
+    "font-ipamjmincho": [
+      {
+        "cask": "font-ipamjmincho",
+        "count": "5"
+      }
+    ],
+    "font-iranian-sans": [
+      {
+        "cask": "font-iranian-sans",
+        "count": "37"
+      }
+    ],
+    "font-iranian-serif": [
+      {
+        "cask": "font-iranian-serif",
+        "count": "36"
+      }
+    ],
+    "font-irish-grover": [
+      {
+        "cask": "font-irish-grover",
+        "count": "59"
+      }
+    ],
+    "font-istok-web": [
+      {
+        "cask": "font-istok-web",
+        "count": "40"
+      }
+    ],
+    "font-italiana": [
+      {
+        "cask": "font-italiana",
+        "count": "58"
+      }
+    ],
+    "font-italianno": [
+      {
+        "cask": "font-italianno",
+        "count": "66"
+      }
+    ],
+    "font-jaapokki": [
+      {
+        "cask": "font-jaapokki",
+        "count": "63"
+      }
+    ],
+    "font-jacques-francois": [
+      {
+        "cask": "font-jacques-francois",
+        "count": "57"
+      }
+    ],
+    "font-jacques-francois-shadow": [
+      {
+        "cask": "font-jacques-francois-shadow",
+        "count": "58"
+      }
+    ],
+    "font-jaldi": [
+      {
+        "cask": "font-jaldi",
+        "count": "1"
+      }
+    ],
+    "font-jetbrains-mono": [
+      {
+        "cask": "font-jetbrains-mono",
+        "count": "4,075"
+      }
+    ],
+    "font-jetbrains-mono-nl": [
+      {
+        "cask": "font-jetbrains-mono-nl",
+        "count": "1"
+      }
+    ],
+    "font-jetbrains-mono-powerline": [
+      {
+        "cask": "font-jetbrains-mono-powerline",
+        "count": "117"
+      }
+    ],
+    "font-jetbrainsmono-nerd-font": [
+      {
+        "cask": "font-jetbrainsmono-nerd-font",
+        "count": "843"
+      }
+    ],
+    "font-jetbrainsmono-nerd-font-mono": [
+      {
+        "cask": "font-jetbrainsmono-nerd-font-mono",
+        "count": "278"
+      }
+    ],
+    "font-jf-open-huninn": [
+      {
+        "cask": "font-jf-open-huninn",
+        "count": "27"
+      }
+    ],
+    "font-jim-nightshade": [
+      {
+        "cask": "font-jim-nightshade",
+        "count": "60"
+      }
+    ],
+    "font-jockey-one": [
+      {
+        "cask": "font-jockey-one",
+        "count": "36"
+      }
+    ],
+    "font-jolly-lodger": [
+      {
+        "cask": "font-jolly-lodger",
+        "count": "59"
+      }
+    ],
+    "font-joscelyn": [
+      {
+        "cask": "font-joscelyn",
+        "count": "6"
+      }
+    ],
+    "font-josefin-sans": [
+      {
+        "cask": "font-josefin-sans",
+        "count": "99"
+      }
+    ],
+    "font-josefin-slab": [
+      {
+        "cask": "font-josefin-slab",
+        "count": "76"
+      }
+    ],
+    "font-jost": [
+      {
+        "cask": "font-jost",
+        "count": "1"
+      }
+    ],
+    "font-joti-one": [
+      {
+        "cask": "font-joti-one",
+        "count": "59"
+      }
+    ],
+    "font-jsmath-cmbx10": [
+      {
+        "cask": "font-jsmath-cmbx10",
+        "count": "45"
+      }
+    ],
+    "font-judson": [
+      {
+        "cask": "font-judson",
+        "count": "58"
+      }
+    ],
+    "font-julee": [
+      {
+        "cask": "font-julee",
+        "count": "58"
+      }
+    ],
+    "font-julius-sans-one": [
+      {
+        "cask": "font-julius-sans-one",
+        "count": "62"
+      }
+    ],
+    "font-junction": [
+      {
+        "cask": "font-junction",
+        "count": "40"
+      }
+    ],
+    "font-junge": [
+      {
+        "cask": "font-junge",
+        "count": "60"
+      }
+    ],
+    "font-junicode": [
+      {
+        "cask": "font-junicode",
+        "count": "61"
+      }
+    ],
+    "font-jura": [
+      {
+        "cask": "font-jura",
+        "count": "61"
+      }
+    ],
+    "font-just-another-hand": [
+      {
+        "cask": "font-just-another-hand",
+        "count": "42"
+      }
+    ],
+    "font-just-me-again-down-here": [
+      {
+        "cask": "font-just-me-again-down-here",
+        "count": "1"
+      }
+    ],
+    "font-kalam": [
+      {
+        "cask": "font-kalam",
+        "count": "54"
+      }
+    ],
+    "font-kameron": [
+      {
+        "cask": "font-kameron",
+        "count": "60"
+      }
+    ],
+    "font-kantumruy": [
+      {
+        "cask": "font-kantumruy",
+        "count": "1"
+      }
+    ],
+    "font-karla": [
+      {
+        "cask": "font-karla",
+        "count": "80"
+      }
+    ],
+    "font-karla-tamil-inclined": [
+      {
+        "cask": "font-karla-tamil-inclined",
+        "count": "1"
+      }
+    ],
+    "font-karla-tamil-upright": [
+      {
+        "cask": "font-karla-tamil-upright",
+        "count": "1"
+      }
+    ],
+    "font-karma": [
+      {
+        "cask": "font-karma",
+        "count": "63"
+      }
+    ],
+    "font-kaushan-script": [
+      {
+        "cask": "font-kaushan-script",
+        "count": "50"
+      }
+    ],
+    "font-kavoon": [
+      {
+        "cask": "font-kavoon",
+        "count": "1"
+      }
+    ],
+    "font-kawkab-mono": [
+      {
+        "cask": "font-kawkab-mono",
+        "count": "60"
+      }
+    ],
+    "font-kayases": [
+      {
+        "cask": "font-kayases",
+        "count": "1"
+      }
+    ],
+    "font-kdam-thmor": [
+      {
+        "cask": "font-kdam-thmor",
+        "count": "1"
+      }
+    ],
+    "font-keania-one": [
+      {
+        "cask": "font-keania-one",
+        "count": "1"
+      }
+    ],
+    "font-keep-calm": [
+      {
+        "cask": "font-keep-calm",
+        "count": "1"
+      }
+    ],
+    "font-kelly-slab": [
+      {
+        "cask": "font-kelly-slab",
+        "count": "1"
+      }
+    ],
+    "font-kenia": [
+      {
+        "cask": "font-kenia",
+        "count": "1"
+      }
+    ],
+    "font-khmer": [
+      {
+        "cask": "font-khmer",
+        "count": "41"
+      }
+    ],
+    "font-khmer-os-bundle": [
+      {
+        "cask": "font-khmer-os-bundle",
+        "count": "1"
+      }
+    ],
+    "font-khmeros-bundle": [
+      {
+        "cask": "font-khmeros-bundle",
+        "count": "1"
+      }
+    ],
+    "font-kisiska": [
+      {
+        "cask": "font-kisiska",
+        "count": "1"
+      }
+    ],
+    "font-kite-one": [
+      {
+        "cask": "font-kite-one",
+        "count": "38"
+      }
+    ],
+    "font-knewave": [
+      {
+        "cask": "font-knewave",
+        "count": "1"
+      }
+    ],
+    "font-kopub": [
+      {
+        "cask": "font-kopub",
+        "count": "6"
+      }
+    ],
+    "font-koruri": [
+      {
+        "cask": "font-koruri",
+        "count": "1"
+      }
+    ],
+    "font-kotta-one": [
+      {
+        "cask": "font-kotta-one",
+        "count": "1"
+      }
+    ],
+    "font-koulen": [
+      {
+        "cask": "font-koulen",
+        "count": "1"
+      }
+    ],
+    "font-kranky": [
+      {
+        "cask": "font-kranky",
+        "count": "61"
+      }
+    ],
+    "font-kreon": [
+      {
+        "cask": "font-kreon",
+        "count": "44"
+      }
+    ],
+    "font-kristi": [
+      {
+        "cask": "font-kristi",
+        "count": "37"
+      }
+    ],
+    "font-krona-one": [
+      {
+        "cask": "font-krona-one",
+        "count": "63"
+      }
+    ],
+    "font-la-belle-aurore": [
+      {
+        "cask": "font-la-belle-aurore",
+        "count": "41"
+      }
+    ],
+    "font-laila": [
+      {
+        "cask": "font-laila",
+        "count": "65"
+      }
+    ],
+    "font-lancelot": [
+      {
+        "cask": "font-lancelot",
+        "count": "65"
+      }
+    ],
+    "font-langdon": [
+      {
+        "cask": "font-langdon",
+        "count": "38"
+      }
+    ],
+    "font-lateef": [
+      {
+        "cask": "font-lateef",
+        "count": "1"
+      }
+    ],
+    "font-latin-modern": [
+      {
+        "cask": "font-latin-modern",
+        "count": "133"
+      }
+    ],
+    "font-latin-modern-math": [
+      {
+        "cask": "font-latin-modern-math",
+        "count": "119"
+      }
+    ],
+    "font-lato": [
+      {
+        "cask": "font-lato",
+        "count": "1,318"
+      }
+    ],
+    "font-league-gothic": [
+      {
+        "cask": "font-league-gothic",
+        "count": "120"
+      }
+    ],
+    "font-league-script": [
+      {
+        "cask": "font-league-script",
+        "count": "6"
+      }
+    ],
+    "font-league-spartan": [
+      {
+        "cask": "font-league-spartan",
+        "count": "87"
+      }
+    ],
+    "font-leckerli-one": [
+      {
+        "cask": "font-leckerli-one",
+        "count": "45"
+      }
+    ],
+    "font-ledger": [
+      {
+        "cask": "font-ledger",
+        "count": "59"
+      }
+    ],
+    "font-lekton": [
+      {
+        "cask": "font-lekton",
+        "count": "67"
+      }
+    ],
+    "font-lekton-nerd-font": [
+      {
+        "cask": "font-lekton-nerd-font",
+        "count": "295"
+      }
+    ],
+    "font-lekton-nerd-font-mono": [
+      {
+        "cask": "font-lekton-nerd-font-mono",
+        "count": "237"
+      }
+    ],
+    "font-lemon": [
+      {
+        "cask": "font-lemon",
+        "count": "48"
+      }
+    ],
+    "font-lexend-deca": [
+      {
+        "cask": "font-lexend-deca",
+        "count": "4"
+      }
+    ],
+    "font-liberation-mono-for-powerline": [
+      {
+        "cask": "font-liberation-mono-for-powerline",
+        "count": "734"
+      }
+    ],
+    "font-liberation-nerd-font": [
+      {
+        "cask": "font-liberation-nerd-font",
+        "count": "26"
+      }
+    ],
+    "font-liberation-sans": [
+      {
+        "cask": "font-liberation-sans",
+        "count": "286"
+      }
+    ],
+    "font-liberationmono-nerd-font": [
+      {
+        "cask": "font-liberationmono-nerd-font",
+        "count": "375"
+      }
+    ],
+    "font-liberationmono-nerd-font-mono": [
+      {
+        "cask": "font-liberationmono-nerd-font-mono",
+        "count": "281"
+      }
+    ],
+    "font-libertinus": [
+      {
+        "cask": "font-libertinus",
+        "count": "108"
+      }
+    ],
+    "font-libre-baskerville": [
+      {
+        "cask": "font-libre-baskerville",
+        "count": "125"
+      }
+    ],
+    "font-libre-caslon-display": [
+      {
+        "cask": "font-libre-caslon-display",
+        "count": "40"
+      }
+    ],
+    "font-libre-caslon-text": [
+      {
+        "cask": "font-libre-caslon-text",
+        "count": "55"
+      }
+    ],
+    "font-libre-franklin": [
+      {
+        "cask": "font-libre-franklin",
+        "count": "88"
+      }
+    ],
+    "font-life-savers": [
+      {
+        "cask": "font-life-savers",
+        "count": "55"
+      }
+    ],
+    "font-ligature-symbols": [
+      {
+        "cask": "font-ligature-symbols",
+        "count": "46"
+      }
+    ],
+    "font-lilex": [
+      {
+        "cask": "font-lilex",
+        "count": "9"
+      }
+    ],
+    "font-lilita-one": [
+      {
+        "cask": "font-lilita-one",
+        "count": "57"
+      }
+    ],
+    "font-lily-script-one": [
+      {
+        "cask": "font-lily-script-one",
+        "count": "1"
+      }
+    ],
+    "font-limelight": [
+      {
+        "cask": "font-limelight",
+        "count": "56"
+      }
+    ],
+    "font-linden-hill": [
+      {
+        "cask": "font-linden-hill",
+        "count": "66"
+      }
+    ],
+    "font-linux-biolinum": [
+      {
+        "cask": "font-linux-biolinum",
+        "count": "72"
+      }
+    ],
+    "font-linux-libertine": [
+      {
+        "cask": "font-linux-libertine",
+        "count": "226"
+      }
+    ],
+    "font-lobster": [
+      {
+        "cask": "font-lobster",
+        "count": "78"
+      }
+    ],
+    "font-lobster-two": [
+      {
+        "cask": "font-lobster-two",
+        "count": "57"
+      }
+    ],
+    "font-londrina-outline": [
+      {
+        "cask": "font-londrina-outline",
+        "count": "57"
+      }
+    ],
+    "font-londrina-shadow": [
+      {
+        "cask": "font-londrina-shadow",
+        "count": "55"
+      }
+    ],
+    "font-londrina-sketch": [
+      {
+        "cask": "font-londrina-sketch",
+        "count": "61"
+      }
+    ],
+    "font-londrina-solid": [
+      {
+        "cask": "font-londrina-solid",
+        "count": "55"
+      }
+    ],
+    "font-lora": [
+      {
+        "cask": "font-lora",
+        "count": "201"
+      }
+    ],
+    "font-love-ya-like-a-sister": [
+      {
+        "cask": "font-love-ya-like-a-sister",
+        "count": "59"
+      }
+    ],
+    "font-loved-by-the-king": [
+      {
+        "cask": "font-loved-by-the-king",
+        "count": "54"
+      }
+    ],
+    "font-lovers-quarrel": [
+      {
+        "cask": "font-lovers-quarrel",
+        "count": "57"
+      }
+    ],
+    "font-luckiest-guy": [
+      {
+        "cask": "font-luckiest-guy",
+        "count": "55"
+      }
+    ],
+    "font-luculent": [
+      {
+        "cask": "font-luculent",
+        "count": "45"
+      }
+    ],
+    "font-lusitana": [
+      {
+        "cask": "font-lusitana",
+        "count": "33"
+      }
+    ],
+    "font-lustria": [
+      {
+        "cask": "font-lustria",
+        "count": "52"
+      }
+    ],
+    "font-m-plus": [
+      {
+        "cask": "font-m-plus",
+        "count": "294"
+      }
+    ],
+    "font-macondo": [
+      {
+        "cask": "font-macondo",
+        "count": "31"
+      }
+    ],
+    "font-macondo-swash-caps": [
+      {
+        "cask": "font-macondo-swash-caps",
+        "count": "30"
+      }
+    ],
+    "font-magra": [
+      {
+        "cask": "font-magra",
+        "count": "27"
+      }
+    ],
+    "font-maiden-orange": [
+      {
+        "cask": "font-maiden-orange",
+        "count": "51"
+      }
+    ],
+    "font-mako": [
+      {
+        "cask": "font-mako",
+        "count": "31"
+      }
+    ],
+    "font-marcellus": [
+      {
+        "cask": "font-marcellus",
+        "count": "54"
+      }
+    ],
+    "font-marcellus-sc": [
+      {
+        "cask": "font-marcellus-sc",
+        "count": "55"
+      }
+    ],
+    "font-marck-script": [
+      {
+        "cask": "font-marck-script",
+        "count": "35"
+      }
+    ],
+    "font-margarine": [
+      {
+        "cask": "font-margarine",
+        "count": "27"
+      }
+    ],
+    "font-marko-one": [
+      {
+        "cask": "font-marko-one",
+        "count": "27"
+      }
+    ],
+    "font-marmelad": [
+      {
+        "cask": "font-marmelad",
+        "count": "28"
+      }
+    ],
+    "font-marvel": [
+      {
+        "cask": "font-marvel",
+        "count": "61"
+      }
+    ],
+    "font-masinahikan": [
+      {
+        "cask": "font-masinahikan",
+        "count": "29"
+      }
+    ],
+    "font-masinahikan-dene": [
+      {
+        "cask": "font-masinahikan-dene",
+        "count": "29"
+      }
+    ],
+    "font-mate": [
+      {
+        "cask": "font-mate",
+        "count": "28"
+      }
+    ],
+    "font-mate-sc": [
+      {
+        "cask": "font-mate-sc",
+        "count": "28"
+      }
+    ],
+    "font-material-icons": [
+      {
+        "cask": "font-material-icons",
+        "count": "222"
+      }
+    ],
+    "font-materialdesignicons-webfont": [
+      {
+        "cask": "font-materialdesignicons-webfont",
+        "count": "79"
+      }
+    ],
+    "font-maven-pro": [
+      {
+        "cask": "font-maven-pro",
+        "count": "55"
+      }
+    ],
+    "font-mclaren": [
+      {
+        "cask": "font-mclaren",
+        "count": "41"
+      }
+    ],
+    "font-meddon": [
+      {
+        "cask": "font-meddon",
+        "count": "29"
+      }
+    ],
+    "font-medievalsharp": [
+      {
+        "cask": "font-medievalsharp",
+        "count": "64"
+      }
+    ],
+    "font-medula-one": [
+      {
+        "cask": "font-medula-one",
+        "count": "29"
+      }
+    ],
+    "font-megrim": [
+      {
+        "cask": "font-megrim",
+        "count": "27"
+      }
+    ],
+    "font-meie-script": [
+      {
+        "cask": "font-meie-script",
+        "count": "26"
+      }
+    ],
+    "font-meltho": [
+      {
+        "cask": "font-meltho",
+        "count": "24"
+      }
+    ],
+    "font-menlo-for-powerline": [
+      {
+        "cask": "font-menlo-for-powerline",
+        "count": "2,259"
+      }
+    ],
+    "font-merienda": [
+      {
+        "cask": "font-merienda",
+        "count": "30"
+      }
+    ],
+    "font-merienda-one": [
+      {
+        "cask": "font-merienda-one",
+        "count": "28"
+      }
+    ],
+    "font-merriweather": [
+      {
+        "cask": "font-merriweather",
+        "count": "238"
+      }
+    ],
+    "font-merriweather-sans": [
+      {
+        "cask": "font-merriweather-sans",
+        "count": "86"
+      }
+    ],
+    "font-meslo-for-powerline": [
+      {
+        "cask": "font-meslo-for-powerline",
+        "count": "2,086"
+      }
+    ],
+    "font-meslo-lg": [
+      {
+        "cask": "font-meslo-lg",
+        "count": "510"
+      }
+    ],
+    "font-meslo-lgs-nf-bold": [
+      {
+        "cask": "font-meslo-lgs-nf-bold",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-bold-italic": [
+      {
+        "cask": "font-meslo-lgs-nf-bold-italic",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-italic": [
+      {
+        "cask": "font-meslo-lgs-nf-italic",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-regular": [
+      {
+        "cask": "font-meslo-lgs-nf-regular",
+        "count": "1"
+      }
+    ],
+    "font-meslo-nerd-font": [
+      {
+        "cask": "font-meslo-nerd-font",
+        "count": "3,177"
+      }
+    ],
+    "font-meslo-nerd-font-mono": [
+      {
+        "cask": "font-meslo-nerd-font-mono",
+        "count": "1,088"
+      }
+    ],
+    "font-meslo-nerd-font-patched": [
+      {
+        "cask": "font-meslo-nerd-font-patched",
+        "count": "5"
+      }
+    ],
+    "font-meslolg-nerd-font": [
+      {
+        "cask": "font-meslolg-nerd-font",
+        "count": "167"
+      }
+    ],
+    "font-metal": [
+      {
+        "cask": "font-metal",
+        "count": "29"
+      }
+    ],
+    "font-metal-mania": [
+      {
+        "cask": "font-metal-mania",
+        "count": "53"
+      }
+    ],
+    "font-metamorphous": [
+      {
+        "cask": "font-metamorphous",
+        "count": "51"
+      }
+    ],
+    "font-metrophobic": [
+      {
+        "cask": "font-metrophobic",
+        "count": "28"
+      }
+    ],
+    "font-metropolis": [
+      {
+        "cask": "font-metropolis",
+        "count": "72"
+      }
+    ],
+    "font-miao-unicode": [
+      {
+        "cask": "font-miao-unicode",
+        "count": "30"
+      }
+    ],
+    "font-michroma": [
+      {
+        "cask": "font-michroma",
+        "count": "25"
+      }
+    ],
+    "font-microsoft-cleartype-family": [
+      {
+        "cask": "font-microsoft-cleartype-family",
+        "count": "12"
+      }
+    ],
+    "font-microsoft-office": [
+      {
+        "cask": "font-microsoft-office",
+        "count": "524"
+      }
+    ],
+    "font-migmix-1m": [
+      {
+        "cask": "font-migmix-1m",
+        "count": "41"
+      }
+    ],
+    "font-migmix-1p": [
+      {
+        "cask": "font-migmix-1p",
+        "count": "89"
+      }
+    ],
+    "font-migmix-2m": [
+      {
+        "cask": "font-migmix-2m",
+        "count": "35"
+      }
+    ],
+    "font-migmix-2p": [
+      {
+        "cask": "font-migmix-2p",
+        "count": "32"
+      }
+    ],
+    "font-migu-1c": [
+      {
+        "cask": "font-migu-1c",
+        "count": "42"
+      }
+    ],
+    "font-migu-1m": [
+      {
+        "cask": "font-migu-1m",
+        "count": "136"
+      }
+    ],
+    "font-migu-1p": [
+      {
+        "cask": "font-migu-1p",
+        "count": "46"
+      }
+    ],
+    "font-migu-2m": [
+      {
+        "cask": "font-migu-2m",
+        "count": "60"
+      }
+    ],
+    "font-milonga": [
+      {
+        "cask": "font-milonga",
+        "count": "50"
+      }
+    ],
+    "font-miltonian": [
+      {
+        "cask": "font-miltonian",
+        "count": "48"
+      }
+    ],
+    "font-miltonian-tattoo": [
+      {
+        "cask": "font-miltonian-tattoo",
+        "count": "48"
+      }
+    ],
+    "font-miniver": [
+      {
+        "cask": "font-miniver",
+        "count": "25"
+      }
+    ],
+    "font-miriam-mono-clm": [
+      {
+        "cask": "font-miriam-mono-clm",
+        "count": "35"
+      }
+    ],
+    "font-miss-fajardose": [
+      {
+        "cask": "font-miss-fajardose",
+        "count": "23"
+      }
+    ],
+    "font-modern-antiqua": [
+      {
+        "cask": "font-modern-antiqua",
+        "count": "50"
+      }
+    ],
+    "font-molengo": [
+      {
+        "cask": "font-molengo",
+        "count": "1"
+      }
+    ],
+    "font-molle": [
+      {
+        "cask": "font-molle",
+        "count": "23"
+      }
+    ],
+    "font-monda": [
+      {
+        "cask": "font-monda",
+        "count": "25"
+      }
+    ],
+    "font-monofett": [
+      {
+        "cask": "font-monofett",
+        "count": "1"
+      }
+    ],
+    "font-monofur-for-powerline": [
+      {
+        "cask": "font-monofur-for-powerline",
+        "count": "564"
+      }
+    ],
+    "font-monofur-nerd-font": [
+      {
+        "cask": "font-monofur-nerd-font",
+        "count": "427"
+      }
+    ],
+    "font-monofur-nerd-font-mono": [
+      {
+        "cask": "font-monofur-nerd-font-mono",
+        "count": "295"
+      }
+    ],
+    "font-monoid": [
+      {
+        "cask": "font-monoid",
+        "count": "663"
+      }
+    ],
+    "font-monoid-halfloose-large": [
+      {
+        "cask": "font-monoid-halfloose-large",
+        "count": "1"
+      }
+    ],
+    "font-monoid-halftight-large-dollar": [
+      {
+        "cask": "font-monoid-halftight-large-dollar",
+        "count": "1"
+      }
+    ],
+    "font-monoid-large": [
+      {
+        "cask": "font-monoid-large",
+        "count": "1"
+      }
+    ],
+    "font-monoid-large-dollar": [
+      {
+        "cask": "font-monoid-large-dollar",
+        "count": "1"
+      }
+    ],
+    "font-monoid-loose-xtralarge": [
+      {
+        "cask": "font-monoid-loose-xtralarge",
+        "count": "1"
+      }
+    ],
+    "font-monoid-nerd-font": [
+      {
+        "cask": "font-monoid-nerd-font",
+        "count": "816"
+      }
+    ],
+    "font-monoid-nerd-font-mono": [
+      {
+        "cask": "font-monoid-nerd-font-mono",
+        "count": "394"
+      }
+    ],
+    "font-monoisome": [
+      {
+        "cask": "font-monoisome",
+        "count": "89"
+      }
+    ],
+    "font-mononoki": [
+      {
+        "cask": "font-mononoki",
+        "count": "289"
+      }
+    ],
+    "font-mononoki-nerd-font": [
+      {
+        "cask": "font-mononoki-nerd-font",
+        "count": "788"
+      }
+    ],
+    "font-mononoki-nerd-font-mono": [
+      {
+        "cask": "font-mononoki-nerd-font-mono",
+        "count": "462"
+      }
+    ],
+    "font-monoton": [
+      {
+        "cask": "font-monoton",
+        "count": "72"
+      }
+    ],
+    "font-monsieur-la-doulaise": [
+      {
+        "cask": "font-monsieur-la-doulaise",
+        "count": "25"
+      }
+    ],
+    "font-montaga": [
+      {
+        "cask": "font-montaga",
+        "count": "46"
+      }
+    ],
+    "font-montez": [
+      {
+        "cask": "font-montez",
+        "count": "44"
+      }
+    ],
+    "font-montserrat": [
+      {
+        "cask": "font-montserrat",
+        "count": "598"
+      }
+    ],
+    "font-montserrat-subrayada": [
+      {
+        "cask": "font-montserrat-subrayada",
+        "count": "34"
+      }
+    ],
+    "font-moul": [
+      {
+        "cask": "font-moul",
+        "count": "22"
+      }
+    ],
+    "font-moulpali": [
+      {
+        "cask": "font-moulpali",
+        "count": "1"
+      }
+    ],
+    "font-mountains-of-christmas": [
+      {
+        "cask": "font-mountains-of-christmas",
+        "count": "49"
+      }
+    ],
+    "font-mouse-memoirs": [
+      {
+        "cask": "font-mouse-memoirs",
+        "count": "44"
+      }
+    ],
+    "font-mplus-1mn-nerd-font-mono": [
+      {
+        "cask": "font-mplus-1mn-nerd-font-mono",
+        "count": "7"
+      }
+    ],
+    "font-mplus-1mn-nerd-mono": [
+      {
+        "cask": "font-mplus-1mn-nerd-mono",
+        "count": "150"
+      }
+    ],
+    "font-mplus-nerd-font": [
+      {
+        "cask": "font-mplus-nerd-font",
+        "count": "325"
+      }
+    ],
+    "font-mplus-nerd-font-mono": [
+      {
+        "cask": "font-mplus-nerd-font-mono",
+        "count": "270"
+      }
+    ],
+    "font-mr-bedfort": [
+      {
+        "cask": "font-mr-bedfort",
+        "count": "45"
+      }
+    ],
+    "font-mr-dafoe": [
+      {
+        "cask": "font-mr-dafoe",
+        "count": "21"
+      }
+    ],
+    "font-mr-de-haviland": [
+      {
+        "cask": "font-mr-de-haviland",
+        "count": "1"
+      }
+    ],
+    "font-mrs-saint-delafield": [
+      {
+        "cask": "font-mrs-saint-delafield",
+        "count": "42"
+      }
+    ],
+    "font-mrs-sheppards": [
+      {
+        "cask": "font-mrs-sheppards",
+        "count": "22"
+      }
+    ],
+    "font-mukti-narrow": [
+      {
+        "cask": "font-mukti-narrow",
+        "count": "21"
+      }
+    ],
+    "font-muli": [
+      {
+        "cask": "font-muli",
+        "count": "100"
+      }
+    ],
+    "font-museo": [
+      {
+        "cask": "font-museo",
+        "count": "47"
+      }
+    ],
+    "font-myrica": [
+      {
+        "cask": "font-myrica",
+        "count": "250"
+      }
+    ],
+    "font-myrica@2.012.20180119": [
+      {
+        "cask": "font-myrica@2.012.20180119",
+        "count": "1"
+      }
+    ],
+    "font-myricam": [
+      {
+        "cask": "font-myricam",
+        "count": "174"
+      }
+    ],
+    "font-myricam@2.012.20180119": [
+      {
+        "cask": "font-myricam@2.012.20180119",
+        "count": "1"
+      }
+    ],
+    "font-mystery-quest": [
+      {
+        "cask": "font-mystery-quest",
+        "count": "50"
+      }
+    ],
+    "font-n-gage": [
+      {
+        "cask": "font-n-gage",
+        "count": "23"
+      }
+    ],
+    "font-nanumbarungothic": [
+      {
+        "cask": "font-nanumbarungothic",
+        "count": "1"
+      }
+    ],
+    "font-nanumgothic": [
+      {
+        "cask": "font-nanumgothic",
+        "count": "134"
+      }
+    ],
+    "font-nanumgothiccoding": [
+      {
+        "cask": "font-nanumgothiccoding",
+        "count": "177"
+      }
+    ],
+    "font-nanummyeongjo": [
+      {
+        "cask": "font-nanummyeongjo",
+        "count": "83"
+      }
+    ],
+    "font-nanumsquare": [
+      {
+        "cask": "font-nanumsquare",
+        "count": "3"
+      }
+    ],
+    "font-nanumsquare-round": [
+      {
+        "cask": "font-nanumsquare-round",
+        "count": "3"
+      }
+    ],
+    "font-national-park": [
+      {
+        "cask": "font-national-park",
+        "count": "49"
+      }
+    ],
+    "font-neodunggeunmo": [
+      {
+        "cask": "font-neodunggeunmo",
+        "count": "27"
+      }
+    ],
+    "font-neodunggeunmo-code": [
+      {
+        "cask": "font-neodunggeunmo-code",
+        "count": "32"
+      }
+    ],
+    "font-neucha": [
+      {
+        "cask": "font-neucha",
+        "count": "28"
+      }
+    ],
+    "font-neue-plak": [
+      {
+        "cask": "font-neue-plak",
+        "count": "7"
+      }
+    ],
+    "font-neuton": [
+      {
+        "cask": "font-neuton",
+        "count": "30"
+      }
+    ],
+    "font-new-athena-unicode": [
+      {
+        "cask": "font-new-athena-unicode",
+        "count": "1"
+      }
+    ],
+    "font-new-rocker": [
+      {
+        "cask": "font-new-rocker",
+        "count": "22"
+      }
+    ],
+    "font-new-york": [
+      {
+        "cask": "font-new-york",
+        "count": "15"
+      }
+    ],
+    "font-news-cycle": [
+      {
+        "cask": "font-news-cycle",
+        "count": "25"
+      }
+    ],
+    "font-niconne": [
+      {
+        "cask": "font-niconne",
+        "count": "27"
+      }
+    ],
+    "font-nimbus-sans-l": [
+      {
+        "cask": "font-nimbus-sans-l",
+        "count": "14"
+      }
+    ],
+    "font-nixie-one": [
+      {
+        "cask": "font-nixie-one",
+        "count": "143"
+      }
+    ],
+    "font-nobile": [
+      {
+        "cask": "font-nobile",
+        "count": "25"
+      }
+    ],
+    "font-nokora": [
+      {
+        "cask": "font-nokora",
+        "count": "24"
+      }
+    ],
+    "font-norican": [
+      {
+        "cask": "font-norican",
+        "count": "26"
+      }
+    ],
+    "font-norwester": [
+      {
+        "cask": "font-norwester",
+        "count": "1"
+      }
+    ],
+    "font-nosifer": [
+      {
+        "cask": "font-nosifer",
+        "count": "44"
+      }
+    ],
+    "font-nothing-you-could-do": [
+      {
+        "cask": "font-nothing-you-could-do",
+        "count": "27"
+      }
+    ],
+    "font-noticia-text": [
+      {
+        "cask": "font-noticia-text",
+        "count": "26"
+      }
+    ],
+    "font-noto-color-emoji": [
+      {
+        "cask": "font-noto-color-emoji",
+        "count": "247"
+      }
+    ],
+    "font-noto-emoji": [
+      {
+        "cask": "font-noto-emoji",
+        "count": "214"
+      }
+    ],
+    "font-noto-kufi-arabic": [
+      {
+        "cask": "font-noto-kufi-arabic",
+        "count": "38"
+      }
+    ],
+    "font-noto-mono": [
+      {
+        "cask": "font-noto-mono",
+        "count": "371"
+      }
+    ],
+    "font-noto-mono-for-powerline": [
+      {
+        "cask": "font-noto-mono-for-powerline",
+        "count": "722"
+      }
+    ],
+    "font-noto-naskh-arabic": [
+      {
+        "cask": "font-noto-naskh-arabic",
+        "count": "41"
+      }
+    ],
+    "font-noto-nastaliq-urdu": [
+      {
+        "cask": "font-noto-nastaliq-urdu",
+        "count": "39"
+      }
+    ],
+    "font-noto-nerd-font": [
+      {
+        "cask": "font-noto-nerd-font",
+        "count": "372"
+      }
+    ],
+    "font-noto-nerd-font-mono": [
+      {
+        "cask": "font-noto-nerd-font-mono",
+        "count": "310"
+      }
+    ],
+    "font-noto-sans": [
+      {
+        "cask": "font-noto-sans",
+        "count": "738"
+      }
+    ],
+    "font-noto-sans-adlam": [
+      {
+        "cask": "font-noto-sans-adlam",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-adlam-unjoined": [
+      {
+        "cask": "font-noto-sans-adlam-unjoined",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-anatolian-hieroglyphs": [
+      {
+        "cask": "font-noto-sans-anatolian-hieroglyphs",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-arabic": [
+      {
+        "cask": "font-noto-sans-arabic",
+        "count": "41"
+      }
+    ],
+    "font-noto-sans-armenian": [
+      {
+        "cask": "font-noto-sans-armenian",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-avestan": [
+      {
+        "cask": "font-noto-sans-avestan",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-balinese": [
+      {
+        "cask": "font-noto-sans-balinese",
+        "count": "40"
+      }
+    ],
+    "font-noto-sans-bamum": [
+      {
+        "cask": "font-noto-sans-bamum",
+        "count": "39"
+      }
+    ],
+    "font-noto-sans-batak": [
+      {
+        "cask": "font-noto-sans-batak",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-bengali": [
+      {
+        "cask": "font-noto-sans-bengali",
+        "count": "39"
+      }
+    ],
+    "font-noto-sans-brahmi": [
+      {
+        "cask": "font-noto-sans-brahmi",
+        "count": "40"
+      }
+    ],
+    "font-noto-sans-buginese": [
+      {
+        "cask": "font-noto-sans-buginese",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-buhid": [
+      {
+        "cask": "font-noto-sans-buhid",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-canadian-aboriginal": [
+      {
+        "cask": "font-noto-sans-canadian-aboriginal",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-carian": [
+      {
+        "cask": "font-noto-sans-carian",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-chakma": [
+      {
+        "cask": "font-noto-sans-chakma",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-cham": [
+      {
+        "cask": "font-noto-sans-cham",
+        "count": "48"
+      }
+    ],
+    "font-noto-sans-cherokee": [
+      {
+        "cask": "font-noto-sans-cherokee",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-cjk": [
+      {
+        "cask": "font-noto-sans-cjk",
+        "count": "402"
+      }
+    ],
+    "font-noto-sans-cjk-jp": [
+      {
+        "cask": "font-noto-sans-cjk-jp",
+        "count": "734"
+      }
+    ],
+    "font-noto-sans-cjk-kr": [
+      {
+        "cask": "font-noto-sans-cjk-kr",
+        "count": "156"
+      }
+    ],
+    "font-noto-sans-cjk-sc": [
+      {
+        "cask": "font-noto-sans-cjk-sc",
+        "count": "125"
+      }
+    ],
+    "font-noto-sans-cjk-tc": [
+      {
+        "cask": "font-noto-sans-cjk-tc",
+        "count": "170"
+      }
+    ],
+    "font-noto-sans-coptic": [
+      {
+        "cask": "font-noto-sans-coptic",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-cuneiform": [
+      {
+        "cask": "font-noto-sans-cuneiform",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-cypriot": [
+      {
+        "cask": "font-noto-sans-cypriot",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-deseret": [
+      {
+        "cask": "font-noto-sans-deseret",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-devanagari": [
+      {
+        "cask": "font-noto-sans-devanagari",
+        "count": "48"
+      }
+    ],
+    "font-noto-sans-display": [
+      {
+        "cask": "font-noto-sans-display",
+        "count": "75"
+      }
+    ],
+    "font-noto-sans-egyptian-hieroglyphs": [
+      {
+        "cask": "font-noto-sans-egyptian-hieroglyphs",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-ethiopic": [
+      {
+        "cask": "font-noto-sans-ethiopic",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-georgian": [
+      {
+        "cask": "font-noto-sans-georgian",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-glagolitic": [
+      {
+        "cask": "font-noto-sans-glagolitic",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-gothic": [
+      {
+        "cask": "font-noto-sans-gothic",
+        "count": "58"
+      }
+    ],
+    "font-noto-sans-gujarati": [
+      {
+        "cask": "font-noto-sans-gujarati",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-gurmukhi": [
+      {
+        "cask": "font-noto-sans-gurmukhi",
+        "count": "41"
+      }
+    ],
+    "font-noto-sans-hanunoo": [
+      {
+        "cask": "font-noto-sans-hanunoo",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-hebrew": [
+      {
+        "cask": "font-noto-sans-hebrew",
+        "count": "45"
+      }
+    ],
+    "font-noto-sans-imperial-aramaic": [
+      {
+        "cask": "font-noto-sans-imperial-aramaic",
+        "count": "31"
+      }
+    ],
+    "font-noto-sans-inscriptional-pahlavi": [
+      {
+        "cask": "font-noto-sans-inscriptional-pahlavi",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-inscriptional-parthian": [
+      {
+        "cask": "font-noto-sans-inscriptional-parthian",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-javanese": [
+      {
+        "cask": "font-noto-sans-javanese",
+        "count": "40"
+      }
+    ],
+    "font-noto-sans-kaithi": [
+      {
+        "cask": "font-noto-sans-kaithi",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-kannada": [
+      {
+        "cask": "font-noto-sans-kannada",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-kayah-li": [
+      {
+        "cask": "font-noto-sans-kayah-li",
+        "count": "32"
+      }
+    ],
+    "font-noto-sans-kharoshthi": [
+      {
+        "cask": "font-noto-sans-kharoshthi",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-khmer": [
+      {
+        "cask": "font-noto-sans-khmer",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-lao": [
+      {
+        "cask": "font-noto-sans-lao",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-lepcha": [
+      {
+        "cask": "font-noto-sans-lepcha",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-limbu": [
+      {
+        "cask": "font-noto-sans-limbu",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-linear-b": [
+      {
+        "cask": "font-noto-sans-linear-b",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-lisu": [
+      {
+        "cask": "font-noto-sans-lisu",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-lycian": [
+      {
+        "cask": "font-noto-sans-lycian",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-lydian": [
+      {
+        "cask": "font-noto-sans-lydian",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-malayalam": [
+      {
+        "cask": "font-noto-sans-malayalam",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-mandaic": [
+      {
+        "cask": "font-noto-sans-mandaic",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-meetei-mayek": [
+      {
+        "cask": "font-noto-sans-meetei-mayek",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-mongolian": [
+      {
+        "cask": "font-noto-sans-mongolian",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-mono": [
+      {
+        "cask": "font-noto-sans-mono",
+        "count": "215"
+      }
+    ],
+    "font-noto-sans-myanmar": [
+      {
+        "cask": "font-noto-sans-myanmar",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-n-ko": [
+      {
+        "cask": "font-noto-sans-n-ko",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-new-tai-lue": [
+      {
+        "cask": "font-noto-sans-new-tai-lue",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-ogham": [
+      {
+        "cask": "font-noto-sans-ogham",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-ol-chiki": [
+      {
+        "cask": "font-noto-sans-ol-chiki",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-old-italic": [
+      {
+        "cask": "font-noto-sans-old-italic",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-old-persian": [
+      {
+        "cask": "font-noto-sans-old-persian",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-old-south-arabian": [
+      {
+        "cask": "font-noto-sans-old-south-arabian",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-old-turkic": [
+      {
+        "cask": "font-noto-sans-old-turkic",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-oriya": [
+      {
+        "cask": "font-noto-sans-oriya",
+        "count": "39"
+      }
+    ],
+    "font-noto-sans-osage": [
+      {
+        "cask": "font-noto-sans-osage",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-osmanya": [
+      {
+        "cask": "font-noto-sans-osmanya",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-phags-pa": [
+      {
+        "cask": "font-noto-sans-phags-pa",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-phoenician": [
+      {
+        "cask": "font-noto-sans-phoenician",
+        "count": "39"
+      }
+    ],
+    "font-noto-sans-rejang": [
+      {
+        "cask": "font-noto-sans-rejang",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-runic": [
+      {
+        "cask": "font-noto-sans-runic",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-samaritan": [
+      {
+        "cask": "font-noto-sans-samaritan",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-saurashtra": [
+      {
+        "cask": "font-noto-sans-saurashtra",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-shavian": [
+      {
+        "cask": "font-noto-sans-shavian",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-sinhala": [
+      {
+        "cask": "font-noto-sans-sinhala",
+        "count": "40"
+      }
+    ],
+    "font-noto-sans-sundanese": [
+      {
+        "cask": "font-noto-sans-sundanese",
+        "count": "37"
+      }
+    ],
+    "font-noto-sans-syloti-nagri": [
+      {
+        "cask": "font-noto-sans-syloti-nagri",
+        "count": "38"
+      }
+    ],
+    "font-noto-sans-symbols": [
+      {
+        "cask": "font-noto-sans-symbols",
+        "count": "71"
+      }
+    ],
+    "font-noto-sans-symbols2": [
+      {
+        "cask": "font-noto-sans-symbols2",
+        "count": "66"
+      }
+    ],
+    "font-noto-sans-syriac-eastern": [
+      {
+        "cask": "font-noto-sans-syriac-eastern",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-syriac-estrangela": [
+      {
+        "cask": "font-noto-sans-syriac-estrangela",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-syriac-western": [
+      {
+        "cask": "font-noto-sans-syriac-western",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-tagalog": [
+      {
+        "cask": "font-noto-sans-tagalog",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-tagbanwa": [
+      {
+        "cask": "font-noto-sans-tagbanwa",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-tai-le": [
+      {
+        "cask": "font-noto-sans-tai-le",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-tai-tham": [
+      {
+        "cask": "font-noto-sans-tai-tham",
+        "count": "33"
+      }
+    ],
+    "font-noto-sans-tai-viet": [
+      {
+        "cask": "font-noto-sans-tai-viet",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-tamil": [
+      {
+        "cask": "font-noto-sans-tamil",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-telugu": [
+      {
+        "cask": "font-noto-sans-telugu",
+        "count": "39"
+      }
+    ],
+    "font-noto-sans-thaana": [
+      {
+        "cask": "font-noto-sans-thaana",
+        "count": "34"
+      }
+    ],
+    "font-noto-sans-thai": [
+      {
+        "cask": "font-noto-sans-thai",
+        "count": "45"
+      }
+    ],
+    "font-noto-sans-tibetan": [
+      {
+        "cask": "font-noto-sans-tibetan",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-tifinagh": [
+      {
+        "cask": "font-noto-sans-tifinagh",
+        "count": "36"
+      }
+    ],
+    "font-noto-sans-ugaritic": [
+      {
+        "cask": "font-noto-sans-ugaritic",
+        "count": "35"
+      }
+    ],
+    "font-noto-sans-vai": [
+      {
+        "cask": "font-noto-sans-vai",
+        "count": "32"
+      }
+    ],
+    "font-noto-sans-yi": [
+      {
+        "cask": "font-noto-sans-yi",
+        "count": "35"
+      }
+    ],
+    "font-noto-serif": [
+      {
+        "cask": "font-noto-serif",
+        "count": "460"
+      }
+    ],
+    "font-noto-serif-armenian": [
+      {
+        "cask": "font-noto-serif-armenian",
+        "count": "34"
+      }
+    ],
+    "font-noto-serif-bengali": [
+      {
+        "cask": "font-noto-serif-bengali",
+        "count": "37"
+      }
+    ],
+    "font-noto-serif-cjk": [
+      {
+        "cask": "font-noto-serif-cjk",
+        "count": "288"
+      }
+    ],
+    "font-noto-serif-cjk-jp": [
+      {
+        "cask": "font-noto-serif-cjk-jp",
+        "count": "403"
+      }
+    ],
+    "font-noto-serif-cjk-kr": [
+      {
+        "cask": "font-noto-serif-cjk-kr",
+        "count": "130"
+      }
+    ],
+    "font-noto-serif-cjk-sc": [
+      {
+        "cask": "font-noto-serif-cjk-sc",
+        "count": "87"
+      }
+    ],
+    "font-noto-serif-cjk-tc": [
+      {
+        "cask": "font-noto-serif-cjk-tc",
+        "count": "157"
+      }
+    ],
+    "font-noto-serif-devanagari": [
+      {
+        "cask": "font-noto-serif-devanagari",
+        "count": "45"
+      }
+    ],
+    "font-noto-serif-display": [
+      {
+        "cask": "font-noto-serif-display",
+        "count": "56"
+      }
+    ],
+    "font-noto-serif-ethiopic": [
+      {
+        "cask": "font-noto-serif-ethiopic",
+        "count": "35"
+      }
+    ],
+    "font-noto-serif-georgian": [
+      {
+        "cask": "font-noto-serif-georgian",
+        "count": "2"
+      }
+    ],
+    "font-noto-serif-gujarati": [
+      {
+        "cask": "font-noto-serif-gujarati",
+        "count": "34"
+      }
+    ],
+    "font-noto-serif-hebrew": [
+      {
+        "cask": "font-noto-serif-hebrew",
+        "count": "41"
+      }
+    ],
+    "font-noto-serif-kannada": [
+      {
+        "cask": "font-noto-serif-kannada",
+        "count": "35"
+      }
+    ],
+    "font-noto-serif-khmer": [
+      {
+        "cask": "font-noto-serif-khmer",
+        "count": "34"
+      }
+    ],
+    "font-noto-serif-lao": [
+      {
+        "cask": "font-noto-serif-lao",
+        "count": "34"
+      }
+    ],
+    "font-noto-serif-malayalam": [
+      {
+        "cask": "font-noto-serif-malayalam",
+        "count": "34"
+      }
+    ],
+    "font-noto-serif-myanmar": [
+      {
+        "cask": "font-noto-serif-myanmar",
+        "count": "33"
+      }
+    ],
+    "font-noto-serif-sinhala": [
+      {
+        "cask": "font-noto-serif-sinhala",
+        "count": "36"
+      }
+    ],
+    "font-noto-serif-tamil": [
+      {
+        "cask": "font-noto-serif-tamil",
+        "count": "36"
+      }
+    ],
+    "font-noto-serif-telugu": [
+      {
+        "cask": "font-noto-serif-telugu",
+        "count": "37"
+      }
+    ],
+    "font-noto-serif-thai": [
+      {
+        "cask": "font-noto-serif-thai",
+        "count": "41"
+      }
+    ],
+    "font-nova-cut": [
+      {
+        "cask": "font-nova-cut",
+        "count": "25"
+      }
+    ],
+    "font-nova-flat": [
+      {
+        "cask": "font-nova-flat",
+        "count": "26"
+      }
+    ],
+    "font-nova-mono": [
+      {
+        "cask": "font-nova-mono",
+        "count": "102"
+      }
+    ],
+    "font-nova-oval": [
+      {
+        "cask": "font-nova-oval",
+        "count": "26"
+      }
+    ],
+    "font-nova-round": [
+      {
+        "cask": "font-nova-round",
+        "count": "24"
+      }
+    ],
+    "font-nova-script": [
+      {
+        "cask": "font-nova-script",
+        "count": "27"
+      }
+    ],
+    "font-nova-slim": [
+      {
+        "cask": "font-nova-slim",
+        "count": "24"
+      }
+    ],
+    "font-nova-square": [
+      {
+        "cask": "font-nova-square",
+        "count": "26"
+      }
+    ],
+    "font-nunito": [
+      {
+        "cask": "font-nunito",
+        "count": "174"
+      }
+    ],
+    "font-ocr": [
+      {
+        "cask": "font-ocr",
+        "count": "48"
+      }
+    ],
+    "font-octicons": [
+      {
+        "cask": "font-octicons",
+        "count": "2"
+      }
+    ],
+    "font-office-code-pro": [
+      {
+        "cask": "font-office-code-pro",
+        "count": "346"
+      }
+    ],
+    "font-old-standard-tt": [
+      {
+        "cask": "font-old-standard-tt",
+        "count": "53"
+      }
+    ],
+    "font-oleo-script": [
+      {
+        "cask": "font-oleo-script",
+        "count": "1"
+      }
+    ],
+    "font-open-huninn": [
+      {
+        "cask": "font-open-huninn",
+        "count": "4"
+      }
+    ],
+    "font-open-iconic": [
+      {
+        "cask": "font-open-iconic",
+        "count": "40"
+      }
+    ],
+    "font-open-khmer-school": [
+      {
+        "cask": "font-open-khmer-school",
+        "count": "3"
+      }
+    ],
+    "font-open-sans": [
+      {
+        "cask": "font-open-sans",
+        "count": "1,591"
+      }
+    ],
+    "font-open-sans-condensed": [
+      {
+        "cask": "font-open-sans-condensed",
+        "count": "326"
+      }
+    ],
+    "font-open-sans-hebrew": [
+      {
+        "cask": "font-open-sans-hebrew",
+        "count": "37"
+      }
+    ],
+    "font-open-sans-hebrew-condensed": [
+      {
+        "cask": "font-open-sans-hebrew-condensed",
+        "count": "32"
+      }
+    ],
+    "font-opendyslexic": [
+      {
+        "cask": "font-opendyslexic",
+        "count": "290"
+      }
+    ],
+    "font-opendyslexic-nerd-font": [
+      {
+        "cask": "font-opendyslexic-nerd-font",
+        "count": "18"
+      }
+    ],
+    "font-operator-mono": [
+      {
+        "cask": "font-operator-mono",
+        "count": "1"
+      }
+    ],
+    "font-operator-pro": [
+      {
+        "cask": "font-operator-pro",
+        "count": "1"
+      }
+    ],
+    "font-optician-sans": [
+      {
+        "cask": "font-optician-sans",
+        "count": "24"
+      }
+    ],
+    "font-oranienbaum": [
+      {
+        "cask": "font-oranienbaum",
+        "count": "44"
+      }
+    ],
+    "font-orbitron": [
+      {
+        "cask": "font-orbitron",
+        "count": "28"
+      }
+    ],
+    "font-original-surfer": [
+      {
+        "cask": "font-original-surfer",
+        "count": "4"
+      }
+    ],
+    "font-ostrich-sans": [
+      {
+        "cask": "font-ostrich-sans",
+        "count": "27"
+      }
+    ],
+    "font-oswald": [
+      {
+        "cask": "font-oswald",
+        "count": "199"
+      }
+    ],
+    "font-overlock": [
+      {
+        "cask": "font-overlock",
+        "count": "48"
+      }
+    ],
+    "font-overlock-sc": [
+      {
+        "cask": "font-overlock-sc",
+        "count": "43"
+      }
+    ],
+    "font-overpass": [
+      {
+        "cask": "font-overpass",
+        "count": "207"
+      }
+    ],
+    "font-overpass-nerd-font": [
+      {
+        "cask": "font-overpass-nerd-font",
+        "count": "27"
+      }
+    ],
+    "font-oxygen": [
+      {
+        "cask": "font-oxygen",
+        "count": "58"
+      }
+    ],
+    "font-oxygen-mono": [
+      {
+        "cask": "font-oxygen-mono",
+        "count": "98"
+      }
+    ],
+    "font-pacifico": [
+      {
+        "cask": "font-pacifico",
+        "count": "67"
+      }
+    ],
+    "font-padauk": [
+      {
+        "cask": "font-padauk",
+        "count": "41"
+      }
+    ],
+    "font-paprika": [
+      {
+        "cask": "font-paprika",
+        "count": "2"
+      }
+    ],
+    "font-parisienne": [
+      {
+        "cask": "font-parisienne",
+        "count": "1"
+      }
+    ],
+    "font-passion-one": [
+      {
+        "cask": "font-passion-one",
+        "count": "43"
+      }
+    ],
+    "font-patrick-hand": [
+      {
+        "cask": "font-patrick-hand",
+        "count": "1"
+      }
+    ],
+    "font-patua-one": [
+      {
+        "cask": "font-patua-one",
+        "count": "27"
+      }
+    ],
+    "font-permanent-marker": [
+      {
+        "cask": "font-permanent-marker",
+        "count": "50"
+      }
+    ],
+    "font-petit-formal-script": [
+      {
+        "cask": "font-petit-formal-script",
+        "count": "214"
+      }
+    ],
+    "font-plaster": [
+      {
+        "cask": "font-plaster",
+        "count": "4"
+      }
+    ],
+    "font-playfair-display": [
+      {
+        "cask": "font-playfair-display",
+        "count": "152"
+      }
+    ],
+    "font-playfair-display-sc": [
+      {
+        "cask": "font-playfair-display-sc",
+        "count": "35"
+      }
+    ],
+    "font-poiret-one": [
+      {
+        "cask": "font-poiret-one",
+        "count": "47"
+      }
+    ],
+    "font-poller-one": [
+      {
+        "cask": "font-poller-one",
+        "count": "43"
+      }
+    ],
+    "font-poly": [
+      {
+        "cask": "font-poly",
+        "count": "1"
+      }
+    ],
+    "font-pompiere": [
+      {
+        "cask": "font-pompiere",
+        "count": "4"
+      }
+    ],
+    "font-poppins": [
+      {
+        "cask": "font-poppins",
+        "count": "220"
+      }
+    ],
+    "font-poppins-latin": [
+      {
+        "cask": "font-poppins-latin",
+        "count": "27"
+      }
+    ],
+    "font-powerline-symbols": [
+      {
+        "cask": "font-powerline-symbols",
+        "count": "2,192"
+      }
+    ],
+    "font-prata": [
+      {
+        "cask": "font-prata",
+        "count": "44"
+      }
+    ],
+    "font-press-start2p": [
+      {
+        "cask": "font-press-start2p",
+        "count": "34"
+      }
+    ],
+    "font-princess-sofia": [
+      {
+        "cask": "font-princess-sofia",
+        "count": "44"
+      }
+    ],
+    "font-prociono": [
+      {
+        "cask": "font-prociono",
+        "count": "45"
+      }
+    ],
+    "font-profont-nerd-font": [
+      {
+        "cask": "font-profont-nerd-font",
+        "count": "398"
+      }
+    ],
+    "font-profont-nerd-font-mono": [
+      {
+        "cask": "font-profont-nerd-font-mono",
+        "count": "312"
+      }
+    ],
+    "font-profontx": [
+      {
+        "cask": "font-profontx",
+        "count": "45"
+      }
+    ],
+    "font-proggyclean-nerd-font": [
+      {
+        "cask": "font-proggyclean-nerd-font",
+        "count": "314"
+      }
+    ],
+    "font-proggyclean-nerd-font-mono": [
+      {
+        "cask": "font-proggyclean-nerd-font-mono",
+        "count": "308"
+      }
+    ],
+    "font-proggycleantt-nerd-font": [
+      {
+        "cask": "font-proggycleantt-nerd-font",
+        "count": "22"
+      }
+    ],
+    "font-proza-libre": [
+      {
+        "cask": "font-proza-libre",
+        "count": "26"
+      }
+    ],
+    "font-pt-mono": [
+      {
+        "cask": "font-pt-mono",
+        "count": "253"
+      }
+    ],
+    "font-pt-sans": [
+      {
+        "cask": "font-pt-sans",
+        "count": "188"
+      }
+    ],
+    "font-pt-serif": [
+      {
+        "cask": "font-pt-serif",
+        "count": "138"
+      }
+    ],
+    "font-public-sans": [
+      {
+        "cask": "font-public-sans",
+        "count": "120"
+      }
+    ],
+    "font-purple-purse": [
+      {
+        "cask": "font-purple-purse",
+        "count": "4"
+      }
+    ],
+    "font-px437-pxplus": [
+      {
+        "cask": "font-px437-pxplus",
+        "count": "36"
+      }
+    ],
+    "font-quando": [
+      {
+        "cask": "font-quando",
+        "count": "4"
+      }
+    ],
+    "font-quattrocento": [
+      {
+        "cask": "font-quattrocento",
+        "count": "48"
+      }
+    ],
+    "font-quattrocento-sans": [
+      {
+        "cask": "font-quattrocento-sans",
+        "count": "58"
+      }
+    ],
+    "font-quebec-serial": [
+      {
+        "cask": "font-quebec-serial",
+        "count": "3"
+      }
+    ],
+    "font-questrial": [
+      {
+        "cask": "font-questrial",
+        "count": "49"
+      }
+    ],
+    "font-quicksand": [
+      {
+        "cask": "font-quicksand",
+        "count": "170"
+      }
+    ],
+    "font-quivira": [
+      {
+        "cask": "font-quivira",
+        "count": "1"
+      }
+    ],
+    "font-radley": [
+      {
+        "cask": "font-radley",
+        "count": "4"
+      }
+    ],
+    "font-rajdhani": [
+      {
+        "cask": "font-rajdhani",
+        "count": "29"
+      }
+    ],
+    "font-raleway": [
+      {
+        "cask": "font-raleway",
+        "count": "484"
+      }
+    ],
+    "font-raleway-dots": [
+      {
+        "cask": "font-raleway-dots",
+        "count": "78"
+      }
+    ],
+    "font-rambla": [
+      {
+        "cask": "font-rambla",
+        "count": "2"
+      }
+    ],
+    "font-rammetto-one": [
+      {
+        "cask": "font-rammetto-one",
+        "count": "4"
+      }
+    ],
+    "font-ranchers": [
+      {
+        "cask": "font-ranchers",
+        "count": "42"
+      }
+    ],
+    "font-ranga": [
+      {
+        "cask": "font-ranga",
+        "count": "3"
+      }
+    ],
+    "font-rebellion-icons": [
+      {
+        "cask": "font-rebellion-icons",
+        "count": "1"
+      }
+    ],
+    "font-redacted": [
+      {
+        "cask": "font-redacted",
+        "count": "30"
+      }
+    ],
+    "font-redhat": [
+      {
+        "cask": "font-redhat",
+        "count": "141"
+      }
+    ],
+    "font-ribeye": [
+      {
+        "cask": "font-ribeye",
+        "count": "40"
+      }
+    ],
+    "font-ribeye-marrow": [
+      {
+        "cask": "font-ribeye-marrow",
+        "count": "41"
+      }
+    ],
+    "font-ricty-diminished": [
+      {
+        "cask": "font-ricty-diminished",
+        "count": "1,487"
+      }
+    ],
+    "font-ricty-diminished-nerd-font": [
+      {
+        "cask": "font-ricty-diminished-nerd-font",
+        "count": "1"
+      }
+    ],
+    "font-ricty-diminished@4.1.1": [
+      {
+        "cask": "font-ricty-diminished@4.1.1",
+        "count": "1"
+      }
+    ],
+    "font-ricty_diminished-devicon": [
+      {
+        "cask": "font-ricty_diminished-devicon",
+        "count": "3"
+      }
+    ],
+    "font-righteous": [
+      {
+        "cask": "font-righteous",
+        "count": "43"
+      }
+    ],
+    "font-risque": [
+      {
+        "cask": "font-risque",
+        "count": "4"
+      }
+    ],
+    "font-roboto": [
+      {
+        "cask": "font-roboto",
+        "count": "3,026"
+      }
+    ],
+    "font-roboto-condensed": [
+      {
+        "cask": "font-roboto-condensed",
+        "count": "793"
+      }
+    ],
+    "font-roboto-mono": [
+      {
+        "cask": "font-roboto-mono",
+        "count": "1,731"
+      }
+    ],
+    "font-roboto-mono-for-powerline": [
+      {
+        "cask": "font-roboto-mono-for-powerline",
+        "count": "1,538"
+      }
+    ],
+    "font-roboto-slab": [
+      {
+        "cask": "font-roboto-slab",
+        "count": "375"
+      }
+    ],
+    "font-robotomono-nerd-font": [
+      {
+        "cask": "font-robotomono-nerd-font",
+        "count": "957"
+      }
+    ],
+    "font-robotomono-nerd-font-mono": [
+      {
+        "cask": "font-robotomono-nerd-font-mono",
+        "count": "735"
+      }
+    ],
+    "font-rock-salt": [
+      {
+        "cask": "font-rock-salt",
+        "count": "11"
+      }
+    ],
+    "font-rosarivo": [
+      {
+        "cask": "font-rosarivo",
+        "count": "1"
+      }
+    ],
+    "font-rounded-m-plus": [
+      {
+        "cask": "font-rounded-m-plus",
+        "count": "49"
+      }
+    ],
+    "font-routed-gothic": [
+      {
+        "cask": "font-routed-gothic",
+        "count": "14"
+      }
+    ],
+    "font-rozha-one": [
+      {
+        "cask": "font-rozha-one",
+        "count": "4"
+      }
+    ],
+    "font-rubik": [
+      {
+        "cask": "font-rubik",
+        "count": "133"
+      }
+    ],
+    "font-ruda": [
+      {
+        "cask": "font-ruda",
+        "count": "2"
+      }
+    ],
+    "font-ruda-black": [
+      {
+        "cask": "font-ruda-black",
+        "count": "1"
+      }
+    ],
+    "font-ruda-bold": [
+      {
+        "cask": "font-ruda-bold",
+        "count": "1"
+      }
+    ],
+    "font-sacramento": [
+      {
+        "cask": "font-sacramento",
+        "count": "55"
+      }
+    ],
+    "font-saira": [
+      {
+        "cask": "font-saira",
+        "count": "1"
+      }
+    ],
+    "font-san-francisco-compact": [
+      {
+        "cask": "font-san-francisco-compact",
+        "count": "13"
+      }
+    ],
+    "font-san-francisco-pro": [
+      {
+        "cask": "font-san-francisco-pro",
+        "count": "20"
+      }
+    ],
+    "font-sanchez": [
+      {
+        "cask": "font-sanchez",
+        "count": "1"
+      }
+    ],
+    "font-sanfrancisco": [
+      {
+        "cask": "font-sanfrancisco",
+        "count": "9"
+      }
+    ],
+    "font-sans-forgetica": [
+      {
+        "cask": "font-sans-forgetica",
+        "count": "92"
+      }
+    ],
+    "font-sarasa-gothic": [
+      {
+        "cask": "font-sarasa-gothic",
+        "count": "498"
+      }
+    ],
+    "font-satisfy": [
+      {
+        "cask": "font-satisfy",
+        "count": "56"
+      }
+    ],
+    "font-saucecodepro-nerd-font": [
+      {
+        "cask": "font-saucecodepro-nerd-font",
+        "count": "256"
+      }
+    ],
+    "font-scheherazade": [
+      {
+        "cask": "font-scheherazade",
+        "count": "27"
+      }
+    ],
+    "font-script12-bt": [
+      {
+        "cask": "font-script12-bt",
+        "count": "2"
+      }
+    ],
+    "font-seymour-one": [
+      {
+        "cask": "font-seymour-one",
+        "count": "4"
+      }
+    ],
+    "font-sf-compact": [
+      {
+        "cask": "font-sf-compact",
+        "count": "8"
+      }
+    ],
+    "font-sf-mono": [
+      {
+        "cask": "font-sf-mono",
+        "count": "17"
+      }
+    ],
+    "font-sf-mono-nerd-font": [
+      {
+        "cask": "font-sf-mono-nerd-font",
+        "count": "49"
+      }
+    ],
+    "font-sf-mono-powerline": [
+      {
+        "cask": "font-sf-mono-powerline",
+        "count": "2"
+      }
+    ],
+    "font-sf-pro": [
+      {
+        "cask": "font-sf-pro",
+        "count": "8"
+      }
+    ],
+    "font-shadows-into-light-two": [
+      {
+        "cask": "font-shadows-into-light-two",
+        "count": "26"
+      }
+    ],
+    "font-share": [
+      {
+        "cask": "font-share",
+        "count": "25"
+      }
+    ],
+    "font-share-tech": [
+      {
+        "cask": "font-share-tech",
+        "count": "32"
+      }
+    ],
+    "font-share-tech-mono": [
+      {
+        "cask": "font-share-tech-mono",
+        "count": "72"
+      }
+    ],
+    "font-sharetechmono-nerd-font": [
+      {
+        "cask": "font-sharetechmono-nerd-font",
+        "count": "224"
+      }
+    ],
+    "font-sharetechmono-nerd-font-mono": [
+      {
+        "cask": "font-sharetechmono-nerd-font-mono",
+        "count": "228"
+      }
+    ],
+    "font-shuretechmono-nerd-font": [
+      {
+        "cask": "font-shuretechmono-nerd-font",
+        "count": "17"
+      }
+    ],
+    "font-sigmar-one": [
+      {
+        "cask": "font-sigmar-one",
+        "count": "40"
+      }
+    ],
+    "font-simhei": [
+      {
+        "cask": "font-simhei",
+        "count": "7"
+      }
+    ],
+    "font-simonetta": [
+      {
+        "cask": "font-simonetta",
+        "count": "39"
+      }
+    ],
+    "font-simple-line-icons": [
+      {
+        "cask": "font-simple-line-icons",
+        "count": "80"
+      }
+    ],
+    "font-simsun": [
+      {
+        "cask": "font-simsun",
+        "count": "7"
+      }
+    ],
+    "font-sirin-stencil": [
+      {
+        "cask": "font-sirin-stencil",
+        "count": "1"
+      }
+    ],
+    "font-six-caps": [
+      {
+        "cask": "font-six-caps",
+        "count": "39"
+      }
+    ],
+    "font-slackey": [
+      {
+        "cask": "font-slackey",
+        "count": "4"
+      }
+    ],
+    "font-sniglet": [
+      {
+        "cask": "font-sniglet",
+        "count": "22"
+      }
+    ],
+    "font-snowburst-one": [
+      {
+        "cask": "font-snowburst-one",
+        "count": "4"
+      }
+    ],
+    "font-sonsie-one": [
+      {
+        "cask": "font-sonsie-one",
+        "count": "4"
+      }
+    ],
+    "font-sorts-mill-goudy": [
+      {
+        "cask": "font-sorts-mill-goudy",
+        "count": "37"
+      }
+    ],
+    "font-source-code-pro": [
+      {
+        "cask": "font-source-code-pro",
+        "count": "17,368"
+      }
+    ],
+    "font-source-code-pro-for-powerline": [
+      {
+        "cask": "font-source-code-pro-for-powerline",
+        "count": "4,090"
+      }
+    ],
+    "font-source-han-code-jp": [
+      {
+        "cask": "font-source-han-code-jp",
+        "count": "1,093"
+      }
+    ],
+    "font-source-han-mono": [
+      {
+        "cask": "font-source-han-mono",
+        "count": "134"
+      }
+    ],
+    "font-source-han-noto-cjk": [
+      {
+        "cask": "font-source-han-noto-cjk",
+        "count": "160"
+      }
+    ],
+    "font-source-han-sans": [
+      {
+        "cask": "font-source-han-sans",
+        "count": "608"
+      }
+    ],
+    "font-source-han-serif": [
+      {
+        "cask": "font-source-han-serif",
+        "count": "301"
+      }
+    ],
+    "font-source-han-serif-el-m": [
+      {
+        "cask": "font-source-han-serif-el-m",
+        "count": "57"
+      }
+    ],
+    "font-source-han-serif-sb-h": [
+      {
+        "cask": "font-source-han-serif-sb-h",
+        "count": "56"
+      }
+    ],
+    "font-source-sans-pro": [
+      {
+        "cask": "font-source-sans-pro",
+        "count": "1,727"
+      }
+    ],
+    "font-source-serif-pro": [
+      {
+        "cask": "font-source-serif-pro",
+        "count": "1,139"
+      }
+    ],
+    "font-sourcecodepro-nerd-font": [
+      {
+        "cask": "font-sourcecodepro-nerd-font",
+        "count": "8,186"
+      }
+    ],
+    "font-sourcecodepro-nerd-font-mono": [
+      {
+        "cask": "font-sourcecodepro-nerd-font-mono",
+        "count": "1,535"
+      }
+    ],
+    "font-space-grotesk": [
+      {
+        "cask": "font-space-grotesk",
+        "count": "49"
+      }
+    ],
+    "font-space-mono": [
+      {
+        "cask": "font-space-mono",
+        "count": "231"
+      }
+    ],
+    "font-spacemono-nerd-font": [
+      {
+        "cask": "font-spacemono-nerd-font",
+        "count": "522"
+      }
+    ],
+    "font-spacemono-nerd-font-mono": [
+      {
+        "cask": "font-spacemono-nerd-font-mono",
+        "count": "331"
+      }
+    ],
+    "font-special-elite": [
+      {
+        "cask": "font-special-elite",
+        "count": "52"
+      }
+    ],
+    "font-spectral": [
+      {
+        "cask": "font-spectral",
+        "count": "40"
+      }
+    ],
+    "font-spirax": [
+      {
+        "cask": "font-spirax",
+        "count": "4"
+      }
+    ],
+    "font-spleen": [
+      {
+        "cask": "font-spleen",
+        "count": "38"
+      }
+    ],
+    "font-sriracha": [
+      {
+        "cask": "font-sriracha",
+        "count": "2"
+      }
+    ],
+    "font-stint-ultra-condensed": [
+      {
+        "cask": "font-stint-ultra-condensed",
+        "count": "4"
+      }
+    ],
+    "font-stint-ultra-expanded": [
+      {
+        "cask": "font-stint-ultra-expanded",
+        "count": "4"
+      }
+    ],
+    "font-stix": [
+      {
+        "cask": "font-stix",
+        "count": "55"
+      }
+    ],
+    "font-sudo": [
+      {
+        "cask": "font-sudo",
+        "count": "165"
+      }
+    ],
+    "font-symbola": [
+      {
+        "cask": "font-symbola",
+        "count": "125"
+      }
+    ],
+    "font-syncopate": [
+      {
+        "cask": "font-syncopate",
+        "count": "4"
+      }
+    ],
+    "font-takaoex": [
+      {
+        "cask": "font-takaoex",
+        "count": "33"
+      }
+    ],
+    "font-tangerine": [
+      {
+        "cask": "font-tangerine",
+        "count": "22"
+      }
+    ],
+    "font-techna-sans": [
+      {
+        "cask": "font-techna-sans",
+        "count": "3"
+      }
+    ],
+    "font-teko": [
+      {
+        "cask": "font-teko",
+        "count": "2"
+      }
+    ],
+    "font-terminessttf-nerd-font": [
+      {
+        "cask": "font-terminessttf-nerd-font",
+        "count": "23"
+      }
+    ],
+    "font-terminus": [
+      {
+        "cask": "font-terminus",
+        "count": "543"
+      }
+    ],
+    "font-terminus-nerd-font": [
+      {
+        "cask": "font-terminus-nerd-font",
+        "count": "497"
+      }
+    ],
+    "font-terminus-nerd-font-mono": [
+      {
+        "cask": "font-terminus-nerd-font-mono",
+        "count": "463"
+      }
+    ],
+    "font-tex-gyre-adventor": [
+      {
+        "cask": "font-tex-gyre-adventor",
+        "count": "64"
+      }
+    ],
+    "font-tex-gyre-bonum": [
+      {
+        "cask": "font-tex-gyre-bonum",
+        "count": "57"
+      }
+    ],
+    "font-tex-gyre-bonum-math": [
+      {
+        "cask": "font-tex-gyre-bonum-math",
+        "count": "46"
+      }
+    ],
+    "font-tex-gyre-chorus": [
+      {
+        "cask": "font-tex-gyre-chorus",
+        "count": "54"
+      }
+    ],
+    "font-tex-gyre-cursor": [
+      {
+        "cask": "font-tex-gyre-cursor",
+        "count": "65"
+      }
+    ],
+    "font-tex-gyre-heros": [
+      {
+        "cask": "font-tex-gyre-heros",
+        "count": "76"
+      }
+    ],
+    "font-tex-gyre-pagella": [
+      {
+        "cask": "font-tex-gyre-pagella",
+        "count": "96"
+      }
+    ],
+    "font-tex-gyre-pagella-math": [
+      {
+        "cask": "font-tex-gyre-pagella-math",
+        "count": "85"
+      }
+    ],
+    "font-tex-gyre-schola": [
+      {
+        "cask": "font-tex-gyre-schola",
+        "count": "66"
+      }
+    ],
+    "font-tex-gyre-schola-math": [
+      {
+        "cask": "font-tex-gyre-schola-math",
+        "count": "51"
+      }
+    ],
+    "font-tex-gyre-termes": [
+      {
+        "cask": "font-tex-gyre-termes",
+        "count": "74"
+      }
+    ],
+    "font-tex-gyre-termes-math": [
+      {
+        "cask": "font-tex-gyre-termes-math",
+        "count": "51"
+      }
+    ],
+    "font-the-faceshop": [
+      {
+        "cask": "font-the-faceshop",
+        "count": "1"
+      }
+    ],
+    "font-the-girl-next-door": [
+      {
+        "cask": "font-the-girl-next-door",
+        "count": "38"
+      }
+    ],
+    "font-thesansuhh": [
+      {
+        "cask": "font-thesansuhh",
+        "count": "1"
+      }
+    ],
+    "font-tillium-web": [
+      {
+        "cask": "font-tillium-web",
+        "count": "2"
+      }
+    ],
+    "font-times-new-roman": [
+      {
+        "cask": "font-times-new-roman",
+        "count": "69"
+      }
+    ],
+    "font-tinos-nerd-font": [
+      {
+        "cask": "font-tinos-nerd-font",
+        "count": "222"
+      }
+    ],
+    "font-tinos-nerd-font-mono": [
+      {
+        "cask": "font-tinos-nerd-font-mono",
+        "count": "203"
+      }
+    ],
+    "font-titillium": [
+      {
+        "cask": "font-titillium",
+        "count": "58"
+      }
+    ],
+    "font-trebuchet-ms": [
+      {
+        "cask": "font-trebuchet-ms",
+        "count": "47"
+      }
+    ],
+    "font-tulpen-one": [
+      {
+        "cask": "font-tulpen-one",
+        "count": "42"
+      }
+    ],
+    "font-twitter-color-emoji": [
+      {
+        "cask": "font-twitter-color-emoji",
+        "count": "133"
+      }
+    ],
+    "font-ubuntu": [
+      {
+        "cask": "font-ubuntu",
+        "count": "999"
+      }
+    ],
+    "font-ubuntu-mono-derivative-powerline": [
+      {
+        "cask": "font-ubuntu-mono-derivative-powerline",
+        "count": "882"
+      }
+    ],
+    "font-ubuntu-nerd-font": [
+      {
+        "cask": "font-ubuntu-nerd-font",
+        "count": "624"
+      }
+    ],
+    "font-ubuntu-nerd-font-mono": [
+      {
+        "cask": "font-ubuntu-nerd-font-mono",
+        "count": "401"
+      }
+    ],
+    "font-ubuntumono-nerd-font": [
+      {
+        "cask": "font-ubuntumono-nerd-font",
+        "count": "782"
+      }
+    ],
+    "font-ubuntumono-nerd-font-mono": [
+      {
+        "cask": "font-ubuntumono-nerd-font-mono",
+        "count": "453"
+      }
+    ],
+    "font-ultra": [
+      {
+        "cask": "font-ultra",
+        "count": "4"
+      }
+    ],
+    "font-uncial-antiqua": [
+      {
+        "cask": "font-uncial-antiqua",
+        "count": "4"
+      }
+    ],
+    "font-urw-base35": [
+      {
+        "cask": "font-urw-base35",
+        "count": "34"
+      }
+    ],
+    "font-varela": [
+      {
+        "cask": "font-varela",
+        "count": "3"
+      }
+    ],
+    "font-varela-round": [
+      {
+        "cask": "font-varela-round",
+        "count": "25"
+      }
+    ],
+    "font-vast-shadow": [
+      {
+        "cask": "font-vast-shadow",
+        "count": "4"
+      }
+    ],
+    "font-verdana": [
+      {
+        "cask": "font-verdana",
+        "count": "42"
+      }
+    ],
+    "font-victor-mono": [
+      {
+        "cask": "font-victor-mono",
+        "count": "3,213"
+      }
+    ],
+    "font-victormono-nerd-font": [
+      {
+        "cask": "font-victormono-nerd-font",
+        "count": "49"
+      }
+    ],
+    "font-vidaloka": [
+      {
+        "cask": "font-vidaloka",
+        "count": "37"
+      }
+    ],
+    "font-vlgothic": [
+      {
+        "cask": "font-vlgothic",
+        "count": "3"
+      }
+    ],
+    "font-voces": [
+      {
+        "cask": "font-voces",
+        "count": "1"
+      }
+    ],
+    "font-volkhov": [
+      {
+        "cask": "font-volkhov",
+        "count": "42"
+      }
+    ],
+    "font-vollkorn": [
+      {
+        "cask": "font-vollkorn",
+        "count": "97"
+      }
+    ],
+    "font-vt323": [
+      {
+        "cask": "font-vt323",
+        "count": "33"
+      }
+    ],
+    "font-wendy-one": [
+      {
+        "cask": "font-wendy-one",
+        "count": "4"
+      }
+    ],
+    "font-wenquanyi-micro-hei": [
+      {
+        "cask": "font-wenquanyi-micro-hei",
+        "count": "29"
+      }
+    ],
+    "font-wenquanyi-zen-hei": [
+      {
+        "cask": "font-wenquanyi-zen-hei",
+        "count": "28"
+      }
+    ],
+    "font-wire-one": [
+      {
+        "cask": "font-wire-one",
+        "count": "36"
+      }
+    ],
+    "font-work-sans": [
+      {
+        "cask": "font-work-sans",
+        "count": "136"
+      }
+    ],
+    "font-xits": [
+      {
+        "cask": "font-xits",
+        "count": "76"
+      }
+    ],
+    "font-xkcd": [
+      {
+        "cask": "font-xkcd",
+        "count": "81"
+      }
+    ],
+    "font-xkcd-script": [
+      {
+        "cask": "font-xkcd-script",
+        "count": "68"
+      }
+    ],
+    "font-yanone-kaffeesatz": [
+      {
+        "cask": "font-yanone-kaffeesatz",
+        "count": "1"
+      }
+    ],
+    "font-yellowtail": [
+      {
+        "cask": "font-yellowtail",
+        "count": "20"
+      }
+    ],
+    "font-yorkten": [
+      {
+        "cask": "font-yorkten",
+        "count": "4"
+      }
+    ],
+    "font-ysabeau": [
+      {
+        "cask": "font-ysabeau",
+        "count": "14"
+      }
+    ],
+    "font-zcool-qingke-huangyou": [
+      {
+        "cask": "font-zcool-qingke-huangyou",
+        "count": "3"
+      }
+    ],
+    "font-zilla-slab": [
+      {
+        "cask": "font-zilla-slab",
+        "count": "51"
+      }
+    ],
+    "fontbase": [
+      {
+        "cask": "fontbase",
+        "count": "573"
+      }
+    ],
+    "fontexplorer-x-pro": [
+      {
+        "cask": "fontexplorer-x-pro",
+        "count": "190"
+      }
+    ],
+    "fontforge": [
+      {
+        "cask": "fontforge",
+        "count": "3,556"
+      }
+    ],
+    "fontgoggles": [
+      {
+        "cask": "fontgoggles",
+        "count": "108"
+      }
+    ],
+    "fontlab": [
+      {
+        "cask": "fontlab",
+        "count": "45"
+      }
+    ],
+    "fontplop": [
+      {
+        "cask": "fontplop",
+        "count": "293"
+      }
+    ],
+    "fontprep": [
+      {
+        "cask": "fontprep",
+        "count": "3"
+      }
+    ],
+    "fontstand": [
+      {
+        "cask": "fontstand",
+        "count": "24"
+      }
+    ],
+    "foo": [
+      {
+        "cask": "foo",
+        "count": "11"
+      }
+    ],
+    "foobar2000": [
+      {
+        "cask": "foobar2000",
+        "count": "8"
+      }
+    ],
+    "force-paste": [
+      {
+        "cask": "force-paste",
+        "count": "233"
+      }
+    ],
+    "forecast": [
+      {
+        "cask": "forecast",
+        "count": "79"
+      }
+    ],
+    "foreman": [
+      {
+        "cask": "foreman",
+        "count": "467"
+      }
+    ],
+    "fork": [
+      {
+        "cask": "fork",
+        "count": "11,426"
+      }
+    ],
+    "forklift": [
+      {
+        "cask": "forklift",
+        "count": "2,886"
+      }
+    ],
+    "forklift-beta": [
+      {
+        "cask": "forklift-beta",
+        "count": "10"
+      }
+    ],
+    "forklift2": [
+      {
+        "cask": "forklift2",
+        "count": "57"
+      }
+    ],
+    "forticlient": [
+      {
+        "cask": "forticlient",
+        "count": "2,089"
+      }
+    ],
+    "forticlientvpn": [
+      {
+        "cask": "forticlientvpn",
+        "count": "20"
+      }
+    ],
+    "foundationdb": [
+      {
+        "cask": "foundationdb",
+        "count": "3"
+      }
+    ],
+    "foundationdb-document-layer": [
+      {
+        "cask": "foundationdb-document-layer",
+        "count": "1"
+      }
+    ],
+    "fox": [
+      {
+        "cask": "fox",
+        "count": "3"
+      }
+    ],
+    "foxitreader": [
+      {
+        "cask": "foxitreader",
+        "count": "1,158"
+      }
+    ],
+    "foxmail": [
+      {
+        "cask": "foxmail",
+        "count": "518"
+      }
+    ],
+    "fpcsrc": [
+      {
+        "cask": "fpcsrc",
+        "count": "709"
+      }
+    ],
+    "fractal-bot": [
+      {
+        "cask": "fractal-bot",
+        "count": "7"
+      }
+    ],
+    "fraise": [
+      {
+        "cask": "fraise",
+        "count": "1"
+      }
+    ],
+    "framer": [
+      {
+        "cask": "framer",
+        "count": "72"
+      }
+    ],
+    "framer-x": [
+      {
+        "cask": "framer-x",
+        "count": "305"
+      }
+    ],
+    "franz": [
+      {
+        "cask": "franz",
+        "count": "4,734"
+      }
+    ],
+    "frc2019": [
+      {
+        "cask": "frc2019",
+        "count": "9"
+      }
+    ],
+    "freac": [
+      {
+        "cask": "freac",
+        "count": "437"
+      }
+    ],
+    "fredm-fuse": [
+      {
+        "cask": "fredm-fuse",
+        "count": "26"
+      }
+    ],
+    "free-download-manager": [
+      {
+        "cask": "free-download-manager",
+        "count": "1,392"
+      }
+    ],
+    "free-ruler": [
+      {
+        "cask": "free-ruler",
+        "count": "295"
+      }
+    ],
+    "free87-fr-comp": [
+      {
+        "cask": "free87-fr-comp",
+        "count": "3"
+      }
+    ],
+    "free87-fr-equa": [
+      {
+        "cask": "free87-fr-equa",
+        "count": "3"
+      }
+    ],
+    "free87-fr-gate": [
+      {
+        "cask": "free87-fr-gate",
+        "count": "3"
+      }
+    ],
+    "free87-fr-limit": [
+      {
+        "cask": "free87-fr-limit",
+        "count": "3"
+      }
+    ],
+    "freealpha": [
+      {
+        "cask": "freealpha",
+        "count": "3"
+      }
+    ],
+    "freecad": [
+      {
+        "cask": "freecad",
+        "count": "2,197"
+      }
+    ],
+    "freecad-asm3": [
+      {
+        "cask": "freecad-asm3",
+        "count": "1"
+      }
+    ],
+    "freecad-beta": [
+      {
+        "cask": "freecad-beta",
+        "count": "1"
+      }
+    ],
+    "freecad-dev": [
+      {
+        "cask": "freecad-dev",
+        "count": "1"
+      }
+    ],
+    "freecad-manual": [
+      {
+        "cask": "freecad-manual",
+        "count": "1"
+      }
+    ],
+    "freecad-nightly": [
+      {
+        "cask": "freecad-nightly",
+        "count": "3"
+      }
+    ],
+    "freeclip": [
+      {
+        "cask": "freeclip",
+        "count": "3"
+      }
+    ],
+    "freecol": [
+      {
+        "cask": "freecol",
+        "count": "51"
+      }
+    ],
+    "freedom": [
+      {
+        "cask": "freedom",
+        "count": "205"
+      }
+    ],
+    "freedome": [
+      {
+        "cask": "freedome",
+        "count": "88"
+      }
+    ],
+    "freefilesync": [
+      {
+        "cask": "freefilesync",
+        "count": "37"
+      }
+    ],
+    "freemind": [
+      {
+        "cask": "freemind",
+        "count": "1,531"
+      }
+    ],
+    "freenettray": [
+      {
+        "cask": "freenettray",
+        "count": "78"
+      }
+    ],
+    "freeorion": [
+      {
+        "cask": "freeorion",
+        "count": "30"
+      }
+    ],
+    "freeplane": [
+      {
+        "cask": "freeplane",
+        "count": "853"
+      }
+    ],
+    "freeshuttercounter": [
+      {
+        "cask": "freeshuttercounter",
+        "count": "2"
+      }
+    ],
+    "freesmug-chromium": [
+      {
+        "cask": "freesmug-chromium",
+        "count": "758"
+      }
+    ],
+    "freeswitch": [
+      {
+        "cask": "freeswitch",
+        "count": "2"
+      }
+    ],
+    "freeter": [
+      {
+        "cask": "freeter",
+        "count": "70"
+      }
+    ],
+    "freeyourmusic": [
+      {
+        "cask": "freeyourmusic",
+        "count": "42"
+      }
+    ],
+    "freeze": [
+      {
+        "cask": "freeze",
+        "count": "231"
+      }
+    ],
+    "frequency-shifter": [
+      {
+        "cask": "frequency-shifter",
+        "count": "4"
+      }
+    ],
+    "frescobaldi": [
+      {
+        "cask": "frescobaldi",
+        "count": "421"
+      }
+    ],
+    "fresh": [
+      {
+        "cask": "fresh",
+        "count": "2"
+      }
+    ],
+    "freshback": [
+      {
+        "cask": "freshback",
+        "count": "9"
+      }
+    ],
+    "frhelper": [
+      {
+        "cask": "frhelper",
+        "count": "76"
+      }
+    ],
+    "fritzing": [
+      {
+        "cask": "fritzing",
+        "count": "1,773"
+      }
+    ],
+    "fromscratch": [
+      {
+        "cask": "fromscratch",
+        "count": "107"
+      }
+    ],
+    "front": [
+      {
+        "cask": "front",
+        "count": "144"
+      }
+    ],
+    "fruit": [
+      {
+        "cask": "fruit",
+        "count": "2"
+      }
+    ],
+    "fs-uae": [
+      {
+        "cask": "fs-uae",
+        "count": "178"
+      }
+    ],
+    "fsmonitor": [
+      {
+        "cask": "fsmonitor",
+        "count": "123"
+      }
+    ],
+    "fsnotes": [
+      {
+        "cask": "fsnotes",
+        "count": "2,545"
+      }
+    ],
+    "fspviewer": [
+      {
+        "cask": "fspviewer",
+        "count": "3"
+      }
+    ],
+    "fstream": [
+      {
+        "cask": "fstream",
+        "count": "42"
+      }
+    ],
+    "ftdi-vcp-driver": [
+      {
+        "cask": "ftdi-vcp-driver",
+        "count": "287"
+      }
+    ],
+    "fugu": [
+      {
+        "cask": "fugu",
+        "count": "1,111"
+      }
+    ],
+    "fujifilm-x-raw-studio": [
+      {
+        "cask": "fujifilm-x-raw-studio",
+        "count": "7"
+      }
+    ],
+    "fujitsu-scansnap-home": [
+      {
+        "cask": "fujitsu-scansnap-home",
+        "count": "89"
+      }
+    ],
+    "fujitsu-scansnap-manager": [
+      {
+        "cask": "fujitsu-scansnap-manager",
+        "count": "66"
+      }
+    ],
+    "fujitsu-scansnap-manager-ix100": [
+      {
+        "cask": "fujitsu-scansnap-manager-ix100",
+        "count": "1"
+      }
+    ],
+    "fujitsu-scansnap-manager-ix500": [
+      {
+        "cask": "fujitsu-scansnap-manager-ix500",
+        "count": "82"
+      }
+    ],
+    "fujitsu-scansnap-manager-s1300": [
+      {
+        "cask": "fujitsu-scansnap-manager-s1300",
+        "count": "30"
+      }
+    ],
+    "full-bucket-brigade-delay": [
+      {
+        "cask": "full-bucket-brigade-delay",
+        "count": "4"
+      }
+    ],
+    "full-bucket-mps": [
+      {
+        "cask": "full-bucket-mps",
+        "count": "5"
+      }
+    ],
+    "full-bucket-phaser": [
+      {
+        "cask": "full-bucket-phaser",
+        "count": "4"
+      }
+    ],
+    "functionflip": [
+      {
+        "cask": "functionflip",
+        "count": "62"
+      }
+    ],
+    "functiontoggler": [
+      {
+        "cask": "functiontoggler",
+        "count": "5"
+      }
+    ],
+    "funter": [
+      {
+        "cask": "funter",
+        "count": "229"
+      }
+    ],
+    "fuse": [
+      {
+        "cask": "fuse",
+        "count": "1,872"
+      }
+    ],
+    "futuniuniu": [
+      {
+        "cask": "futuniuniu",
+        "count": "154"
+      }
+    ],
+    "fuwari": [
+      {
+        "cask": "fuwari",
+        "count": "29"
+      }
+    ],
+    "fuzzyclock": [
+      {
+        "cask": "fuzzyclock",
+        "count": "30"
+      }
+    ],
+    "fvim": [
+      {
+        "cask": "fvim",
+        "count": "7"
+      }
+    ],
+    "fwbuilder": [
+      {
+        "cask": "fwbuilder",
+        "count": "27"
+      }
+    ],
+    "fxcastbridge": [
+      {
+        "cask": "fxcastbridge",
+        "count": "2"
+      }
+    ],
+    "g-raid-with-thunderbolt-configurator": [
+      {
+        "cask": "g-raid-with-thunderbolt-configurator",
+        "count": "3"
+      }
+    ],
+    "gambit": [
+      {
+        "cask": "gambit",
+        "count": "11"
+      }
+    ],
+    "gameranger": [
+      {
+        "cask": "gameranger",
+        "count": "28"
+      }
+    ],
+    "gameshow": [
+      {
+        "cask": "gameshow",
+        "count": "13"
+      }
+    ],
+    "ganache": [
+      {
+        "cask": "ganache",
+        "count": "507"
+      }
+    ],
+    "ganttproject": [
+      {
+        "cask": "ganttproject",
+        "count": "712"
+      }
+    ],
+    "gapid": [
+      {
+        "cask": "gapid",
+        "count": "1"
+      }
+    ],
+    "garagebuy": [
+      {
+        "cask": "garagebuy",
+        "count": "23"
+      }
+    ],
+    "garagesale": [
+      {
+        "cask": "garagesale",
+        "count": "47"
+      }
+    ],
+    "gargoyle": [
+      {
+        "cask": "gargoyle",
+        "count": "68"
+      }
+    ],
+    "garmin-basecamp": [
+      {
+        "cask": "garmin-basecamp",
+        "count": "157"
+      }
+    ],
+    "garmin-express": [
+      {
+        "cask": "garmin-express",
+        "count": "755"
+      }
+    ],
+    "garmin-fresh": [
+      {
+        "cask": "garmin-fresh",
+        "count": "5"
+      }
+    ],
+    "garmin-virb-edit": [
+      {
+        "cask": "garmin-virb-edit",
+        "count": "11"
+      }
+    ],
+    "gas-mask": [
+      {
+        "cask": "gas-mask",
+        "count": "1,955"
+      }
+    ],
+    "gaston": [
+      {
+        "cask": "gaston",
+        "count": "1"
+      }
+    ],
+    "gawker": [
+      {
+        "cask": "gawker",
+        "count": "12"
+      }
+    ],
+    "gb-studio": [
+      {
+        "cask": "gb-studio",
+        "count": "50"
+      }
+    ],
+    "gcc-arm-embedded": [
+      {
+        "cask": "gcc-arm-embedded",
+        "count": "2,389"
+      }
+    ],
+    "gcc-arm-embedded-2017q2": [
+      {
+        "cask": "gcc-arm-embedded-2017q2",
+        "count": "3"
+      }
+    ],
+    "gcc-arm-embedded-2017q4": [
+      {
+        "cask": "gcc-arm-embedded-2017q4",
+        "count": "1"
+      }
+    ],
+    "gcc-arm-embedded-2019q3": [
+      {
+        "cask": "gcc-arm-embedded-2019q3",
+        "count": "1"
+      }
+    ],
+    "gcc-arm-embedded-2019q4": [
+      {
+        "cask": "gcc-arm-embedded-2019q4",
+        "count": "2"
+      }
+    ],
+    "gcc-arm-embedded-4_9-2015q3": [
+      {
+        "cask": "gcc-arm-embedded-4_9-2015q3",
+        "count": "1"
+      }
+    ],
+    "gcc-arm-embedded-8-2018-q4-major": [
+      {
+        "cask": "gcc-arm-embedded-8-2018-q4-major",
+        "count": "1"
+      }
+    ],
+    "gcc-riscv-embedded": [
+      {
+        "cask": "gcc-riscv-embedded",
+        "count": "1"
+      }
+    ],
+    "gcollazo-mongodb": [
+      {
+        "cask": "gcollazo-mongodb",
+        "count": "300"
+      }
+    ],
+    "gdisk": [
+      {
+        "cask": "gdisk",
+        "count": "1,295"
+      }
+    ],
+    "gdlauncher": [
+      {
+        "cask": "gdlauncher",
+        "count": "3"
+      }
+    ],
+    "geany": [
+      {
+        "cask": "geany",
+        "count": "2,456"
+      }
+    ],
+    "gear-player": [
+      {
+        "cask": "gear-player",
+        "count": "2"
+      }
+    ],
+    "gear360-scripts": [
+      {
+        "cask": "gear360-scripts",
+        "count": "22"
+      }
+    ],
+    "gearboy": [
+      {
+        "cask": "gearboy",
+        "count": "22"
+      }
+    ],
+    "gearsystem": [
+      {
+        "cask": "gearsystem",
+        "count": "6"
+      }
+    ],
+    "geburtstagschecker": [
+      {
+        "cask": "geburtstagschecker",
+        "count": "66"
+      }
+    ],
+    "geekbench": [
+      {
+        "cask": "geekbench",
+        "count": "3,224"
+      }
+    ],
+    "geektool": [
+      {
+        "cask": "geektool",
+        "count": "689"
+      }
+    ],
+    "gemini": [
+      {
+        "cask": "gemini",
+        "count": "636"
+      }
+    ],
+    "gemini-classic": [
+      {
+        "cask": "gemini-classic",
+        "count": "3"
+      }
+    ],
+    "geneious-prime": [
+      {
+        "cask": "geneious-prime",
+        "count": "5"
+      }
+    ],
+    "geniatech-eyetv": [
+      {
+        "cask": "geniatech-eyetv",
+        "count": "16"
+      }
+    ],
+    "genome-workbench": [
+      {
+        "cask": "genome-workbench",
+        "count": "1"
+      }
+    ],
+    "genymotion": [
+      {
+        "cask": "genymotion",
+        "count": "1,844"
+      }
+    ],
+    "genymotion@3.0.2": [
+      {
+        "cask": "genymotion@3.0.2",
+        "count": "5"
+      }
+    ],
+    "geoda": [
+      {
+        "cask": "geoda",
+        "count": "9"
+      }
+    ],
+    "geogebra": [
+      {
+        "cask": "geogebra",
+        "count": "716"
+      }
+    ],
+    "geomap": [
+      {
+        "cask": "geomap",
+        "count": "53"
+      }
+    ],
+    "geotag": [
+      {
+        "cask": "geotag",
+        "count": "100"
+      }
+    ],
+    "geotag-photos-pro": [
+      {
+        "cask": "geotag-photos-pro",
+        "count": "16"
+      }
+    ],
+    "geotagger": [
+      {
+        "cask": "geotagger",
+        "count": "8"
+      }
+    ],
+    "geph": [
+      {
+        "cask": "geph",
+        "count": "42"
+      }
+    ],
+    "gephi": [
+      {
+        "cask": "gephi",
+        "count": "797"
+      }
+    ],
+    "gerrit-jarvis": [
+      {
+        "cask": "gerrit-jarvis",
+        "count": "1"
+      }
+    ],
+    "get-backup-pro": [
+      {
+        "cask": "get-backup-pro",
+        "count": "73"
+      }
+    ],
+    "get-iplayer-automator": [
+      {
+        "cask": "get-iplayer-automator",
+        "count": "89"
+      }
+    ],
+    "get-lyrical": [
+      {
+        "cask": "get-lyrical",
+        "count": "62"
+      }
+    ],
+    "getrasplex": [
+      {
+        "cask": "getrasplex",
+        "count": "13"
+      }
+    ],
+    "gfortran": [
+      {
+        "cask": "gfortran",
+        "count": "6,259"
+      }
+    ],
+    "gfxcardstatus": [
+      {
+        "cask": "gfxcardstatus",
+        "count": "1,126"
+      }
+    ],
+    "ggobi": [
+      {
+        "cask": "ggobi",
+        "count": "1"
+      }
+    ],
+    "ghdl": [
+      {
+        "cask": "ghdl",
+        "count": "72"
+      }
+    ],
+    "ghidra": [
+      {
+        "cask": "ghidra",
+        "count": "2,320"
+      }
+    ],
+    "ghidra-beta": [
+      {
+        "cask": "ghidra-beta",
+        "count": "20"
+      }
+    ],
+    "ghost": [
+      {
+        "cask": "ghost",
+        "count": "214"
+      }
+    ],
+    "ghost-browser": [
+      {
+        "cask": "ghost-browser",
+        "count": "79"
+      }
+    ],
+    "ghostlab": [
+      {
+        "cask": "ghostlab",
+        "count": "23"
+      }
+    ],
+    "ghosttile": [
+      {
+        "cask": "ghosttile",
+        "count": "79"
+      }
+    ],
+    "gifcapture": [
+      {
+        "cask": "gifcapture",
+        "count": "861"
+      }
+    ],
+    "gifox": [
+      {
+        "cask": "gifox",
+        "count": "620"
+      }
+    ],
+    "gifrocket": [
+      {
+        "cask": "gifrocket",
+        "count": "237"
+      }
+    ],
+    "gifs": [
+      {
+        "cask": "gifs",
+        "count": "62"
+      }
+    ],
+    "gimme-quote": [
+      {
+        "cask": "gimme-quote",
+        "count": "3"
+      }
+    ],
+    "gimme-quote-desktop": [
+      {
+        "cask": "gimme-quote-desktop",
+        "count": "1"
+      }
+    ],
+    "gimp": [
+      {
+        "cask": "gimp",
+        "count": "42,016"
+      }
+    ],
+    "gimp-2.10.12": [
+      {
+        "cask": "gimp-2.10.12",
+        "count": "1"
+      }
+    ],
+    "gingko": [
+      {
+        "cask": "gingko",
+        "count": "48"
+      }
+    ],
+    "gingr": [
+      {
+        "cask": "gingr",
+        "count": "1"
+      }
+    ],
+    "giphy-anywhere": [
+      {
+        "cask": "giphy-anywhere",
+        "count": "6"
+      }
+    ],
+    "gislook": [
+      {
+        "cask": "gislook",
+        "count": "17"
+      }
+    ],
+    "gisto": [
+      {
+        "cask": "gisto",
+        "count": "332"
+      }
+    ],
+    "git-fork": [
+      {
+        "cask": "git-fork",
+        "count": "2"
+      }
+    ],
+    "git-it": [
+      {
+        "cask": "git-it",
+        "count": "195"
+      }
+    ],
+    "git-store-meta": [
+      {
+        "cask": "git-store-meta",
+        "count": "4"
+      }
+    ],
+    "gitahead": [
+      {
+        "cask": "gitahead",
+        "count": "372"
+      }
+    ],
+    "gitblade": [
+      {
+        "cask": "gitblade",
+        "count": "201"
+      }
+    ],
+    "gitbook": [
+      {
+        "cask": "gitbook",
+        "count": "956"
+      }
+    ],
+    "gitbook-editor": [
+      {
+        "cask": "gitbook-editor",
+        "count": "328"
+      }
+    ],
+    "gitbox": [
+      {
+        "cask": "gitbox",
+        "count": "44"
+      }
+    ],
+    "gitee": [
+      {
+        "cask": "gitee",
+        "count": "52"
+      }
+    ],
+    "giteye": [
+      {
+        "cask": "giteye",
+        "count": "30"
+      }
+    ],
+    "gitfiend": [
+      {
+        "cask": "gitfiend",
+        "count": "5"
+      }
+    ],
+    "gitfinder": [
+      {
+        "cask": "gitfinder",
+        "count": "107"
+      }
+    ],
+    "gitfox": [
+      {
+        "cask": "gitfox",
+        "count": "251"
+      }
+    ],
+    "github": [
+      {
+        "cask": "github",
+        "count": "20,769"
+      }
+    ],
+    "github-beta": [
+      {
+        "cask": "github-beta",
+        "count": "248"
+      }
+    ],
+    "github-desktop": [
+      {
+        "cask": "github-desktop",
+        "count": "93"
+      }
+    ],
+    "githubpulse": [
+      {
+        "cask": "githubpulse",
+        "count": "72"
+      }
+    ],
+    "gitifier": [
+      {
+        "cask": "gitifier",
+        "count": "1"
+      }
+    ],
+    "gitify": [
+      {
+        "cask": "gitify",
+        "count": "995"
+      }
+    ],
+    "gitkraken": [
+      {
+        "cask": "gitkraken",
+        "count": "9,805"
+      }
+    ],
+    "gitkraken60": [
+      {
+        "cask": "gitkraken60",
+        "count": "6"
+      }
+    ],
+    "gitnote": [
+      {
+        "cask": "gitnote",
+        "count": "118"
+      }
+    ],
+    "gitscout": [
+      {
+        "cask": "gitscout",
+        "count": "68"
+      }
+    ],
+    "gitter": [
+      {
+        "cask": "gitter",
+        "count": "1,103"
+      }
+    ],
+    "gitup": [
+      {
+        "cask": "gitup",
+        "count": "2,722"
+      }
+    ],
+    "gitx": [
+      {
+        "cask": "gitx",
+        "count": "1,662"
+      }
+    ],
+    "gitx-gitx": [
+      {
+        "cask": "gitx-gitx",
+        "count": "5"
+      }
+    ],
+    "glimmerblocker": [
+      {
+        "cask": "glimmerblocker",
+        "count": "38"
+      }
+    ],
+    "glip": [
+      {
+        "cask": "glip",
+        "count": "79"
+      }
+    ],
+    "global-relay-message": [
+      {
+        "cask": "global-relay-message",
+        "count": "1"
+      }
+    ],
+    "globalmeet": [
+      {
+        "cask": "globalmeet",
+        "count": "16"
+      }
+    ],
+    "globalprotect": [
+      {
+        "cask": "globalprotect",
+        "count": "27"
+      }
+    ],
+    "gloomhaven-helper": [
+      {
+        "cask": "gloomhaven-helper",
+        "count": "787"
+      }
+    ],
+    "gltfquicklook": [
+      {
+        "cask": "gltfquicklook",
+        "count": "384"
+      }
+    ],
+    "glueprint": [
+      {
+        "cask": "glueprint",
+        "count": "30"
+      }
+    ],
+    "glyphfinder": [
+      {
+        "cask": "glyphfinder",
+        "count": "17"
+      }
+    ],
+    "glyphs": [
+      {
+        "cask": "glyphs",
+        "count": "169"
+      }
+    ],
+    "gmail-notifier": [
+      {
+        "cask": "gmail-notifier",
+        "count": "106"
+      }
+    ],
+    "gmvault": [
+      {
+        "cask": "gmvault",
+        "count": "140"
+      }
+    ],
+    "gnat-community": [
+      {
+        "cask": "gnat-community",
+        "count": "1"
+      }
+    ],
+    "gns3": [
+      {
+        "cask": "gns3",
+        "count": "923"
+      }
+    ],
+    "gnubg": [
+      {
+        "cask": "gnubg",
+        "count": "52"
+      }
+    ],
+    "gnucash": [
+      {
+        "cask": "gnucash",
+        "count": "1,816"
+      }
+    ],
+    "go-agent": [
+      {
+        "cask": "go-agent",
+        "count": "74"
+      }
+    ],
+    "go-agent-18": [
+      {
+        "cask": "go-agent-18",
+        "count": "3"
+      }
+    ],
+    "go-server": [
+      {
+        "cask": "go-server",
+        "count": "33"
+      }
+    ],
+    "go2shell": [
+      {
+        "cask": "go2shell",
+        "count": "2,062"
+      }
+    ],
+    "go64": [
+      {
+        "cask": "go64",
+        "count": "719"
+      }
+    ],
+    "gobbler": [
+      {
+        "cask": "gobbler",
+        "count": "3"
+      }
+    ],
+    "gobdokumente": [
+      {
+        "cask": "gobdokumente",
+        "count": "5"
+      }
+    ],
+    "godot": [
+      {
+        "cask": "godot",
+        "count": "7,677"
+      }
+    ],
+    "godot-mono": [
+      {
+        "cask": "godot-mono",
+        "count": "305"
+      }
+    ],
+    "godot-nightly": [
+      {
+        "cask": "godot-nightly",
+        "count": "8"
+      }
+    ],
+    "gog-downloader": [
+      {
+        "cask": "gog-downloader",
+        "count": "56"
+      }
+    ],
+    "gog-galaxy": [
+      {
+        "cask": "gog-galaxy",
+        "count": "1,264"
+      }
+    ],
+    "gog-galaxy-beta": [
+      {
+        "cask": "gog-galaxy-beta",
+        "count": "5"
+      }
+    ],
+    "gogs": [
+      {
+        "cask": "gogs",
+        "count": "97"
+      }
+    ],
+    "goland": [
+      {
+        "cask": "goland",
+        "count": "6,650"
+      }
+    ],
+    "goldencheetah": [
+      {
+        "cask": "goldencheetah",
+        "count": "125"
+      }
+    ],
+    "goldencheetah-dev": [
+      {
+        "cask": "goldencheetah-dev",
+        "count": "1"
+      }
+    ],
+    "goldendict": [
+      {
+        "cask": "goldendict",
+        "count": "29"
+      }
+    ],
+    "golem": [
+      {
+        "cask": "golem",
+        "count": "753"
+      }
+    ],
+    "golem-mainnet-launcher": [
+      {
+        "cask": "golem-mainnet-launcher",
+        "count": "673"
+      }
+    ],
+    "golly": [
+      {
+        "cask": "golly",
+        "count": "100"
+      }
+    ],
+    "gom-player": [
+      {
+        "cask": "gom-player",
+        "count": "54"
+      }
+    ],
+    "goodhertz-canopener-studio": [
+      {
+        "cask": "goodhertz-canopener-studio",
+        "count": "1"
+      }
+    ],
+    "goodsync": [
+      {
+        "cask": "goodsync",
+        "count": "339"
+      }
+    ],
+    "goodsync-beta": [
+      {
+        "cask": "goodsync-beta",
+        "count": "2"
+      }
+    ],
+    "goofy": [
+      {
+        "cask": "goofy",
+        "count": "616"
+      }
+    ],
+    "google-ads-editor": [
+      {
+        "cask": "google-ads-editor",
+        "count": "878"
+      }
+    ],
+    "google-backup-and-sync": [
+      {
+        "cask": "google-backup-and-sync",
+        "count": "13,470"
+      }
+    ],
+    "google-chat": [
+      {
+        "cask": "google-chat",
+        "count": "2,047"
+      }
+    ],
+    "google-chrome": [
+      {
+        "cask": "google-chrome",
+        "count": "206,850"
+      }
+    ],
+    "google-chrome-beta": [
+      {
+        "cask": "google-chrome-beta",
+        "count": "1,040"
+      }
+    ],
+    "google-chrome-canary": [
+      {
+        "cask": "google-chrome-canary",
+        "count": "6,319"
+      }
+    ],
+    "google-chrome-custom": [
+      {
+        "cask": "google-chrome-custom",
+        "count": "7"
+      }
+    ],
+    "google-chrome-dev": [
+      {
+        "cask": "google-chrome-dev",
+        "count": "1,026"
+      }
+    ],
+    "google-cloud-sdk": [
+      {
+        "cask": "google-cloud-sdk",
+        "count": "55,571"
+      }
+    ],
+    "google-drive-file-stream": [
+      {
+        "cask": "google-drive-file-stream",
+        "count": "13,663"
+      }
+    ],
+    "google-earth-pro": [
+      {
+        "cask": "google-earth-pro",
+        "count": "3,209"
+      }
+    ],
+    "google-featured-photos": [
+      {
+        "cask": "google-featured-photos",
+        "count": "166"
+      }
+    ],
+    "google-hangouts": [
+      {
+        "cask": "google-hangouts",
+        "count": "3,543"
+      }
+    ],
+    "google-japanese-ime": [
+      {
+        "cask": "google-japanese-ime",
+        "count": "5,455"
+      }
+    ],
+    "google-japanese-ime-dev": [
+      {
+        "cask": "google-japanese-ime-dev",
+        "count": "39"
+      }
+    ],
+    "google-nik-collection": [
+      {
+        "cask": "google-nik-collection",
+        "count": "150"
+      }
+    ],
+    "google-notifier": [
+      {
+        "cask": "google-notifier",
+        "count": "51"
+      }
+    ],
+    "google-photos-backup-and-sync": [
+      {
+        "cask": "google-photos-backup-and-sync",
+        "count": "790"
+      }
+    ],
+    "google-trends": [
+      {
+        "cask": "google-trends",
+        "count": "940"
+      }
+    ],
+    "google-web-designer": [
+      {
+        "cask": "google-web-designer",
+        "count": "1,230"
+      }
+    ],
+    "google_drive": [
+      {
+        "cask": "google_drive",
+        "count": "27"
+      }
+    ],
+    "googleappengine": [
+      {
+        "cask": "googleappengine",
+        "count": "165"
+      }
+    ],
+    "gopanda": [
+      {
+        "cask": "gopanda",
+        "count": "33"
+      }
+    ],
+    "gopass-ui": [
+      {
+        "cask": "gopass-ui",
+        "count": "75"
+      }
+    ],
+    "gotiengviet": [
+      {
+        "cask": "gotiengviet",
+        "count": "134"
+      }
+    ],
+    "gpg-suite": [
+      {
+        "cask": "gpg-suite",
+        "count": "13,760"
+      }
+    ],
+    "gpg-suite-nightly": [
+      {
+        "cask": "gpg-suite-nightly",
+        "count": "84"
+      }
+    ],
+    "gpg-suite-no-mail": [
+      {
+        "cask": "gpg-suite-no-mail",
+        "count": "1,987"
+      }
+    ],
+    "gpg-suite-pinentry": [
+      {
+        "cask": "gpg-suite-pinentry",
+        "count": "266"
+      }
+    ],
+    "gpg-sync": [
+      {
+        "cask": "gpg-sync",
+        "count": "151"
+      }
+    ],
+    "gpgtools": [
+      {
+        "cask": "gpgtools",
+        "count": "2"
+      }
+    ],
+    "gplates": [
+      {
+        "cask": "gplates",
+        "count": "3"
+      }
+    ],
+    "gpodder": [
+      {
+        "cask": "gpodder",
+        "count": "200"
+      }
+    ],
+    "gpower": [
+      {
+        "cask": "gpower",
+        "count": "46"
+      }
+    ],
+    "gps4cam": [
+      {
+        "cask": "gps4cam",
+        "count": "6"
+      }
+    ],
+    "gpsdump": [
+      {
+        "cask": "gpsdump",
+        "count": "32"
+      }
+    ],
+    "gputest": [
+      {
+        "cask": "gputest",
+        "count": "2"
+      }
+    ],
+    "gpxsee": [
+      {
+        "cask": "gpxsee",
+        "count": "306"
+      }
+    ],
+    "gqrx": [
+      {
+        "cask": "gqrx",
+        "count": "2,120"
+      }
+    ],
+    "graal-vm": [
+      {
+        "cask": "graal-vm",
+        "count": "1"
+      }
+    ],
+    "graalvm": [
+      {
+        "cask": "graalvm",
+        "count": "2"
+      }
+    ],
+    "graalvm-ce": [
+      {
+        "cask": "graalvm-ce",
+        "count": "751"
+      }
+    ],
+    "graalvm-ce-java11": [
+      {
+        "cask": "graalvm-ce-java11",
+        "count": "1,316"
+      }
+    ],
+    "graalvm-ce-java8": [
+      {
+        "cask": "graalvm-ce-java8",
+        "count": "879"
+      }
+    ],
+    "graalvm-ee-java11": [
+      {
+        "cask": "graalvm-ee-java11",
+        "count": "1"
+      }
+    ],
+    "graalvm-yoco": [
+      {
+        "cask": "graalvm-yoco",
+        "count": "10"
+      }
+    ],
+    "grabber": [
+      {
+        "cask": "grabber",
+        "count": "3"
+      }
+    ],
+    "grabber-dev": [
+      {
+        "cask": "grabber-dev",
+        "count": "1"
+      }
+    ],
+    "grads": [
+      {
+        "cask": "grads",
+        "count": "407"
+      }
+    ],
+    "grads-updated": [
+      {
+        "cask": "grads-updated",
+        "count": "1"
+      }
+    ],
+    "grafx": [
+      {
+        "cask": "grafx",
+        "count": "70"
+      }
+    ],
+    "grakn-workbase": [
+      {
+        "cask": "grakn-workbase",
+        "count": "401"
+      }
+    ],
+    "grammarly": [
+      {
+        "cask": "grammarly",
+        "count": "3,938"
+      }
+    ],
+    "gramps": [
+      {
+        "cask": "gramps",
+        "count": "344"
+      }
+    ],
+    "grandperspective": [
+      {
+        "cask": "grandperspective",
+        "count": "3,979"
+      }
+    ],
+    "grandtotal": [
+      {
+        "cask": "grandtotal",
+        "count": "63"
+      }
+    ],
+    "graphicconverter": [
+      {
+        "cask": "graphicconverter",
+        "count": "245"
+      }
+    ],
+    "graphiql": [
+      {
+        "cask": "graphiql",
+        "count": "14,365"
+      }
+    ],
+    "graphql-ide": [
+      {
+        "cask": "graphql-ide",
+        "count": "184"
+      }
+    ],
+    "graphql-playground": [
+      {
+        "cask": "graphql-playground",
+        "count": "9,481"
+      }
+    ],
+    "graphsketcher": [
+      {
+        "cask": "graphsketcher",
+        "count": "70"
+      }
+    ],
+    "gray": [
+      {
+        "cask": "gray",
+        "count": "528"
+      }
+    ],
+    "greenfoot": [
+      {
+        "cask": "greenfoot",
+        "count": "34"
+      }
+    ],
+    "gretl": [
+      {
+        "cask": "gretl",
+        "count": "71"
+      }
+    ],
+    "gridea": [
+      {
+        "cask": "gridea",
+        "count": "52"
+      }
+    ],
+    "grids": [
+      {
+        "cask": "grids",
+        "count": "41"
+      }
+    ],
+    "grip": [
+      {
+        "cask": "grip",
+        "count": "24"
+      }
+    ],
+    "grisbi": [
+      {
+        "cask": "grisbi",
+        "count": "31"
+      }
+    ],
+    "groove-bpb": [
+      {
+        "cask": "groove-bpb",
+        "count": "3"
+      }
+    ],
+    "growlnotify": [
+      {
+        "cask": "growlnotify",
+        "count": "411"
+      }
+    ],
+    "grpc-java": [
+      {
+        "cask": "grpc-java",
+        "count": "6"
+      }
+    ],
+    "grpc-web": [
+      {
+        "cask": "grpc-web",
+        "count": "14"
+      }
+    ],
+    "gsplus": [
+      {
+        "cask": "gsplus",
+        "count": "3"
+      }
+    ],
+    "gsport": [
+      {
+        "cask": "gsport",
+        "count": "5"
+      }
+    ],
+    "gswitch": [
+      {
+        "cask": "gswitch",
+        "count": "1,799"
+      }
+    ],
+    "gtkwave": [
+      {
+        "cask": "gtkwave",
+        "count": "2,133"
+      }
+    ],
+    "gtt-taskbar": [
+      {
+        "cask": "gtt-taskbar",
+        "count": "3"
+      }
+    ],
+    "gu-base": [
+      {
+        "cask": "gu-base",
+        "count": "27"
+      }
+    ],
+    "gu-scala": [
+      {
+        "cask": "gu-scala",
+        "count": "32"
+      }
+    ],
+    "guagua": [
+      {
+        "cask": "guagua",
+        "count": "2"
+      }
+    ],
+    "guijs": [
+      {
+        "cask": "guijs",
+        "count": "23"
+      }
+    ],
+    "guild-wars2": [
+      {
+        "cask": "guild-wars2",
+        "count": "127"
+      }
+    ],
+    "guitar-pro": [
+      {
+        "cask": "guitar-pro",
+        "count": "208"
+      }
+    ],
+    "gulp": [
+      {
+        "cask": "gulp",
+        "count": "3,363"
+      }
+    ],
+    "guppy": [
+      {
+        "cask": "guppy",
+        "count": "31"
+      }
+    ],
+    "gureumkim": [
+      {
+        "cask": "gureumkim",
+        "count": "447"
+      }
+    ],
+    "gurobi80": [
+      {
+        "cask": "gurobi80",
+        "count": "3"
+      }
+    ],
+    "gutenprint": [
+      {
+        "cask": "gutenprint",
+        "count": "121"
+      }
+    ],
+    "gyazmail": [
+      {
+        "cask": "gyazmail",
+        "count": "11"
+      }
+    ],
+    "gyazo": [
+      {
+        "cask": "gyazo",
+        "count": "806"
+      }
+    ],
+    "gzdoom": [
+      {
+        "cask": "gzdoom",
+        "count": "403"
+      }
+    ],
+    "ha-menu": [
+      {
+        "cask": "ha-menu",
+        "count": "88"
+      }
+    ],
+    "hab": [
+      {
+        "cask": "hab",
+        "count": "25"
+      }
+    ],
+    "hachidori": [
+      {
+        "cask": "hachidori",
+        "count": "10"
+      }
+    ],
+    "hackaru": [
+      {
+        "cask": "hackaru",
+        "count": "1"
+      }
+    ],
+    "hacker-menu": [
+      {
+        "cask": "hacker-menu",
+        "count": "135"
+      }
+    ],
+    "hackety-hack": [
+      {
+        "cask": "hackety-hack",
+        "count": "24"
+      }
+    ],
+    "hackhands": [
+      {
+        "cask": "hackhands",
+        "count": "18"
+      }
+    ],
+    "hackintool": [
+      {
+        "cask": "hackintool",
+        "count": "172"
+      }
+    ],
+    "hackmd": [
+      {
+        "cask": "hackmd",
+        "count": "67"
+      }
+    ],
+    "hakuneko": [
+      {
+        "cask": "hakuneko",
+        "count": "22"
+      }
+    ],
+    "hallelujahinputmethod": [
+      {
+        "cask": "hallelujahinputmethod",
+        "count": "3"
+      }
+    ],
+    "hammerspoon": [
+      {
+        "cask": "hammerspoon",
+        "count": "6,335"
+      }
+    ],
+    "hamsket": [
+      {
+        "cask": "hamsket",
+        "count": "4"
+      }
+    ],
+    "hamsket-nightly": [
+      {
+        "cask": "hamsket-nightly",
+        "count": "33"
+      }
+    ],
+    "hand-mirror": [
+      {
+        "cask": "hand-mirror",
+        "count": "31"
+      }
+    ],
+    "handbrake": [
+      {
+        "cask": "handbrake",
+        "count": "14,389"
+      }
+    ],
+    "handbrake-custom": [
+      {
+        "cask": "handbrake-custom",
+        "count": "1"
+      }
+    ],
+    "handbrake-nightly": [
+      {
+        "cask": "handbrake-nightly",
+        "count": "260"
+      }
+    ],
+    "handbrakebatch": [
+      {
+        "cask": "handbrakebatch",
+        "count": "125"
+      }
+    ],
+    "handbrakecli": [
+      {
+        "cask": "handbrakecli",
+        "count": "1"
+      }
+    ],
+    "handelsbanken-card-reader": [
+      {
+        "cask": "handelsbanken-card-reader",
+        "count": "3"
+      }
+    ],
+    "hands-off": [
+      {
+        "cask": "hands-off",
+        "count": "110"
+      }
+    ],
+    "handshaker": [
+      {
+        "cask": "handshaker",
+        "count": "537"
+      }
+    ],
+    "handylock": [
+      {
+        "cask": "handylock",
+        "count": "27"
+      }
+    ],
+    "happygrep": [
+      {
+        "cask": "happygrep",
+        "count": "28"
+      }
+    ],
+    "haptic-touch-bar": [
+      {
+        "cask": "haptic-touch-bar",
+        "count": "325"
+      }
+    ],
+    "haptickey": [
+      {
+        "cask": "haptickey",
+        "count": "537"
+      }
+    ],
+    "harbor": [
+      {
+        "cask": "harbor",
+        "count": "34"
+      }
+    ],
+    "harmony": [
+      {
+        "cask": "harmony",
+        "count": "109"
+      }
+    ],
+    "haroopad": [
+      {
+        "cask": "haroopad",
+        "count": "154"
+      }
+    ],
+    "harvest": [
+      {
+        "cask": "harvest",
+        "count": "1,062"
+      }
+    ],
+    "hashbackup": [
+      {
+        "cask": "hashbackup",
+        "count": "30"
+      }
+    ],
+    "hashcat": [
+      {
+        "cask": "hashcat",
+        "count": "1"
+      }
+    ],
+    "haskell-for-mac": [
+      {
+        "cask": "haskell-for-mac",
+        "count": "448"
+      }
+    ],
+    "hazel": [
+      {
+        "cask": "hazel",
+        "count": "1,845"
+      }
+    ],
+    "hazeover": [
+      {
+        "cask": "hazeover",
+        "count": "380"
+      }
+    ],
+    "hbuilder": [
+      {
+        "cask": "hbuilder",
+        "count": "257"
+      }
+    ],
+    "hbuilderx": [
+      {
+        "cask": "hbuilderx",
+        "count": "251"
+      }
+    ],
+    "hdhomerun": [
+      {
+        "cask": "hdhomerun",
+        "count": "73"
+      }
+    ],
+    "hdrmerge": [
+      {
+        "cask": "hdrmerge",
+        "count": "33"
+      }
+    ],
+    "headset": [
+      {
+        "cask": "headset",
+        "count": "179"
+      }
+    ],
+    "healthi": [
+      {
+        "cask": "healthi",
+        "count": "1"
+      }
+    ],
+    "hear": [
+      {
+        "cask": "hear",
+        "count": "8"
+      }
+    ],
+    "heaven": [
+      {
+        "cask": "heaven",
+        "count": "149"
+      }
+    ],
+    "hedgewars": [
+      {
+        "cask": "hedgewars",
+        "count": "132"
+      }
+    ],
+    "heimdall-suite": [
+      {
+        "cask": "heimdall-suite",
+        "count": "149"
+      }
+    ],
+    "helio": [
+      {
+        "cask": "helio",
+        "count": "6"
+      }
+    ],
+    "helium": [
+      {
+        "cask": "helium",
+        "count": "763"
+      }
+    ],
+    "helm": [
+      {
+        "cask": "helm",
+        "count": "10"
+      }
+    ],
+    "helmsman": [
+      {
+        "cask": "helmsman",
+        "count": "2"
+      }
+    ],
+    "helo": [
+      {
+        "cask": "helo",
+        "count": "2"
+      }
+    ],
+    "hem": [
+      {
+        "cask": "hem",
+        "count": "9"
+      }
+    ],
+    "hermes": [
+      {
+        "cask": "hermes",
+        "count": "215"
+      }
+    ],
+    "hex": [
+      {
+        "cask": "hex",
+        "count": "111"
+      }
+    ],
+    "hex-fiend": [
+      {
+        "cask": "hex-fiend",
+        "count": "3,423"
+      }
+    ],
+    "hex-fiend-beta": [
+      {
+        "cask": "hex-fiend-beta",
+        "count": "70"
+      }
+    ],
+    "hexels": [
+      {
+        "cask": "hexels",
+        "count": "3"
+      }
+    ],
+    "hfsleuth": [
+      {
+        "cask": "hfsleuth",
+        "count": "43"
+      }
+    ],
+    "hhkb-pro": [
+      {
+        "cask": "hhkb-pro",
+        "count": "2"
+      }
+    ],
+    "hiarcs-chess-explorer": [
+      {
+        "cask": "hiarcs-chess-explorer",
+        "count": "48"
+      }
+    ],
+    "hidden-bar": [
+      {
+        "cask": "hidden-bar",
+        "count": "1"
+      }
+    ],
+    "hiddenbar": [
+      {
+        "cask": "hiddenbar",
+        "count": "1,637"
+      }
+    ],
+    "hider": [
+      {
+        "cask": "hider",
+        "count": "29"
+      }
+    ],
+    "hiera": [
+      {
+        "cask": "hiera",
+        "count": "1"
+      }
+    ],
+    "hipchat": [
+      {
+        "cask": "hipchat",
+        "count": "857"
+      }
+    ],
+    "historyhound": [
+      {
+        "cask": "historyhound",
+        "count": "29"
+      }
+    ],
+    "hma-pro-vpn": [
+      {
+        "cask": "hma-pro-vpn",
+        "count": "134"
+      }
+    ],
+    "hobbyquaker-arcticfox-config": [
+      {
+        "cask": "hobbyquaker-arcticfox-config",
+        "count": "2"
+      }
+    ],
+    "hobo": [
+      {
+        "cask": "hobo",
+        "count": "3"
+      }
+    ],
+    "hockey": [
+      {
+        "cask": "hockey",
+        "count": "135"
+      }
+    ],
+    "hocus-focus": [
+      {
+        "cask": "hocus-focus",
+        "count": "291"
+      }
+    ],
+    "hodito": [
+      {
+        "cask": "hodito",
+        "count": "1"
+      }
+    ],
+    "holavpn": [
+      {
+        "cask": "holavpn",
+        "count": "46"
+      }
+    ],
+    "home-inventory": [
+      {
+        "cask": "home-inventory",
+        "count": "18"
+      }
+    ],
+    "homedale": [
+      {
+        "cask": "homedale",
+        "count": "5"
+      }
+    ],
+    "honer": [
+      {
+        "cask": "honer",
+        "count": "78"
+      }
+    ],
+    "honto": [
+      {
+        "cask": "honto",
+        "count": "55"
+      }
+    ],
+    "hook": [
+      {
+        "cask": "hook",
+        "count": "65"
+      }
+    ],
+    "hopper-debugger-server": [
+      {
+        "cask": "hopper-debugger-server",
+        "count": "75"
+      }
+    ],
+    "hopper-disassembler": [
+      {
+        "cask": "hopper-disassembler",
+        "count": "14"
+      }
+    ],
+    "horndis": [
+      {
+        "cask": "horndis",
+        "count": "1,979"
+      }
+    ],
+    "horndis-pre": [
+      {
+        "cask": "horndis-pre",
+        "count": "4"
+      }
+    ],
+    "horos": [
+      {
+        "cask": "horos",
+        "count": "387"
+      }
+    ],
+    "hostbuddy": [
+      {
+        "cask": "hostbuddy",
+        "count": "25"
+      }
+    ],
+    "hosting-au": [
+      {
+        "cask": "hosting-au",
+        "count": "2"
+      }
+    ],
+    "hosts": [
+      {
+        "cask": "hosts",
+        "count": "6"
+      }
+    ],
+    "hosty": [
+      {
+        "cask": "hosty",
+        "count": "12"
+      }
+    ],
+    "hot-shots": [
+      {
+        "cask": "hot-shots",
+        "count": "1"
+      }
+    ],
+    "hotelier": [
+      {
+        "cask": "hotelier",
+        "count": "1"
+      }
+    ],
+    "hotswitch": [
+      {
+        "cask": "hotswitch",
+        "count": "22"
+      }
+    ],
+    "houdahspot": [
+      {
+        "cask": "houdahspot",
+        "count": "118"
+      }
+    ],
+    "houseparty": [
+      {
+        "cask": "houseparty",
+        "count": "483"
+      }
+    ],
+    "hp-connectivity-kit": [
+      {
+        "cask": "hp-connectivity-kit",
+        "count": "26"
+      }
+    ],
+    "hp-easy-start": [
+      {
+        "cask": "hp-easy-start",
+        "count": "397"
+      }
+    ],
+    "hp-eprint": [
+      {
+        "cask": "hp-eprint",
+        "count": "31"
+      }
+    ],
+    "hp-prime": [
+      {
+        "cask": "hp-prime",
+        "count": "34"
+      }
+    ],
+    "hp-printer-essentials": [
+      {
+        "cask": "hp-printer-essentials",
+        "count": "1"
+      }
+    ],
+    "hp15c": [
+      {
+        "cask": "hp15c",
+        "count": "4"
+      }
+    ],
+    "hqplayer": [
+      {
+        "cask": "hqplayer",
+        "count": "1"
+      }
+    ],
+    "hs-java11": [
+      {
+        "cask": "hs-java11",
+        "count": "3"
+      }
+    ],
+    "hsang": [
+      {
+        "cask": "hsang",
+        "count": "3"
+      }
+    ],
+    "hstracker": [
+      {
+        "cask": "hstracker",
+        "count": "201"
+      }
+    ],
+    "htc-sync-manager": [
+      {
+        "cask": "htc-sync-manager",
+        "count": "11"
+      }
+    ],
+    "htmltomd": [
+      {
+        "cask": "htmltomd",
+        "count": "1"
+      }
+    ],
+    "http-toolkit": [
+      {
+        "cask": "http-toolkit",
+        "count": "365"
+      }
+    ],
+    "hubic": [
+      {
+        "cask": "hubic",
+        "count": "26"
+      }
+    ],
+    "hubstaff": [
+      {
+        "cask": "hubstaff",
+        "count": "108"
+      }
+    ],
+    "hue-sync": [
+      {
+        "cask": "hue-sync",
+        "count": "3"
+      }
+    ],
+    "hue-topia": [
+      {
+        "cask": "hue-topia",
+        "count": "32"
+      }
+    ],
+    "huggle": [
+      {
+        "cask": "huggle",
+        "count": "2"
+      }
+    ],
+    "hugin": [
+      {
+        "cask": "hugin",
+        "count": "575"
+      }
+    ],
+    "huion-tablet-driver": [
+      {
+        "cask": "huion-tablet-driver",
+        "count": "1"
+      }
+    ],
+    "hummingbird": [
+      {
+        "cask": "hummingbird",
+        "count": "69"
+      }
+    ],
+    "hwmonitorsmc2": [
+      {
+        "cask": "hwmonitorsmc2",
+        "count": "3"
+      }
+    ],
+    "hwsensors": [
+      {
+        "cask": "hwsensors",
+        "count": "680"
+      }
+    ],
+    "hydrogen": [
+      {
+        "cask": "hydrogen",
+        "count": "106"
+      }
+    ],
+    "hype": [
+      {
+        "cask": "hype",
+        "count": "75"
+      }
+    ],
+    "hyper": [
+      {
+        "cask": "hyper",
+        "count": "23,766"
+      }
+    ],
+    "hyper-canary": [
+      {
+        "cask": "hyper-canary",
+        "count": "117"
+      }
+    ],
+    "hyperbackupexplorer": [
+      {
+        "cask": "hyperbackupexplorer",
+        "count": "35"
+      }
+    ],
+    "hyperdock": [
+      {
+        "cask": "hyperdock",
+        "count": "1,058"
+      }
+    ],
+    "hyperion-download-manager": [
+      {
+        "cask": "hyperion-download-manager",
+        "count": "9"
+      }
+    ],
+    "hyperswitch": [
+      {
+        "cask": "hyperswitch",
+        "count": "3,234"
+      }
+    ],
+    "i1profiler": [
+      {
+        "cask": "i1profiler",
+        "count": "235"
+      }
+    ],
+    "i4tools": [
+      {
+        "cask": "i4tools",
+        "count": "33"
+      }
+    ],
+    "ian4hu-clipy": [
+      {
+        "cask": "ian4hu-clipy",
+        "count": "2"
+      }
+    ],
+    "ian4hu-clipy-beta": [
+      {
+        "cask": "ian4hu-clipy-beta",
+        "count": "4"
+      }
+    ],
+    "ibabel": [
+      {
+        "cask": "ibabel",
+        "count": "71"
+      }
+    ],
+    "ibackup": [
+      {
+        "cask": "ibackup",
+        "count": "42"
+      }
+    ],
+    "ibackup-viewer": [
+      {
+        "cask": "ibackup-viewer",
+        "count": "161"
+      }
+    ],
+    "ibackupbot": [
+      {
+        "cask": "ibackupbot",
+        "count": "40"
+      }
+    ],
+    "ibettercharge": [
+      {
+        "cask": "ibettercharge",
+        "count": "38"
+      }
+    ],
+    "ibm-cloud-cli": [
+      {
+        "cask": "ibm-cloud-cli",
+        "count": "465"
+      }
+    ],
+    "ibored": [
+      {
+        "cask": "ibored",
+        "count": "38"
+      }
+    ],
+    "icab": [
+      {
+        "cask": "icab",
+        "count": "28"
+      }
+    ],
+    "icamsource": [
+      {
+        "cask": "icamsource",
+        "count": "1"
+      }
+    ],
+    "icanhazshortcut": [
+      {
+        "cask": "icanhazshortcut",
+        "count": "93"
+      }
+    ],
+    "icc": [
+      {
+        "cask": "icc",
+        "count": "50"
+      }
+    ],
+    "iceberg": [
+      {
+        "cask": "iceberg",
+        "count": "33"
+      }
+    ],
+    "icecat": [
+      {
+        "cask": "icecat",
+        "count": "25"
+      }
+    ],
+    "icefloor": [
+      {
+        "cask": "icefloor",
+        "count": "89"
+      }
+    ],
+    "icegridgui": [
+      {
+        "cask": "icegridgui",
+        "count": "16"
+      }
+    ],
+    "icegridgui36": [
+      {
+        "cask": "icegridgui36",
+        "count": "1"
+      }
+    ],
+    "icestudio": [
+      {
+        "cask": "icestudio",
+        "count": "7"
+      }
+    ],
+    "ichm": [
+      {
+        "cask": "ichm",
+        "count": "440"
+      }
+    ],
+    "icloud-control": [
+      {
+        "cask": "icloud-control",
+        "count": "191"
+      }
+    ],
+    "icm-browser": [
+      {
+        "cask": "icm-browser",
+        "count": "1"
+      }
+    ],
+    "icollections": [
+      {
+        "cask": "icollections",
+        "count": "2"
+      }
+    ],
+    "icompta": [
+      {
+        "cask": "icompta",
+        "count": "1"
+      }
+    ],
+    "iconizer": [
+      {
+        "cask": "iconizer",
+        "count": "239"
+      }
+    ],
+    "iconjar": [
+      {
+        "cask": "iconjar",
+        "count": "273"
+      }
+    ],
+    "iconping": [
+      {
+        "cask": "iconping",
+        "count": "46"
+      }
+    ],
+    "icons": [
+      {
+        "cask": "icons",
+        "count": "29"
+      }
+    ],
+    "icons8": [
+      {
+        "cask": "icons8",
+        "count": "206"
+      }
+    ],
+    "iconvert": [
+      {
+        "cask": "iconvert",
+        "count": "86"
+      }
+    ],
+    "icq": [
+      {
+        "cask": "icq",
+        "count": "123"
+      }
+    ],
+    "id3-editor": [
+      {
+        "cask": "id3-editor",
+        "count": "139"
+      }
+    ],
+    "idafree": [
+      {
+        "cask": "idafree",
+        "count": "199"
+      }
+    ],
+    "idagio": [
+      {
+        "cask": "idagio",
+        "count": "52"
+      }
+    ],
+    "idefrag": [
+      {
+        "cask": "idefrag",
+        "count": "37"
+      }
+    ],
+    "idisplay": [
+      {
+        "cask": "idisplay",
+        "count": "37"
+      }
+    ],
+    "idobata-electron": [
+      {
+        "cask": "idobata-electron",
+        "count": "1"
+      }
+    ],
+    "idrive": [
+      {
+        "cask": "idrive",
+        "count": "124"
+      }
+    ],
+    "ieasemusic": [
+      {
+        "cask": "ieasemusic",
+        "count": "1,103"
+      }
+    ],
+    "iexplorer": [
+      {
+        "cask": "iexplorer",
+        "count": "424"
+      }
+    ],
+    "ifilex": [
+      {
+        "cask": "ifilex",
+        "count": "5"
+      }
+    ],
+    "ifunbox": [
+      {
+        "cask": "ifunbox",
+        "count": "351"
+      }
+    ],
+    "igdm": [
+      {
+        "cask": "igdm",
+        "count": "197"
+      }
+    ],
+    "igetter": [
+      {
+        "cask": "igetter",
+        "count": "170"
+      }
+    ],
+    "iglance": [
+      {
+        "cask": "iglance",
+        "count": "3,127"
+      }
+    ],
+    "iglasses": [
+      {
+        "cask": "iglasses",
+        "count": "2"
+      }
+    ],
+    "ignis": [
+      {
+        "cask": "ignis",
+        "count": "19"
+      }
+    ],
+    "igniteamps-anvil": [
+      {
+        "cask": "igniteamps-anvil",
+        "count": "2"
+      }
+    ],
+    "igniteamps-nrr1": [
+      {
+        "cask": "igniteamps-nrr1",
+        "count": "2"
+      }
+    ],
+    "igniteamps-profet": [
+      {
+        "cask": "igniteamps-profet",
+        "count": "2"
+      }
+    ],
+    "igniteamps-pteqx": [
+      {
+        "cask": "igniteamps-pteqx",
+        "count": "2"
+      }
+    ],
+    "igniteamps-ts999": [
+      {
+        "cask": "igniteamps-ts999",
+        "count": "2"
+      }
+    ],
+    "igor-pro": [
+      {
+        "cask": "igor-pro",
+        "count": "3"
+      }
+    ],
+    "iguanatexmac": [
+      {
+        "cask": "iguanatexmac",
+        "count": "4"
+      }
+    ],
+    "igv": [
+      {
+        "cask": "igv",
+        "count": "307"
+      }
+    ],
+    "ihelp": [
+      {
+        "cask": "ihelp",
+        "count": "86"
+      }
+    ],
+    "iina": [
+      {
+        "cask": "iina",
+        "count": "25,392"
+      }
+    ],
+    "iina-beta": [
+      {
+        "cask": "iina-beta",
+        "count": "121"
+      }
+    ],
+    "iina-nightly": [
+      {
+        "cask": "iina-nightly",
+        "count": "16"
+      }
+    ],
+    "iina-plus": [
+      {
+        "cask": "iina-plus",
+        "count": "164"
+      }
+    ],
+    "ilearn": [
+      {
+        "cask": "ilearn",
+        "count": "86"
+      }
+    ],
+    "illformed-glitch": [
+      {
+        "cask": "illformed-glitch",
+        "count": "1"
+      }
+    ],
+    "illustrator-cc": [
+      {
+        "cask": "illustrator-cc",
+        "count": "5"
+      }
+    ],
+    "ilok-license-manager": [
+      {
+        "cask": "ilok-license-manager",
+        "count": "133"
+      }
+    ],
+    "ilya-birman-typography-layout": [
+      {
+        "cask": "ilya-birman-typography-layout",
+        "count": "63"
+      }
+    ],
+    "image-tool": [
+      {
+        "cask": "image-tool",
+        "count": "71"
+      }
+    ],
+    "image2icon": [
+      {
+        "cask": "image2icon",
+        "count": "428"
+      }
+    ],
+    "imagealpha": [
+      {
+        "cask": "imagealpha",
+        "count": "904"
+      }
+    ],
+    "imagej": [
+      {
+        "cask": "imagej",
+        "count": "399"
+      }
+    ],
+    "imagemin": [
+      {
+        "cask": "imagemin",
+        "count": "112"
+      }
+    ],
+    "imageoptim": [
+      {
+        "cask": "imageoptim",
+        "count": "8,827"
+      }
+    ],
+    "imaging-edge": [
+      {
+        "cask": "imaging-edge",
+        "count": "115"
+      }
+    ],
+    "imazing": [
+      {
+        "cask": "imazing",
+        "count": "2,121"
+      }
+    ],
+    "imazing-mini": [
+      {
+        "cask": "imazing-mini",
+        "count": "37"
+      }
+    ],
+    "imeshortcuts": [
+      {
+        "cask": "imeshortcuts",
+        "count": "2"
+      }
+    ],
+    "imgbrd-grabber-nightly": [
+      {
+        "cask": "imgbrd-grabber-nightly",
+        "count": "5"
+      }
+    ],
+    "imgotv": [
+      {
+        "cask": "imgotv",
+        "count": "57"
+      }
+    ],
+    "imgur": [
+      {
+        "cask": "imgur",
+        "count": "97"
+      }
+    ],
+    "imitone": [
+      {
+        "cask": "imitone",
+        "count": "10"
+      }
+    ],
+    "imo": [
+      {
+        "cask": "imo",
+        "count": "17"
+      }
+    ],
+    "impactor": [
+      {
+        "cask": "impactor",
+        "count": "600"
+      }
+    ],
+    "imusic": [
+      {
+        "cask": "imusic",
+        "count": "2"
+      }
+    ],
+    "inav-configurator": [
+      {
+        "cask": "inav-configurator",
+        "count": "12"
+      }
+    ],
+    "inboard": [
+      {
+        "cask": "inboard",
+        "count": "17"
+      }
+    ],
+    "inboxer": [
+      {
+        "cask": "inboxer",
+        "count": "19"
+      }
+    ],
+    "inco": [
+      {
+        "cask": "inco",
+        "count": "1"
+      }
+    ],
+    "indesign-cc": [
+      {
+        "cask": "indesign-cc",
+        "count": "2"
+      }
+    ],
+    "indigo": [
+      {
+        "cask": "indigo",
+        "count": "26"
+      }
+    ],
+    "indigo-control-panel": [
+      {
+        "cask": "indigo-control-panel",
+        "count": "2"
+      }
+    ],
+    "inform": [
+      {
+        "cask": "inform",
+        "count": "46"
+      }
+    ],
+    "inkdrop": [
+      {
+        "cask": "inkdrop",
+        "count": "388"
+      }
+    ],
+    "inklet": [
+      {
+        "cask": "inklet",
+        "count": "10"
+      }
+    ],
+    "inkpod": [
+      {
+        "cask": "inkpod",
+        "count": "2"
+      }
+    ],
+    "inkscape": [
+      {
+        "cask": "inkscape",
+        "count": "33,532"
+      }
+    ],
+    "inkscape-beta": [
+      {
+        "cask": "inkscape-beta",
+        "count": "5"
+      }
+    ],
+    "inkscape-dev": [
+      {
+        "cask": "inkscape-dev",
+        "count": "1"
+      }
+    ],
+    "inkscape-nightly": [
+      {
+        "cask": "inkscape-nightly",
+        "count": "66"
+      }
+    ],
+    "inky": [
+      {
+        "cask": "inky",
+        "count": "65"
+      }
+    ],
+    "inloop-qlplayground": [
+      {
+        "cask": "inloop-qlplayground",
+        "count": "47"
+      }
+    ],
+    "insertdylib": [
+      {
+        "cask": "insertdylib",
+        "count": "1"
+      }
+    ],
+    "insomnia": [
+      {
+        "cask": "insomnia",
+        "count": "41,686"
+      }
+    ],
+    "insomnia-designer": [
+      {
+        "cask": "insomnia-designer",
+        "count": "51"
+      }
+    ],
+    "insomniax": [
+      {
+        "cask": "insomniax",
+        "count": "2"
+      }
+    ],
+    "inspec": [
+      {
+        "cask": "inspec",
+        "count": "1,980"
+      }
+    ],
+    "inssider": [
+      {
+        "cask": "inssider",
+        "count": "192"
+      }
+    ],
+    "insta360-studio": [
+      {
+        "cask": "insta360-studio",
+        "count": "37"
+      }
+    ],
+    "install-disk-creator": [
+      {
+        "cask": "install-disk-creator",
+        "count": "544"
+      }
+    ],
+    "install-unity": [
+      {
+        "cask": "install-unity",
+        "count": "45"
+      }
+    ],
+    "install_mono_mdk": [
+      {
+        "cask": "install_mono_mdk",
+        "count": "15"
+      }
+    ],
+    "install_xamarin_ios": [
+      {
+        "cask": "install_xamarin_ios",
+        "count": "13"
+      }
+    ],
+    "install_xamarin_mac": [
+      {
+        "cask": "install_xamarin_mac",
+        "count": "9"
+      }
+    ],
+    "instant-articles-builder": [
+      {
+        "cask": "instant-articles-builder",
+        "count": "5"
+      }
+    ],
+    "instasizer": [
+      {
+        "cask": "instasizer",
+        "count": "9"
+      }
+    ],
+    "insync": [
+      {
+        "cask": "insync",
+        "count": "503"
+      }
+    ],
+    "integrity": [
+      {
+        "cask": "integrity",
+        "count": "270"
+      }
+    ],
+    "intel-haxm": [
+      {
+        "cask": "intel-haxm",
+        "count": "2,890"
+      }
+    ],
+    "intel-power-gadget": [
+      {
+        "cask": "intel-power-gadget",
+        "count": "5,128"
+      }
+    ],
+    "intel-psxe-ce-c++": [
+      {
+        "cask": "intel-psxe-ce-c++",
+        "count": "3"
+      }
+    ],
+    "intel-psxe-ce-c-plus-plus": [
+      {
+        "cask": "intel-psxe-ce-c-plus-plus",
+        "count": "7"
+      }
+    ],
+    "intel-psxe-ce-fortran": [
+      {
+        "cask": "intel-psxe-ce-fortran",
+        "count": "1"
+      }
+    ],
+    "intellij-eclipse-formatter": [
+      {
+        "cask": "intellij-eclipse-formatter",
+        "count": "1"
+      }
+    ],
+    "intellij-findbugs": [
+      {
+        "cask": "intellij-findbugs",
+        "count": "1"
+      }
+    ],
+    "intellij-idea": [
+      {
+        "cask": "intellij-idea",
+        "count": "35,893"
+      }
+    ],
+    "intellij-idea-ce": [
+      {
+        "cask": "intellij-idea-ce",
+        "count": "21,796"
+      }
+    ],
+    "intellij-idea-ce@2019.1.4": [
+      {
+        "cask": "intellij-idea-ce@2019.1.4",
+        "count": "2"
+      }
+    ],
+    "intellij-idea-newest": [
+      {
+        "cask": "intellij-idea-newest",
+        "count": "7"
+      }
+    ],
+    "intellij-scala": [
+      {
+        "cask": "intellij-scala",
+        "count": "1"
+      }
+    ],
+    "intelliscape-caffeine": [
+      {
+        "cask": "intelliscape-caffeine",
+        "count": "218"
+      }
+    ],
+    "intelliscape-caffeine-beta": [
+      {
+        "cask": "intelliscape-caffeine-beta",
+        "count": "4"
+      }
+    ],
+    "interarchy": [
+      {
+        "cask": "interarchy",
+        "count": "10"
+      }
+    ],
+    "interface-inspector": [
+      {
+        "cask": "interface-inspector",
+        "count": "11"
+      }
+    ],
+    "invesalius": [
+      {
+        "cask": "invesalius",
+        "count": "5"
+      }
+    ],
+    "invisiblix": [
+      {
+        "cask": "invisiblix",
+        "count": "11"
+      }
+    ],
+    "invisionsync": [
+      {
+        "cask": "invisionsync",
+        "count": "91"
+      }
+    ],
+    "inviska-rename": [
+      {
+        "cask": "inviska-rename",
+        "count": "32"
+      }
+    ],
+    "invisor-lite": [
+      {
+        "cask": "invisor-lite",
+        "count": "80"
+      }
+    ],
+    "invisorql": [
+      {
+        "cask": "invisorql",
+        "count": "43"
+      }
+    ],
+    "inxmail-professional": [
+      {
+        "cask": "inxmail-professional",
+        "count": "4"
+      }
+    ],
+    "iograph": [
+      {
+        "cask": "iograph",
+        "count": "11"
+      }
+    ],
+    "iojones": [
+      {
+        "cask": "iojones",
+        "count": "5"
+      }
+    ],
+    "ionic-lab": [
+      {
+        "cask": "ionic-lab",
+        "count": "93"
+      }
+    ],
+    "ionic-machina-cli": [
+      {
+        "cask": "ionic-machina-cli",
+        "count": "8"
+      }
+    ],
+    "ionic-profiles": [
+      {
+        "cask": "ionic-profiles",
+        "count": "2"
+      }
+    ],
+    "ioninja": [
+      {
+        "cask": "ioninja",
+        "count": "13"
+      }
+    ],
+    "ioquake3": [
+      {
+        "cask": "ioquake3",
+        "count": "425"
+      }
+    ],
+    "ios-app-signer": [
+      {
+        "cask": "ios-app-signer",
+        "count": "333"
+      }
+    ],
+    "ios-console": [
+      {
+        "cask": "ios-console",
+        "count": "235"
+      }
+    ],
+    "ios-saver": [
+      {
+        "cask": "ios-saver",
+        "count": "37"
+      }
+    ],
+    "iota-wallet": [
+      {
+        "cask": "iota-wallet",
+        "count": "21"
+      }
+    ],
+    "ip-in-menu-bar": [
+      {
+        "cask": "ip-in-menu-bar",
+        "count": "301"
+      }
+    ],
+    "ip-scanner": [
+      {
+        "cask": "ip-scanner",
+        "count": "19"
+      }
+    ],
+    "ipa-manager": [
+      {
+        "cask": "ipa-manager",
+        "count": "36"
+      }
+    ],
+    "ipalette": [
+      {
+        "cask": "ipalette",
+        "count": "1"
+      }
+    ],
+    "ipartition": [
+      {
+        "cask": "ipartition",
+        "count": "152"
+      }
+    ],
+    "ipass": [
+      {
+        "cask": "ipass",
+        "count": "5"
+      }
+    ],
+    "ipe": [
+      {
+        "cask": "ipe",
+        "count": "241"
+      }
+    ],
+    "ipepresenter": [
+      {
+        "cask": "ipepresenter",
+        "count": "20"
+      }
+    ],
+    "ipfs": [
+      {
+        "cask": "ipfs",
+        "count": "1,060"
+      }
+    ],
+    "iphone-backup-extractor": [
+      {
+        "cask": "iphone-backup-extractor",
+        "count": "1"
+      }
+    ],
+    "iphoney": [
+      {
+        "cask": "iphoney",
+        "count": "25"
+      }
+    ],
+    "iphoto-library-manager": [
+      {
+        "cask": "iphoto-library-manager",
+        "count": "30"
+      }
+    ],
+    "ipremoteutility": [
+      {
+        "cask": "ipremoteutility",
+        "count": "1"
+      }
+    ],
+    "ipsecuritas": [
+      {
+        "cask": "ipsecuritas",
+        "count": "43"
+      }
+    ],
+    "ipswdownloader": [
+      {
+        "cask": "ipswdownloader",
+        "count": "1"
+      }
+    ],
+    "ipvanish-vpn": [
+      {
+        "cask": "ipvanish-vpn",
+        "count": "189"
+      }
+    ],
+    "ipynb-quicklook": [
+      {
+        "cask": "ipynb-quicklook",
+        "count": "220"
+      }
+    ],
+    "iqiyi": [
+      {
+        "cask": "iqiyi",
+        "count": "2"
+      }
+    ],
+    "iqiyi-meeting": [
+      {
+        "cask": "iqiyi-meeting",
+        "count": "1"
+      }
+    ],
+    "irccloud": [
+      {
+        "cask": "irccloud",
+        "count": "218"
+      }
+    ],
+    "ireadfast": [
+      {
+        "cask": "ireadfast",
+        "count": "27"
+      }
+    ],
+    "iridient-developer": [
+      {
+        "cask": "iridient-developer",
+        "count": "17"
+      }
+    ],
+    "iridium": [
+      {
+        "cask": "iridium",
+        "count": "248"
+      }
+    ],
+    "iringg": [
+      {
+        "cask": "iringg",
+        "count": "21"
+      }
+    ],
+    "irip": [
+      {
+        "cask": "irip",
+        "count": "4"
+      }
+    ],
+    "iris": [
+      {
+        "cask": "iris",
+        "count": "86"
+      }
+    ],
+    "irispen-air": [
+      {
+        "cask": "irispen-air",
+        "count": "2"
+      }
+    ],
+    "irreader": [
+      {
+        "cask": "irreader",
+        "count": "4"
+      }
+    ],
+    "isabelle": [
+      {
+        "cask": "isabelle",
+        "count": "126"
+      }
+    ],
+    "isg-jdk-java8": [
+      {
+        "cask": "isg-jdk-java8",
+        "count": "1"
+      }
+    ],
+    "ishowu": [
+      {
+        "cask": "ishowu",
+        "count": "237"
+      }
+    ],
+    "ishowu-hd": [
+      {
+        "cask": "ishowu-hd",
+        "count": "2"
+      }
+    ],
+    "ishowu-instant": [
+      {
+        "cask": "ishowu-instant",
+        "count": "50"
+      }
+    ],
+    "isimulator": [
+      {
+        "cask": "isimulator",
+        "count": "73"
+      }
+    ],
+    "islide": [
+      {
+        "cask": "islide",
+        "count": "69"
+      }
+    ],
+    "isolator": [
+      {
+        "cask": "isolator",
+        "count": "67"
+      }
+    ],
+    "istat-menus": [
+      {
+        "cask": "istat-menus",
+        "count": "9,124"
+      }
+    ],
+    "istat-menus5": [
+      {
+        "cask": "istat-menus5",
+        "count": "195"
+      }
+    ],
+    "istat-server": [
+      {
+        "cask": "istat-server",
+        "count": "199"
+      }
+    ],
+    "isteg": [
+      {
+        "cask": "isteg",
+        "count": "64"
+      }
+    ],
+    "istumbler": [
+      {
+        "cask": "istumbler",
+        "count": "340"
+      }
+    ],
+    "isubtitle": [
+      {
+        "cask": "isubtitle",
+        "count": "27"
+      }
+    ],
+    "iswiff": [
+      {
+        "cask": "iswiff",
+        "count": "47"
+      }
+    ],
+    "isyncr": [
+      {
+        "cask": "isyncr",
+        "count": "38"
+      }
+    ],
+    "itau": [
+      {
+        "cask": "itau",
+        "count": "124"
+      }
+    ],
+    "itch": [
+      {
+        "cask": "itch",
+        "count": "194"
+      }
+    ],
+    "iterm2": [
+      {
+        "cask": "iterm2",
+        "count": "233,851"
+      }
+    ],
+    "iterm2-beta": [
+      {
+        "cask": "iterm2-beta",
+        "count": "2,315"
+      }
+    ],
+    "iterm2-custom": [
+      {
+        "cask": "iterm2-custom",
+        "count": "6"
+      }
+    ],
+    "iterm2-elcapitan": [
+      {
+        "cask": "iterm2-elcapitan",
+        "count": "2"
+      }
+    ],
+    "iterm2-legacy": [
+      {
+        "cask": "iterm2-legacy",
+        "count": "66"
+      }
+    ],
+    "iterm2-nightly": [
+      {
+        "cask": "iterm2-nightly",
+        "count": "1,651"
+      }
+    ],
+    "itest": [
+      {
+        "cask": "itest",
+        "count": "86"
+      }
+    ],
+    "ithoughtsx": [
+      {
+        "cask": "ithoughtsx",
+        "count": "85"
+      }
+    ],
+    "itk-snap": [
+      {
+        "cask": "itk-snap",
+        "count": "65"
+      }
+    ],
+    "itools": [
+      {
+        "cask": "itools",
+        "count": "294"
+      }
+    ],
+    "itrash": [
+      {
+        "cask": "itrash",
+        "count": "20"
+      }
+    ],
+    "itsycal": [
+      {
+        "cask": "itsycal",
+        "count": "6,085"
+      }
+    ],
+    "itubedownloader": [
+      {
+        "cask": "itubedownloader",
+        "count": "154"
+      }
+    ],
+    "itunes-producer": [
+      {
+        "cask": "itunes-producer",
+        "count": "27"
+      }
+    ],
+    "itunes-volume-control": [
+      {
+        "cask": "itunes-volume-control",
+        "count": "44"
+      }
+    ],
+    "iueditor": [
+      {
+        "cask": "iueditor",
+        "count": "2"
+      }
+    ],
+    "iupx": [
+      {
+        "cask": "iupx",
+        "count": "1"
+      }
+    ],
+    "ivideonclient": [
+      {
+        "cask": "ivideonclient",
+        "count": "7"
+      }
+    ],
+    "ivideonserver": [
+      {
+        "cask": "ivideonserver",
+        "count": "6"
+      }
+    ],
+    "ivolume": [
+      {
+        "cask": "ivolume",
+        "count": "20"
+      }
+    ],
+    "ivpn": [
+      {
+        "cask": "ivpn",
+        "count": "171"
+      }
+    ],
+    "izip": [
+      {
+        "cask": "izip",
+        "count": "374"
+      }
+    ],
+    "j": [
+      {
+        "cask": "j",
+        "count": "138"
+      }
+    ],
+    "jabra-direct": [
+      {
+        "cask": "jabra-direct",
+        "count": "235"
+      }
+    ],
+    "jabra-suite": [
+      {
+        "cask": "jabra-suite",
+        "count": "1"
+      }
+    ],
+    "jabref": [
+      {
+        "cask": "jabref",
+        "count": "914"
+      }
+    ],
+    "jad": [
+      {
+        "cask": "jad",
+        "count": "1,183"
+      }
+    ],
+    "jaikoz": [
+      {
+        "cask": "jaikoz",
+        "count": "24"
+      }
+    ],
+    "jaikoz930": [
+      {
+        "cask": "jaikoz930",
+        "count": "1"
+      }
+    ],
+    "jaksta-media-recorder": [
+      {
+        "cask": "jaksta-media-recorder",
+        "count": "24"
+      }
+    ],
+    "jalbum": [
+      {
+        "cask": "jalbum",
+        "count": "19"
+      }
+    ],
+    "jalview": [
+      {
+        "cask": "jalview",
+        "count": "62"
+      }
+    ],
+    "jameica": [
+      {
+        "cask": "jameica",
+        "count": "102"
+      }
+    ],
+    "james": [
+      {
+        "cask": "james",
+        "count": "93"
+      }
+    ],
+    "jamf-migrator": [
+      {
+        "cask": "jamf-migrator",
+        "count": "39"
+      }
+    ],
+    "jami": [
+      {
+        "cask": "jami",
+        "count": "365"
+      }
+    ],
+    "jamovi": [
+      {
+        "cask": "jamovi",
+        "count": "78"
+      }
+    ],
+    "jandi": [
+      {
+        "cask": "jandi",
+        "count": "61"
+      }
+    ],
+    "jasp": [
+      {
+        "cask": "jasp",
+        "count": "103"
+      }
+    ],
+    "jasper": [
+      {
+        "cask": "jasper",
+        "count": "264"
+      }
+    ],
+    "java": [
+      {
+        "cask": "java",
+        "count": "291,742"
+      }
+    ],
+    "java-8-custom": [
+      {
+        "cask": "java-8-custom",
+        "count": "9"
+      }
+    ],
+    "java-beta": [
+      {
+        "cask": "java-beta",
+        "count": "198"
+      }
+    ],
+    "java-custom": [
+      {
+        "cask": "java-custom",
+        "count": "1"
+      }
+    ],
+    "java-zulu": [
+      {
+        "cask": "java-zulu",
+        "count": "7"
+      }
+    ],
+    "java11": [
+      {
+        "cask": "java11",
+        "count": "55,540"
+      }
+    ],
+    "java11jdk": [
+      {
+        "cask": "java11jdk",
+        "count": "1"
+      }
+    ],
+    "java12": [
+      {
+        "cask": "java12",
+        "count": "17"
+      }
+    ],
+    "java13": [
+      {
+        "cask": "java13",
+        "count": "2"
+      }
+    ],
+    "java2": [
+      {
+        "cask": "java2",
+        "count": "1"
+      }
+    ],
+    "java6": [
+      {
+        "cask": "java6",
+        "count": "7,354"
+      }
+    ],
+    "java7": [
+      {
+        "cask": "java7",
+        "count": "6"
+      }
+    ],
+    "java8": [
+      {
+        "cask": "java8",
+        "count": "335"
+      }
+    ],
+    "java8u181": [
+      {
+        "cask": "java8u181",
+        "count": "10"
+      }
+    ],
+    "java8u211": [
+      {
+        "cask": "java8u211",
+        "count": "1"
+      }
+    ],
+    "java9": [
+      {
+        "cask": "java9",
+        "count": "361"
+      }
+    ],
+    "java@8": [
+      {
+        "cask": "java@8",
+        "count": "1"
+      }
+    ],
+    "java_11_0_2": [
+      {
+        "cask": "java_11_0_2",
+        "count": "5"
+      }
+    ],
+    "jaxx-liberty": [
+      {
+        "cask": "jaxx-liberty",
+        "count": "173"
+      }
+    ],
+    "jazzup": [
+      {
+        "cask": "jazzup",
+        "count": "7"
+      }
+    ],
+    "jb-openjdk11": [
+      {
+        "cask": "jb-openjdk11",
+        "count": "6"
+      }
+    ],
+    "jbidwatcher": [
+      {
+        "cask": "jbidwatcher",
+        "count": "40"
+      }
+    ],
+    "jbrowse": [
+      {
+        "cask": "jbrowse",
+        "count": "137"
+      }
+    ],
+    "jclasslib-bytecode-viewer": [
+      {
+        "cask": "jclasslib-bytecode-viewer",
+        "count": "74"
+      }
+    ],
+    "jcryptool": [
+      {
+        "cask": "jcryptool",
+        "count": "46"
+      }
+    ],
+    "jd-gui": [
+      {
+        "cask": "jd-gui",
+        "count": "7,763"
+      }
+    ],
+    "jdiskreport": [
+      {
+        "cask": "jdiskreport",
+        "count": "213"
+      }
+    ],
+    "jdk-mission-control": [
+      {
+        "cask": "jdk-mission-control",
+        "count": "65"
+      }
+    ],
+    "jdk-mission-control-snapshot": [
+      {
+        "cask": "jdk-mission-control-snapshot",
+        "count": "3"
+      }
+    ],
+    "jdk8": [
+      {
+        "cask": "jdk8",
+        "count": "1"
+      }
+    ],
+    "jdownloader": [
+      {
+        "cask": "jdownloader",
+        "count": "3,289"
+      }
+    ],
+    "jedict": [
+      {
+        "cask": "jedict",
+        "count": "9"
+      }
+    ],
+    "jedit": [
+      {
+        "cask": "jedit",
+        "count": "314"
+      }
+    ],
+    "jedit-omega": [
+      {
+        "cask": "jedit-omega",
+        "count": "40"
+      }
+    ],
+    "jedit-x": [
+      {
+        "cask": "jedit-x",
+        "count": "1"
+      }
+    ],
+    "jenkins-menu": [
+      {
+        "cask": "jenkins-menu",
+        "count": "93"
+      }
+    ],
+    "jeromelebel-mongohub": [
+      {
+        "cask": "jeromelebel-mongohub",
+        "count": "271"
+      }
+    ],
+    "jet": [
+      {
+        "cask": "jet",
+        "count": "4,585"
+      }
+    ],
+    "jetbrains-toolbox": [
+      {
+        "cask": "jetbrains-toolbox",
+        "count": "16,994"
+      }
+    ],
+    "jettison": [
+      {
+        "cask": "jettison",
+        "count": "68"
+      }
+    ],
+    "jewelrybox": [
+      {
+        "cask": "jewelrybox",
+        "count": "17"
+      }
+    ],
+    "jgrasp": [
+      {
+        "cask": "jgrasp",
+        "count": "108"
+      }
+    ],
+    "jgrasp-bundle": [
+      {
+        "cask": "jgrasp-bundle",
+        "count": "1"
+      }
+    ],
+    "jietu": [
+      {
+        "cask": "jietu",
+        "count": "359"
+      }
+    ],
+    "jiggler": [
+      {
+        "cask": "jiggler",
+        "count": "599"
+      }
+    ],
+    "jing": [
+      {
+        "cask": "jing",
+        "count": "323"
+      }
+    ],
+    "jira-client": [
+      {
+        "cask": "jira-client",
+        "count": "701"
+      }
+    ],
+    "jiratool": [
+      {
+        "cask": "jiratool",
+        "count": "1"
+      }
+    ],
+    "jitouch": [
+      {
+        "cask": "jitouch",
+        "count": "138"
+      }
+    ],
+    "jitsi": [
+      {
+        "cask": "jitsi",
+        "count": "880"
+      }
+    ],
+    "jitsi-meet": [
+      {
+        "cask": "jitsi-meet",
+        "count": "1,260"
+      }
+    ],
+    "jlutil": [
+      {
+        "cask": "jlutil",
+        "count": "1"
+      }
+    ],
+    "jmc": [
+      {
+        "cask": "jmc",
+        "count": "225"
+      }
+    ],
+    "jmetrik": [
+      {
+        "cask": "jmetrik",
+        "count": "2"
+      }
+    ],
+    "joinme": [
+      {
+        "cask": "joinme",
+        "count": "215"
+      }
+    ],
+    "joker": [
+      {
+        "cask": "joker",
+        "count": "112"
+      }
+    ],
+    "jollysfastvnc": [
+      {
+        "cask": "jollysfastvnc",
+        "count": "282"
+      }
+    ],
+    "joox": [
+      {
+        "cask": "joox",
+        "count": "2"
+      }
+    ],
+    "joplin": [
+      {
+        "cask": "joplin",
+        "count": "15,670"
+      }
+    ],
+    "joshaven-winbox": [
+      {
+        "cask": "joshaven-winbox",
+        "count": "357"
+      }
+    ],
+    "josm": [
+      {
+        "cask": "josm",
+        "count": "1,221"
+      }
+    ],
+    "jotta": [
+      {
+        "cask": "jotta",
+        "count": "6"
+      }
+    ],
+    "journey": [
+      {
+        "cask": "journey",
+        "count": "120"
+      }
+    ],
+    "jprofiler": [
+      {
+        "cask": "jprofiler",
+        "count": "531"
+      }
+    ],
+    "jqbx": [
+      {
+        "cask": "jqbx",
+        "count": "105"
+      }
+    ],
+    "jsanjuan": [
+      {
+        "cask": "jsanjuan",
+        "count": "3"
+      }
+    ],
+    "jsl": [
+      {
+        "cask": "jsl",
+        "count": "35"
+      }
+    ],
+    "jsontohandyjson": [
+      {
+        "cask": "jsontohandyjson",
+        "count": "3"
+      }
+    ],
+    "jsui": [
+      {
+        "cask": "jsui",
+        "count": "35"
+      }
+    ],
+    "jtool": [
+      {
+        "cask": "jtool",
+        "count": "482"
+      }
+    ],
+    "jtool2": [
+      {
+        "cask": "jtool2",
+        "count": "152"
+      }
+    ],
+    "jubler": [
+      {
+        "cask": "jubler",
+        "count": "183"
+      }
+    ],
+    "juicebar": [
+      {
+        "cask": "juicebar",
+        "count": "2"
+      }
+    ],
+    "juicysfplugin": [
+      {
+        "cask": "juicysfplugin",
+        "count": "2"
+      }
+    ],
+    "julia": [
+      {
+        "cask": "julia",
+        "count": "12,170"
+      }
+    ],
+    "julia-lts": [
+      {
+        "cask": "julia-lts",
+        "count": "21"
+      }
+    ],
+    "julia-nightly": [
+      {
+        "cask": "julia-nightly",
+        "count": "82"
+      }
+    ],
+    "julia-rc": [
+      {
+        "cask": "julia-rc",
+        "count": "5"
+      }
+    ],
+    "julia@1.0": [
+      {
+        "cask": "julia@1.0",
+        "count": "1"
+      }
+    ],
+    "julia@1.1": [
+      {
+        "cask": "julia@1.1",
+        "count": "1"
+      }
+    ],
+    "julia@1.2": [
+      {
+        "cask": "julia@1.2",
+        "count": "3"
+      }
+    ],
+    "jump": [
+      {
+        "cask": "jump",
+        "count": "123"
+      }
+    ],
+    "jump-desktop-connect": [
+      {
+        "cask": "jump-desktop-connect",
+        "count": "4"
+      }
+    ],
+    "jumpcut": [
+      {
+        "cask": "jumpcut",
+        "count": "5,476"
+      }
+    ],
+    "jumpcut-elcapitan": [
+      {
+        "cask": "jumpcut-elcapitan",
+        "count": "2"
+      }
+    ],
+    "jumpshare": [
+      {
+        "cask": "jumpshare",
+        "count": "51"
+      }
+    ],
+    "jupyter-notebook-ql": [
+      {
+        "cask": "jupyter-notebook-ql",
+        "count": "629"
+      }
+    ],
+    "jupyter-notebook-viewer": [
+      {
+        "cask": "jupyter-notebook-viewer",
+        "count": "2,116"
+      }
+    ],
+    "k2tf": [
+      {
+        "cask": "k2tf",
+        "count": "1"
+      }
+    ],
+    "k40-whisperer": [
+      {
+        "cask": "k40-whisperer",
+        "count": "1"
+      }
+    ],
+    "kactus": [
+      {
+        "cask": "kactus",
+        "count": "47"
+      }
+    ],
+    "kafka-tool": [
+      {
+        "cask": "kafka-tool",
+        "count": "1,077"
+      }
+    ],
+    "kaiosrt": [
+      {
+        "cask": "kaiosrt",
+        "count": "2"
+      }
+    ],
+    "kairatune-au": [
+      {
+        "cask": "kairatune-au",
+        "count": "1"
+      }
+    ],
+    "kairatune_vst": [
+      {
+        "cask": "kairatune_vst",
+        "count": "1"
+      }
+    ],
+    "kakao-work": [
+      {
+        "cask": "kakao-work",
+        "count": "2"
+      }
+    ],
+    "kakapo": [
+      {
+        "cask": "kakapo",
+        "count": "31"
+      }
+    ],
+    "kaku": [
+      {
+        "cask": "kaku",
+        "count": "14"
+      }
+    ],
+    "kaleidoscope": [
+      {
+        "cask": "kaleidoscope",
+        "count": "2,202"
+      }
+    ],
+    "kanmail": [
+      {
+        "cask": "kanmail",
+        "count": "1"
+      }
+    ],
+    "kaomoji": [
+      {
+        "cask": "kaomoji",
+        "count": "8"
+      }
+    ],
+    "kap": [
+      {
+        "cask": "kap",
+        "count": "6,295"
+      }
+    ],
+    "kap-beta": [
+      {
+        "cask": "kap-beta",
+        "count": "48"
+      }
+    ],
+    "kapitainsky-rclone-browser": [
+      {
+        "cask": "kapitainsky-rclone-browser",
+        "count": "48"
+      }
+    ],
+    "kapow": [
+      {
+        "cask": "kapow",
+        "count": "52"
+      }
+    ],
+    "kappapp": [
+      {
+        "cask": "kappapp",
+        "count": "1"
+      }
+    ],
+    "karabiner": [
+      {
+        "cask": "karabiner",
+        "count": "19"
+      }
+    ],
+    "karabiner-elements": [
+      {
+        "cask": "karabiner-elements",
+        "count": "19,359"
+      }
+    ],
+    "katalon-studio": [
+      {
+        "cask": "katalon-studio",
+        "count": "470"
+      }
+    ],
+    "katana": [
+      {
+        "cask": "katana",
+        "count": "99"
+      }
+    ],
+    "kawa": [
+      {
+        "cask": "kawa",
+        "count": "588"
+      }
+    ],
+    "kc-ausweisapp2": [
+      {
+        "cask": "kc-ausweisapp2",
+        "count": "3"
+      }
+    ],
+    "kc-knockknock": [
+      {
+        "cask": "kc-knockknock",
+        "count": "1"
+      }
+    ],
+    "kc-reinersct-cyberjack-rfid-standard": [
+      {
+        "cask": "kc-reinersct-cyberjack-rfid-standard",
+        "count": "2"
+      }
+    ],
+    "kc-reinersct-cyberjack-rfid-standard-driver": [
+      {
+        "cask": "kc-reinersct-cyberjack-rfid-standard-driver",
+        "count": "2"
+      }
+    ],
+    "kc-safari-fido-u2f": [
+      {
+        "cask": "kc-safari-fido-u2f",
+        "count": "1"
+      }
+    ],
+    "kde-connect": [
+      {
+        "cask": "kde-connect",
+        "count": "3"
+      }
+    ],
+    "kdiff3": [
+      {
+        "cask": "kdiff3",
+        "count": "2,632"
+      }
+    ],
+    "keep": [
+      {
+        "cask": "keep",
+        "count": "236"
+      }
+    ],
+    "keep-it": [
+      {
+        "cask": "keep-it",
+        "count": "44"
+      }
+    ],
+    "keepassx": [
+      {
+        "cask": "keepassx",
+        "count": "6,296"
+      }
+    ],
+    "keepassxc": [
+      {
+        "cask": "keepassxc",
+        "count": "36,677"
+      }
+    ],
+    "keepassxc-beta": [
+      {
+        "cask": "keepassxc-beta",
+        "count": "73"
+      }
+    ],
+    "keepassxc-snapshot": [
+      {
+        "cask": "keepassxc-snapshot",
+        "count": "27"
+      }
+    ],
+    "keeper-password-manager": [
+      {
+        "cask": "keeper-password-manager",
+        "count": "225"
+      }
+    ],
+    "keepingyouawake": [
+      {
+        "cask": "keepingyouawake",
+        "count": "10,266"
+      }
+    ],
+    "keepmeconnected": [
+      {
+        "cask": "keepmeconnected",
+        "count": "2"
+      }
+    ],
+    "keepvid-music-tag-editor": [
+      {
+        "cask": "keepvid-music-tag-editor",
+        "count": "1"
+      }
+    ],
+    "keeweb": [
+      {
+        "cask": "keeweb",
+        "count": "1,460"
+      }
+    ],
+    "keka": [
+      {
+        "cask": "keka",
+        "count": "19,459"
+      }
+    ],
+    "keka-beta": [
+      {
+        "cask": "keka-beta",
+        "count": "136"
+      }
+    ],
+    "keka-custom": [
+      {
+        "cask": "keka-custom",
+        "count": "2"
+      }
+    ],
+    "kekadefaultapp": [
+      {
+        "cask": "kekadefaultapp",
+        "count": "917"
+      }
+    ],
+    "kellerkinder-time-machine-status": [
+      {
+        "cask": "kellerkinder-time-machine-status",
+        "count": "5"
+      }
+    ],
+    "kensington-trackball-works": [
+      {
+        "cask": "kensington-trackball-works",
+        "count": "116"
+      }
+    ],
+    "kerio-control-vpn-client": [
+      {
+        "cask": "kerio-control-vpn-client",
+        "count": "5"
+      }
+    ],
+    "kern": [
+      {
+        "cask": "kern",
+        "count": "4"
+      }
+    ],
+    "kernel": [
+      {
+        "cask": "kernel",
+        "count": "11"
+      }
+    ],
+    "kext-updater": [
+      {
+        "cask": "kext-updater",
+        "count": "203"
+      }
+    ],
+    "kext-utility": [
+      {
+        "cask": "kext-utility",
+        "count": "567"
+      }
+    ],
+    "kextviewr": [
+      {
+        "cask": "kextviewr",
+        "count": "279"
+      }
+    ],
+    "key-codes": [
+      {
+        "cask": "key-codes",
+        "count": "227"
+      }
+    ],
+    "keyaccess": [
+      {
+        "cask": "keyaccess",
+        "count": "1"
+      }
+    ],
+    "keybase": [
+      {
+        "cask": "keybase",
+        "count": "12,339"
+      }
+    ],
+    "keyboard": [
+      {
+        "cask": "keyboard",
+        "count": "5"
+      }
+    ],
+    "keyboard-cleaner": [
+      {
+        "cask": "keyboard-cleaner",
+        "count": "748"
+      }
+    ],
+    "keyboard-lock": [
+      {
+        "cask": "keyboard-lock",
+        "count": "65"
+      }
+    ],
+    "keyboard-maestro": [
+      {
+        "cask": "keyboard-maestro",
+        "count": "1,820"
+      }
+    ],
+    "keyboard-maestro8": [
+      {
+        "cask": "keyboard-maestro8",
+        "count": "15"
+      }
+    ],
+    "keyboardcleantool": [
+      {
+        "cask": "keyboardcleantool",
+        "count": "905"
+      }
+    ],
+    "keycast": [
+      {
+        "cask": "keycast",
+        "count": "97"
+      }
+    ],
+    "keycastr": [
+      {
+        "cask": "keycastr",
+        "count": "7,349"
+      }
+    ],
+    "keychain-pkcs11": [
+      {
+        "cask": "keychain-pkcs11",
+        "count": "10"
+      }
+    ],
+    "keychaincheck2": [
+      {
+        "cask": "keychaincheck2",
+        "count": "15"
+      }
+    ],
+    "keycue": [
+      {
+        "cask": "keycue",
+        "count": "143"
+      }
+    ],
+    "keyfinder": [
+      {
+        "cask": "keyfinder",
+        "count": "26"
+      }
+    ],
+    "keylayout-colemak": [
+      {
+        "cask": "keylayout-colemak",
+        "count": "2"
+      }
+    ],
+    "keyman": [
+      {
+        "cask": "keyman",
+        "count": "3"
+      }
+    ],
+    "keymanager": [
+      {
+        "cask": "keymanager",
+        "count": "54"
+      }
+    ],
+    "keymou": [
+      {
+        "cask": "keymou",
+        "count": "6"
+      }
+    ],
+    "keypad-layout": [
+      {
+        "cask": "keypad-layout",
+        "count": "40"
+      }
+    ],
+    "keys": [
+      {
+        "cask": "keys",
+        "count": "4"
+      }
+    ],
+    "keyshot": [
+      {
+        "cask": "keyshot",
+        "count": "11"
+      }
+    ],
+    "keystore-explorer": [
+      {
+        "cask": "keystore-explorer",
+        "count": "1,224"
+      }
+    ],
+    "keyzoneclassic": [
+      {
+        "cask": "keyzoneclassic",
+        "count": "4"
+      }
+    ],
+    "khmer-unicode-layout": [
+      {
+        "cask": "khmer-unicode-layout",
+        "count": "2"
+      }
+    ],
+    "kicad": [
+      {
+        "cask": "kicad",
+        "count": "1,482"
+      }
+    ],
+    "kid3": [
+      {
+        "cask": "kid3",
+        "count": "1,595"
+      }
+    ],
+    "kii": [
+      {
+        "cask": "kii",
+        "count": "1"
+      }
+    ],
+    "kiibohd-configurator": [
+      {
+        "cask": "kiibohd-configurator",
+        "count": "37"
+      }
+    ],
+    "kindle": [
+      {
+        "cask": "kindle",
+        "count": "7,413"
+      }
+    ],
+    "kindle-1.23": [
+      {
+        "cask": "kindle-1.23",
+        "count": "1"
+      }
+    ],
+    "kindle-50131": [
+      {
+        "cask": "kindle-50131",
+        "count": "3"
+      }
+    ],
+    "kindle-comic-converter": [
+      {
+        "cask": "kindle-comic-converter",
+        "count": "180"
+      }
+    ],
+    "kindle-comic-creator": [
+      {
+        "cask": "kindle-comic-creator",
+        "count": "808"
+      }
+    ],
+    "kindle-previewer": [
+      {
+        "cask": "kindle-previewer",
+        "count": "459"
+      }
+    ],
+    "kindle@1.25.2": [
+      {
+        "cask": "kindle@1.25.2",
+        "count": "1"
+      }
+    ],
+    "kindle_50131": [
+      {
+        "cask": "kindle_50131",
+        "count": "1"
+      }
+    ],
+    "kindle_55093": [
+      {
+        "cask": "kindle_55093",
+        "count": "1"
+      }
+    ],
+    "kindlegen": [
+      {
+        "cask": "kindlegen",
+        "count": "2,262"
+      }
+    ],
+    "kinesis-smart-set": [
+      {
+        "cask": "kinesis-smart-set",
+        "count": "2"
+      }
+    ],
+    "kinesis-smartset": [
+      {
+        "cask": "kinesis-smartset",
+        "count": "3"
+      }
+    ],
+    "kinsky": [
+      {
+        "cask": "kinsky",
+        "count": "5"
+      }
+    ],
+    "kinza": [
+      {
+        "cask": "kinza",
+        "count": "8"
+      }
+    ],
+    "kitabu": [
+      {
+        "cask": "kitabu",
+        "count": "66"
+      }
+    ],
+    "kite": [
+      {
+        "cask": "kite",
+        "count": "1,619"
+      }
+    ],
+    "kitematic": [
+      {
+        "cask": "kitematic",
+        "count": "11,410"
+      }
+    ],
+    "kitematic0176": [
+      {
+        "cask": "kitematic0176",
+        "count": "12"
+      }
+    ],
+    "kitt": [
+      {
+        "cask": "kitt",
+        "count": "6"
+      }
+    ],
+    "kitty": [
+      {
+        "cask": "kitty",
+        "count": "11,056"
+      }
+    ],
+    "kitty13": [
+      {
+        "cask": "kitty13",
+        "count": "1"
+      }
+    ],
+    "kiwi-for-g-suite": [
+      {
+        "cask": "kiwi-for-g-suite",
+        "count": "114"
+      }
+    ],
+    "kiwix": [
+      {
+        "cask": "kiwix",
+        "count": "145"
+      }
+    ],
+    "kk7ds-python-runtime": [
+      {
+        "cask": "kk7ds-python-runtime",
+        "count": "138"
+      }
+    ],
+    "kkbox": [
+      {
+        "cask": "kkbox",
+        "count": "78"
+      }
+    ],
+    "klanghelm-vumt": [
+      {
+        "cask": "klanghelm-vumt",
+        "count": "1"
+      }
+    ],
+    "klatexformula": [
+      {
+        "cask": "klatexformula",
+        "count": "98"
+      }
+    ],
+    "klayout": [
+      {
+        "cask": "klayout",
+        "count": "107"
+      }
+    ],
+    "klokki": [
+      {
+        "cask": "klokki",
+        "count": "24"
+      }
+    ],
+    "kmbmpdc": [
+      {
+        "cask": "kmbmpdc",
+        "count": "67"
+      }
+    ],
+    "kmplayer": [
+      {
+        "cask": "kmplayer",
+        "count": "336"
+      }
+    ],
+    "knime": [
+      {
+        "cask": "knime",
+        "count": "248"
+      }
+    ],
+    "knock": [
+      {
+        "cask": "knock",
+        "count": "60"
+      }
+    ],
+    "knockknock": [
+      {
+        "cask": "knockknock",
+        "count": "1,227"
+      }
+    ],
+    "knotes": [
+      {
+        "cask": "knotes",
+        "count": "54"
+      }
+    ],
+    "knox": [
+      {
+        "cask": "knox",
+        "count": "70"
+      }
+    ],
+    "knuff": [
+      {
+        "cask": "knuff",
+        "count": "39"
+      }
+    ],
+    "koa11y": [
+      {
+        "cask": "koa11y",
+        "count": "39"
+      }
+    ],
+    "koala": [
+      {
+        "cask": "koala",
+        "count": "120"
+      }
+    ],
+    "kobo": [
+      {
+        "cask": "kobo",
+        "count": "387"
+      }
+    ],
+    "kode54-cog": [
+      {
+        "cask": "kode54-cog",
+        "count": "255"
+      }
+    ],
+    "kodelife": [
+      {
+        "cask": "kodelife",
+        "count": "54"
+      }
+    ],
+    "kodi": [
+      {
+        "cask": "kodi",
+        "count": "3,515"
+      }
+    ],
+    "kodi-development": [
+      {
+        "cask": "kodi-development",
+        "count": "2"
+      }
+    ],
+    "komet": [
+      {
+        "cask": "komet",
+        "count": "3"
+      }
+    ],
+    "komodo-edit": [
+      {
+        "cask": "komodo-edit",
+        "count": "248"
+      }
+    ],
+    "komodo-ide": [
+      {
+        "cask": "komodo-ide",
+        "count": "110"
+      }
+    ],
+    "kompozer": [
+      {
+        "cask": "kompozer",
+        "count": "67"
+      }
+    ],
+    "konica-minolta-bizhub-c220-c280-c360-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c220-c280-c360-driver",
+        "count": "112"
+      }
+    ],
+    "konica-minolta-bizhub-c250i-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c250i-driver",
+        "count": "1"
+      }
+    ],
+    "konica-minolta-bizhub-c554-c364-109-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c554-c364-109-driver",
+        "count": "21"
+      }
+    ],
+    "konica-minolta-bizhub-c650i-c360i-c4005i-c4000i-c3320i-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c650i-c360i-c4005i-c4000i-c3320i-driver",
+        "count": "2"
+      }
+    ],
+    "konica-minolta-bizhub-c650i-c360i-c4050i-c4000i-c3320i-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c650i-c360i-c4050i-c4000i-c3320i-driver",
+        "count": "115"
+      }
+    ],
+    "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver",
+        "count": "61"
+      }
+    ],
+    "kopypasta": [
+      {
+        "cask": "kopypasta",
+        "count": "5"
+      }
+    ],
+    "korean-spelling-checker": [
+      {
+        "cask": "korean-spelling-checker",
+        "count": "8"
+      }
+    ],
+    "kotlin-native": [
+      {
+        "cask": "kotlin-native",
+        "count": "558"
+      }
+    ],
+    "koto-qt": [
+      {
+        "cask": "koto-qt",
+        "count": "1"
+      }
+    ],
+    "kpsaver": [
+      {
+        "cask": "kpsaver",
+        "count": "1"
+      }
+    ],
+    "kptransfer-test": [
+      {
+        "cask": "kptransfer-test",
+        "count": "1"
+      }
+    ],
+    "krew": [
+      {
+        "cask": "krew",
+        "count": "16"
+      }
+    ],
+    "krisp": [
+      {
+        "cask": "krisp",
+        "count": "1,036"
+      }
+    ],
+    "krita": [
+      {
+        "cask": "krita",
+        "count": "3,464"
+      }
+    ],
+    "krita-dev": [
+      {
+        "cask": "krita-dev",
+        "count": "8"
+      }
+    ],
+    "kroger-ascii": [
+      {
+        "cask": "kroger-ascii",
+        "count": "1"
+      }
+    ],
+    "krush": [
+      {
+        "cask": "krush",
+        "count": "4"
+      }
+    ],
+    "ksdiff": [
+      {
+        "cask": "ksdiff",
+        "count": "517"
+      }
+    ],
+    "kse": [
+      {
+        "cask": "kse",
+        "count": "2"
+      }
+    ],
+    "kstars": [
+      {
+        "cask": "kstars",
+        "count": "62"
+      }
+    ],
+    "kubar": [
+      {
+        "cask": "kubar",
+        "count": "6"
+      }
+    ],
+    "kube-cluster": [
+      {
+        "cask": "kube-cluster",
+        "count": "36"
+      }
+    ],
+    "kube-forwarder": [
+      {
+        "cask": "kube-forwarder",
+        "count": "581"
+      }
+    ],
+    "kube-solo": [
+      {
+        "cask": "kube-solo",
+        "count": "8"
+      }
+    ],
+    "kubebuilder": [
+      {
+        "cask": "kubebuilder",
+        "count": "18"
+      }
+    ],
+    "kubecontext": [
+      {
+        "cask": "kubecontext",
+        "count": "490"
+      }
+    ],
+    "kubedog": [
+      {
+        "cask": "kubedog",
+        "count": "1"
+      }
+    ],
+    "kubenav": [
+      {
+        "cask": "kubenav",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.10.11": [
+      {
+        "cask": "kubernetes-cli-1.10.11",
+        "count": "7"
+      }
+    ],
+    "kubernetes-cli-1.10.13": [
+      {
+        "cask": "kubernetes-cli-1.10.13",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.10.5": [
+      {
+        "cask": "kubernetes-cli-1.10.5",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.10.6": [
+      {
+        "cask": "kubernetes-cli-1.10.6",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.11.10": [
+      {
+        "cask": "kubernetes-cli-1.11.10",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.11.3": [
+      {
+        "cask": "kubernetes-cli-1.11.3",
+        "count": "4"
+      }
+    ],
+    "kubernetes-cli-1.11.4": [
+      {
+        "cask": "kubernetes-cli-1.11.4",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.11.9": [
+      {
+        "cask": "kubernetes-cli-1.11.9",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.12.0": [
+      {
+        "cask": "kubernetes-cli-1.12.0",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.12.10": [
+      {
+        "cask": "kubernetes-cli-1.12.10",
+        "count": "3"
+      }
+    ],
+    "kubernetes-cli-1.12.3": [
+      {
+        "cask": "kubernetes-cli-1.12.3",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.12.8": [
+      {
+        "cask": "kubernetes-cli-1.12.8",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.12.9": [
+      {
+        "cask": "kubernetes-cli-1.12.9",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.13.0": [
+      {
+        "cask": "kubernetes-cli-1.13.0",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.10": [
+      {
+        "cask": "kubernetes-cli-1.13.10",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.13.11": [
+      {
+        "cask": "kubernetes-cli-1.13.11",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.12": [
+      {
+        "cask": "kubernetes-cli-1.13.12",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.13.2": [
+      {
+        "cask": "kubernetes-cli-1.13.2",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.6": [
+      {
+        "cask": "kubernetes-cli-1.13.6",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.13.8": [
+      {
+        "cask": "kubernetes-cli-1.13.8",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.9": [
+      {
+        "cask": "kubernetes-cli-1.13.9",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.14.2": [
+      {
+        "cask": "kubernetes-cli-1.14.2",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.14.3": [
+      {
+        "cask": "kubernetes-cli-1.14.3",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.14.6": [
+      {
+        "cask": "kubernetes-cli-1.14.6",
+        "count": "8"
+      }
+    ],
+    "kubernetes-cli-1.14.7": [
+      {
+        "cask": "kubernetes-cli-1.14.7",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.14.9": [
+      {
+        "cask": "kubernetes-cli-1.14.9",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.15.0": [
+      {
+        "cask": "kubernetes-cli-1.15.0",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.15.11": [
+      {
+        "cask": "kubernetes-cli-1.15.11",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.15.3": [
+      {
+        "cask": "kubernetes-cli-1.15.3",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.15.5": [
+      {
+        "cask": "kubernetes-cli-1.15.5",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.15.6": [
+      {
+        "cask": "kubernetes-cli-1.15.6",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.16.1": [
+      {
+        "cask": "kubernetes-cli-1.16.1",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.16.2": [
+      {
+        "cask": "kubernetes-cli-1.16.2",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.16.3": [
+      {
+        "cask": "kubernetes-cli-1.16.3",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.16.6": [
+      {
+        "cask": "kubernetes-cli-1.16.6",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.16.8": [
+      {
+        "cask": "kubernetes-cli-1.16.8",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.17.0": [
+      {
+        "cask": "kubernetes-cli-1.17.0",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.17.4": [
+      {
+        "cask": "kubernetes-cli-1.17.4",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.8.15": [
+      {
+        "cask": "kubernetes-cli-1.8.15",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.8.6": [
+      {
+        "cask": "kubernetes-cli-1.8.6",
+        "count": "1"
+      }
+    ],
+    "kubernetic": [
+      {
+        "cask": "kubernetic",
+        "count": "811"
+      }
+    ],
+    "kubespy": [
+      {
+        "cask": "kubespy",
+        "count": "1"
+      }
+    ],
+    "kugoumusic": [
+      {
+        "cask": "kugoumusic",
+        "count": "219"
+      }
+    ],
+    "kui": [
+      {
+        "cask": "kui",
+        "count": "9"
+      }
+    ],
+    "kvirc": [
+      {
+        "cask": "kvirc",
+        "count": "118"
+      }
+    ],
+    "kyocera": [
+      {
+        "cask": "kyocera",
+        "count": "7"
+      }
+    ],
+    "kyocera-printer": [
+      {
+        "cask": "kyocera-printer",
+        "count": "1"
+      }
+    ],
+    "kyocera-printer-drivers": [
+      {
+        "cask": "kyocera-printer-drivers",
+        "count": "2"
+      }
+    ],
+    "lab": [
+      {
+        "cask": "lab",
+        "count": "48"
+      }
+    ],
+    "labelme": [
+      {
+        "cask": "labelme",
+        "count": "654"
+      }
+    ],
+    "lacaille": [
+      {
+        "cask": "lacaille",
+        "count": "5"
+      }
+    ],
+    "lacie-network-assistant": [
+      {
+        "cask": "lacie-network-assistant",
+        "count": "6"
+      }
+    ],
+    "lacona": [
+      {
+        "cask": "lacona",
+        "count": "106"
+      }
+    ],
+    "ladiomanager": [
+      {
+        "cask": "ladiomanager",
+        "count": "1"
+      }
+    ],
+    "lando": [
+      {
+        "cask": "lando",
+        "count": "2,853"
+      }
+    ],
+    "language-switcher": [
+      {
+        "cask": "language-switcher",
+        "count": "68"
+      }
+    ],
+    "lantern": [
+      {
+        "cask": "lantern",
+        "count": "703"
+      }
+    ],
+    "laplock": [
+      {
+        "cask": "laplock",
+        "count": "5"
+      }
+    ],
+    "laravel-kit": [
+      {
+        "cask": "laravel-kit",
+        "count": "125"
+      }
+    ],
+    "lark": [
+      {
+        "cask": "lark",
+        "count": "79"
+      }
+    ],
+    "lastfm": [
+      {
+        "cask": "lastfm",
+        "count": "369"
+      }
+    ],
+    "lastpass": [
+      {
+        "cask": "lastpass",
+        "count": "6,984"
+      }
+    ],
+    "latest": [
+      {
+        "cask": "latest",
+        "count": "657"
+      }
+    ],
+    "latexdraw": [
+      {
+        "cask": "latexdraw",
+        "count": "169"
+      }
+    ],
+    "latexit": [
+      {
+        "cask": "latexit",
+        "count": "2,109"
+      }
+    ],
+    "launchbar": [
+      {
+        "cask": "launchbar",
+        "count": "941"
+      }
+    ],
+    "launchbar4": [
+      {
+        "cask": "launchbar4",
+        "count": "2"
+      }
+    ],
+    "launchbar@4": [
+      {
+        "cask": "launchbar@4",
+        "count": "2"
+      }
+    ],
+    "launchcontrol": [
+      {
+        "cask": "launchcontrol",
+        "count": "3,386"
+      }
+    ],
+    "launchpad-manager": [
+      {
+        "cask": "launchpad-manager",
+        "count": "218"
+      }
+    ],
+    "launchpad-manager-yosemite": [
+      {
+        "cask": "launchpad-manager-yosemite",
+        "count": "77"
+      }
+    ],
+    "launchrocket": [
+      {
+        "cask": "launchrocket",
+        "count": "4,945"
+      }
+    ],
+    "launchy": [
+      {
+        "cask": "launchy",
+        "count": "50"
+      }
+    ],
+    "laverna": [
+      {
+        "cask": "laverna",
+        "count": "76"
+      }
+    ],
+    "lazarus": [
+      {
+        "cask": "lazarus",
+        "count": "501"
+      }
+    ],
+    "lazpaint": [
+      {
+        "cask": "lazpaint",
+        "count": "63"
+      }
+    ],
+    "lazy": [
+      {
+        "cask": "lazy",
+        "count": "8"
+      }
+    ],
+    "lazygit": [
+      {
+        "cask": "lazygit",
+        "count": "1"
+      }
+    ],
+    "lbry": [
+      {
+        "cask": "lbry",
+        "count": "204"
+      }
+    ],
+    "lds-vagrant": [
+      {
+        "cask": "lds-vagrant",
+        "count": "29"
+      }
+    ],
+    "league-displays": [
+      {
+        "cask": "league-displays",
+        "count": "8"
+      }
+    ],
+    "league-of-legends": [
+      {
+        "cask": "league-of-legends",
+        "count": "1,823"
+      }
+    ],
+    "league-of-legends-kr": [
+      {
+        "cask": "league-of-legends-kr",
+        "count": "4"
+      }
+    ],
+    "leanote": [
+      {
+        "cask": "leanote",
+        "count": "85"
+      }
+    ],
+    "leanpub": [
+      {
+        "cask": "leanpub",
+        "count": "36"
+      }
+    ],
+    "leap": [
+      {
+        "cask": "leap",
+        "count": "2"
+      }
+    ],
+    "leap-motion": [
+      {
+        "cask": "leap-motion",
+        "count": "56"
+      }
+    ],
+    "lectionary": [
+      {
+        "cask": "lectionary",
+        "count": "2"
+      }
+    ],
+    "ledger-live": [
+      {
+        "cask": "ledger-live",
+        "count": "736"
+      }
+    ],
+    "leech": [
+      {
+        "cask": "leech",
+        "count": "83"
+      }
+    ],
+    "leela": [
+      {
+        "cask": "leela",
+        "count": "1"
+      }
+    ],
+    "lego-digital-designer": [
+      {
+        "cask": "lego-digital-designer",
+        "count": "86"
+      }
+    ],
+    "lego-mindstorms-ev3": [
+      {
+        "cask": "lego-mindstorms-ev3",
+        "count": "141"
+      }
+    ],
+    "lehreroffice": [
+      {
+        "cask": "lehreroffice",
+        "count": "6"
+      }
+    ],
+    "leksah": [
+      {
+        "cask": "leksah",
+        "count": "96"
+      }
+    ],
+    "lektor": [
+      {
+        "cask": "lektor",
+        "count": "44"
+      }
+    ],
+    "lelivrescolairefr": [
+      {
+        "cask": "lelivrescolairefr",
+        "count": "10"
+      }
+    ],
+    "lennardigital-sylenth1": [
+      {
+        "cask": "lennardigital-sylenth1",
+        "count": "1"
+      }
+    ],
+    "lens": [
+      {
+        "cask": "lens",
+        "count": "647"
+      }
+    ],
+    "leocad": [
+      {
+        "cask": "leocad",
+        "count": "56"
+      }
+    ],
+    "lepou-hybrit-au": [
+      {
+        "cask": "lepou-hybrit-au",
+        "count": "1"
+      }
+    ],
+    "lepton": [
+      {
+        "cask": "lepton",
+        "count": "2,142"
+      }
+    ],
+    "lets-view": [
+      {
+        "cask": "lets-view",
+        "count": "1"
+      }
+    ],
+    "letsview": [
+      {
+        "cask": "letsview",
+        "count": "4"
+      }
+    ],
+    "letterfix": [
+      {
+        "cask": "letterfix",
+        "count": "6"
+      }
+    ],
+    "levelator": [
+      {
+        "cask": "levelator",
+        "count": "32"
+      }
+    ],
+    "lg-onscreen-control": [
+      {
+        "cask": "lg-onscreen-control",
+        "count": "165"
+      }
+    ],
+    "liberica-jdk": [
+      {
+        "cask": "liberica-jdk",
+        "count": "1"
+      }
+    ],
+    "liberica-jdk11": [
+      {
+        "cask": "liberica-jdk11",
+        "count": "92"
+      }
+    ],
+    "liberica-jdk11-full": [
+      {
+        "cask": "liberica-jdk11-full",
+        "count": "21"
+      }
+    ],
+    "liberica-jdk11-lite": [
+      {
+        "cask": "liberica-jdk11-lite",
+        "count": "2"
+      }
+    ],
+    "liberica-jdk12": [
+      {
+        "cask": "liberica-jdk12",
+        "count": "25"
+      }
+    ],
+    "liberica-jdk12-lite": [
+      {
+        "cask": "liberica-jdk12-lite",
+        "count": "5"
+      }
+    ],
+    "liberica-jdk13": [
+      {
+        "cask": "liberica-jdk13",
+        "count": "39"
+      }
+    ],
+    "liberica-jdk13-full": [
+      {
+        "cask": "liberica-jdk13-full",
+        "count": "12"
+      }
+    ],
+    "liberica-jdk13-lite": [
+      {
+        "cask": "liberica-jdk13-lite",
+        "count": "7"
+      }
+    ],
+    "liberica-jdk14": [
+      {
+        "cask": "liberica-jdk14",
+        "count": "19"
+      }
+    ],
+    "liberica-jdk14-full": [
+      {
+        "cask": "liberica-jdk14-full",
+        "count": "21"
+      }
+    ],
+    "liberica-jdk14-lite": [
+      {
+        "cask": "liberica-jdk14-lite",
+        "count": "3"
+      }
+    ],
+    "liberica-jdk8": [
+      {
+        "cask": "liberica-jdk8",
+        "count": "1,440"
+      }
+    ],
+    "liberica-jdk8-full": [
+      {
+        "cask": "liberica-jdk8-full",
+        "count": "463"
+      }
+    ],
+    "liberica-jre11": [
+      {
+        "cask": "liberica-jre11",
+        "count": "6"
+      }
+    ],
+    "liberica-jre11-full": [
+      {
+        "cask": "liberica-jre11-full",
+        "count": "3"
+      }
+    ],
+    "liberica-jre13": [
+      {
+        "cask": "liberica-jre13",
+        "count": "5"
+      }
+    ],
+    "liberica-jre13-full": [
+      {
+        "cask": "liberica-jre13-full",
+        "count": "3"
+      }
+    ],
+    "liberica-jre14": [
+      {
+        "cask": "liberica-jre14",
+        "count": "2"
+      }
+    ],
+    "liberica-jre14-full": [
+      {
+        "cask": "liberica-jre14-full",
+        "count": "2"
+      }
+    ],
+    "liberica-jre8": [
+      {
+        "cask": "liberica-jre8",
+        "count": "11"
+      }
+    ],
+    "liberica-jre8-full": [
+      {
+        "cask": "liberica-jre8-full",
+        "count": "10"
+      }
+    ],
+    "librecad": [
+      {
+        "cask": "librecad",
+        "count": "815"
+      }
+    ],
+    "libreelec-usb-sd-creator": [
+      {
+        "cask": "libreelec-usb-sd-creator",
+        "count": "110"
+      }
+    ],
+    "libreoffice": [
+      {
+        "cask": "libreoffice",
+        "count": "38,284"
+      }
+    ],
+    "libreoffice-language-pack": [
+      {
+        "cask": "libreoffice-language-pack",
+        "count": "4,725"
+      }
+    ],
+    "libreoffice-rc": [
+      {
+        "cask": "libreoffice-rc",
+        "count": "31"
+      }
+    ],
+    "libreoffice-still": [
+      {
+        "cask": "libreoffice-still",
+        "count": "145"
+      }
+    ],
+    "libreofficeja": [
+      {
+        "cask": "libreofficeja",
+        "count": "10"
+      }
+    ],
+    "librepcb": [
+      {
+        "cask": "librepcb",
+        "count": "9"
+      }
+    ],
+    "licecap": [
+      {
+        "cask": "licecap",
+        "count": "4,644"
+      }
+    ],
+    "license-control-center": [
+      {
+        "cask": "license-control-center",
+        "count": "14"
+      }
+    ],
+    "licensed": [
+      {
+        "cask": "licensed",
+        "count": "20"
+      }
+    ],
+    "liclipse": [
+      {
+        "cask": "liclipse",
+        "count": "56"
+      }
+    ],
+    "lidarr": [
+      {
+        "cask": "lidarr",
+        "count": "75"
+      }
+    ],
+    "lifesize": [
+      {
+        "cask": "lifesize",
+        "count": "201"
+      }
+    ],
+    "lift-java": [
+      {
+        "cask": "lift-java",
+        "count": "39"
+      }
+    ],
+    "liga-iosevka": [
+      {
+        "cask": "liga-iosevka",
+        "count": "1"
+      }
+    ],
+    "lightgallery": [
+      {
+        "cask": "lightgallery",
+        "count": "89"
+      }
+    ],
+    "lighting": [
+      {
+        "cask": "lighting",
+        "count": "30"
+      }
+    ],
+    "lightmod": [
+      {
+        "cask": "lightmod",
+        "count": "1"
+      }
+    ],
+    "lightning": [
+      {
+        "cask": "lightning",
+        "count": "4"
+      }
+    ],
+    "lightpaper": [
+      {
+        "cask": "lightpaper",
+        "count": "39"
+      }
+    ],
+    "lightproxy": [
+      {
+        "cask": "lightproxy",
+        "count": "25"
+      }
+    ],
+    "lighttable": [
+      {
+        "cask": "lighttable",
+        "count": "613"
+      }
+    ],
+    "lightworks": [
+      {
+        "cask": "lightworks",
+        "count": "223"
+      }
+    ],
+    "lijitest": [
+      {
+        "cask": "lijitest",
+        "count": "2"
+      }
+    ],
+    "lilypond": [
+      {
+        "cask": "lilypond",
+        "count": "585"
+      }
+    ],
+    "lilypond-dev": [
+      {
+        "cask": "lilypond-dev",
+        "count": "81"
+      }
+    ],
+    "lilypond-unofficial": [
+      {
+        "cask": "lilypond-unofficial",
+        "count": "3"
+      }
+    ],
+    "lilypond-unstable": [
+      {
+        "cask": "lilypond-unstable",
+        "count": "1"
+      }
+    ],
+    "lilypond64": [
+      {
+        "cask": "lilypond64",
+        "count": "1"
+      }
+    ],
+    "limiter-no6": [
+      {
+        "cask": "limiter-no6",
+        "count": "2"
+      }
+    ],
+    "lincastor": [
+      {
+        "cask": "lincastor",
+        "count": "39"
+      }
+    ],
+    "line-bot-designer": [
+      {
+        "cask": "line-bot-designer",
+        "count": "32"
+      }
+    ],
+    "linear": [
+      {
+        "cask": "linear",
+        "count": "149"
+      }
+    ],
+    "linein": [
+      {
+        "cask": "linein",
+        "count": "181"
+      }
+    ],
+    "lingo": [
+      {
+        "cask": "lingo",
+        "count": "46"
+      }
+    ],
+    "lingon-x": [
+      {
+        "cask": "lingon-x",
+        "count": "716"
+      }
+    ],
+    "lingon-x5": [
+      {
+        "cask": "lingon-x5",
+        "count": "15"
+      }
+    ],
+    "linkliar": [
+      {
+        "cask": "linkliar",
+        "count": "492"
+      }
+    ],
+    "linphone": [
+      {
+        "cask": "linphone",
+        "count": "464"
+      }
+    ],
+    "lisanet-gimp": [
+      {
+        "cask": "lisanet-gimp",
+        "count": "125"
+      }
+    ],
+    "listen1": [
+      {
+        "cask": "listen1",
+        "count": "325"
+      }
+    ],
+    "litecoin": [
+      {
+        "cask": "litecoin",
+        "count": "51"
+      }
+    ],
+    "liteicon": [
+      {
+        "cask": "liteicon",
+        "count": "421"
+      }
+    ],
+    "liteide": [
+      {
+        "cask": "liteide",
+        "count": "559"
+      }
+    ],
+    "liteswitch-x": [
+      {
+        "cask": "liteswitch-x",
+        "count": "13"
+      }
+    ],
+    "little-snitch": [
+      {
+        "cask": "little-snitch",
+        "count": "4,798"
+      }
+    ],
+    "little-snitch-nightly": [
+      {
+        "cask": "little-snitch-nightly",
+        "count": "48"
+      }
+    ],
+    "littleroadey-au": [
+      {
+        "cask": "littleroadey-au",
+        "count": "1"
+      }
+    ],
+    "littleroadey-vst": [
+      {
+        "cask": "littleroadey-vst",
+        "count": "2"
+      }
+    ],
+    "littleroadey-vst3": [
+      {
+        "cask": "littleroadey-vst3",
+        "count": "2"
+      }
+    ],
+    "littlesecrets": [
+      {
+        "cask": "littlesecrets",
+        "count": "14"
+      }
+    ],
+    "livechat": [
+      {
+        "cask": "livechat",
+        "count": "60"
+      }
+    ],
+    "livecode-ce": [
+      {
+        "cask": "livecode-ce",
+        "count": "1"
+      }
+    ],
+    "livereload": [
+      {
+        "cask": "livereload",
+        "count": "143"
+      }
+    ],
+    "livetail": [
+      {
+        "cask": "livetail",
+        "count": "55"
+      }
+    ],
+    "liya": [
+      {
+        "cask": "liya",
+        "count": "29"
+      }
+    ],
+    "lmms": [
+      {
+        "cask": "lmms",
+        "count": "431"
+      }
+    ],
+    "lmsclients-squeezeplay": [
+      {
+        "cask": "lmsclients-squeezeplay",
+        "count": "26"
+      }
+    ],
+    "lnkd-ads-cli": [
+      {
+        "cask": "lnkd-ads-cli",
+        "count": "29,645"
+      }
+    ],
+    "lnkd-amf-cli": [
+      {
+        "cask": "lnkd-amf-cli",
+        "count": "17,725"
+      }
+    ],
+    "lnkd-amf-qualys": [
+      {
+        "cask": "lnkd-amf-qualys",
+        "count": "51,905"
+      }
+    ],
+    "lnkd-argos-tracert-cli": [
+      {
+        "cask": "lnkd-argos-tracert-cli",
+        "count": "29,921"
+      }
+    ],
+    "lnkd-arrow": [
+      {
+        "cask": "lnkd-arrow",
+        "count": "45,087"
+      }
+    ],
+    "lnkd-artifact-tools": [
+      {
+        "cask": "lnkd-artifact-tools",
+        "count": "30,315"
+      }
+    ],
+    "lnkd-ask-project-tools": [
+      {
+        "cask": "lnkd-ask-project-tools",
+        "count": "38,588"
+      }
+    ],
+    "lnkd-assembler-cli": [
+      {
+        "cask": "lnkd-assembler-cli",
+        "count": "33,647"
+      }
+    ],
+    "lnkd-assembler-rollback-cli": [
+      {
+        "cask": "lnkd-assembler-rollback-cli",
+        "count": "28,745"
+      }
+    ],
+    "lnkd-ats-admin-cli": [
+      {
+        "cask": "lnkd-ats-admin-cli",
+        "count": "30,952"
+      }
+    ],
+    "lnkd-ats-tools": [
+      {
+        "cask": "lnkd-ats-tools",
+        "count": "106,048"
+      }
+    ],
+    "lnkd-auto2to4": [
+      {
+        "cask": "lnkd-auto2to4",
+        "count": "30,153"
+      }
+    ],
+    "lnkd-autoalerts-cli": [
+      {
+        "cask": "lnkd-autoalerts-cli",
+        "count": "15,972"
+      }
+    ],
+    "lnkd-autoalerts-cli-go": [
+      {
+        "cask": "lnkd-autoalerts-cli-go",
+        "count": "29,178"
+      }
+    ],
+    "lnkd-autochangelog": [
+      {
+        "cask": "lnkd-autochangelog",
+        "count": "25,868"
+      }
+    ],
+    "lnkd-autometrics-index-cli": [
+      {
+        "cask": "lnkd-autometrics-index-cli",
+        "count": "39,695"
+      }
+    ],
+    "lnkd-autopilot": [
+      {
+        "cask": "lnkd-autopilot",
+        "count": "17,435"
+      }
+    ],
+    "lnkd-aws-tools": [
+      {
+        "cask": "lnkd-aws-tools",
+        "count": "17,498"
+      }
+    ],
+    "lnkd-az-imds-control": [
+      {
+        "cask": "lnkd-az-imds-control",
+        "count": "50,698"
+      }
+    ],
+    "lnkd-base": [
+      {
+        "cask": "lnkd-base",
+        "count": "69,640"
+      }
+    ],
+    "lnkd-bastion": [
+      {
+        "cask": "lnkd-bastion",
+        "count": "17,294"
+      }
+    ],
+    "lnkd-batman": [
+      {
+        "cask": "lnkd-batman",
+        "count": "17,356"
+      }
+    ],
+    "lnkd-bazel-wrapper": [
+      {
+        "cask": "lnkd-bazel-wrapper",
+        "count": "41,002"
+      }
+    ],
+    "lnkd-binary-cache": [
+      {
+        "cask": "lnkd-binary-cache",
+        "count": "30,463"
+      }
+    ],
+    "lnkd-bloodhound": [
+      {
+        "cask": "lnkd-bloodhound",
+        "count": "41,672"
+      }
+    ],
+    "lnkd-blueshift-grid-migration-cli": [
+      {
+        "cask": "lnkd-blueshift-grid-migration-cli",
+        "count": "32,487"
+      }
+    ],
+    "lnkd-brannigan": [
+      {
+        "cask": "lnkd-brannigan",
+        "count": "30,578"
+      }
+    ],
+    "lnkd-brooklin-tool": [
+      {
+        "cask": "lnkd-brooklin-tool",
+        "count": "88,229"
+      }
+    ],
+    "lnkd-caas-fleet": [
+      {
+        "cask": "lnkd-caas-fleet",
+        "count": "30,369"
+      }
+    ],
+    "lnkd-caas-tools": [
+      {
+        "cask": "lnkd-caas-tools",
+        "count": "67,237"
+      }
+    ],
+    "lnkd-cablein": [
+      {
+        "cask": "lnkd-cablein",
+        "count": "29,647"
+      }
+    ],
+    "lnkd-cachemanager-cli": [
+      {
+        "cask": "lnkd-cachemanager-cli",
+        "count": "32,953"
+      }
+    ],
+    "lnkd-cam-cli": [
+      {
+        "cask": "lnkd-cam-cli",
+        "count": "16,956"
+      }
+    ],
+    "lnkd-camels": [
+      {
+        "cask": "lnkd-camels",
+        "count": "17,598"
+      }
+    ],
+    "lnkd-ccdo": [
+      {
+        "cask": "lnkd-ccdo",
+        "count": "37,205"
+      }
+    ],
+    "lnkd-cfg2-commands": [
+      {
+        "cask": "lnkd-cfg2-commands",
+        "count": "62,929"
+      }
+    ],
+    "lnkd-chimp-cli": [
+      {
+        "cask": "lnkd-chimp-cli",
+        "count": "42,961"
+      }
+    ],
+    "lnkd-cia-utilities": [
+      {
+        "cask": "lnkd-cia-utilities",
+        "count": "16,769"
+      }
+    ],
+    "lnkd-cit": [
+      {
+        "cask": "lnkd-cit",
+        "count": "29,647"
+      }
+    ],
+    "lnkd-clean-staging": [
+      {
+        "cask": "lnkd-clean-staging",
+        "count": "23,607"
+      }
+    ],
+    "lnkd-cleanpython27": [
+      {
+        "cask": "lnkd-cleanpython27",
+        "count": "7,150"
+      }
+    ],
+    "lnkd-cleanpython35": [
+      {
+        "cask": "lnkd-cleanpython35",
+        "count": "7,128"
+      }
+    ],
+    "lnkd-cleanpython36": [
+      {
+        "cask": "lnkd-cleanpython36",
+        "count": "7,192"
+      }
+    ],
+    "lnkd-cleanpython37": [
+      {
+        "cask": "lnkd-cleanpython37",
+        "count": "12,394"
+      }
+    ],
+    "lnkd-cleanpython38": [
+      {
+        "cask": "lnkd-cleanpython38",
+        "count": "14,772"
+      }
+    ],
+    "lnkd-cli-bench": [
+      {
+        "cask": "lnkd-cli-bench",
+        "count": "29,030"
+      }
+    ],
+    "lnkd-clusterator-cli": [
+      {
+        "cask": "lnkd-clusterator-cli",
+        "count": "16,703"
+      }
+    ],
+    "lnkd-code-search-cli": [
+      {
+        "cask": "lnkd-code-search-cli",
+        "count": "38,698"
+      }
+    ],
+    "lnkd-codecoverage-tools": [
+      {
+        "cask": "lnkd-codecoverage-tools",
+        "count": "17,609"
+      }
+    ],
+    "lnkd-commerce-workflow-tool": [
+      {
+        "cask": "lnkd-commerce-workflow-tool",
+        "count": "17,328"
+      }
+    ],
+    "lnkd-compatibility-test-tool": [
+      {
+        "cask": "lnkd-compatibility-test-tool",
+        "count": "29,671"
+      }
+    ],
+    "lnkd-configure-app-runtime": [
+      {
+        "cask": "lnkd-configure-app-runtime",
+        "count": "17,559"
+      }
+    ],
+    "lnkd-content-sre-iris-dashboard-autogen": [
+      {
+        "cask": "lnkd-content-sre-iris-dashboard-autogen",
+        "count": "18,863"
+      }
+    ],
+    "lnkd-couch-tracker-cli": [
+      {
+        "cask": "lnkd-couch-tracker-cli",
+        "count": "18,088"
+      }
+    ],
+    "lnkd-couchbase-tools": [
+      {
+        "cask": "lnkd-couchbase-tools",
+        "count": "53,058"
+      }
+    ],
+    "lnkd-craem": [
+      {
+        "cask": "lnkd-craem",
+        "count": "31,241"
+      }
+    ],
+    "lnkd-crt-clis": [
+      {
+        "cask": "lnkd-crt-clis",
+        "count": "26,480"
+      }
+    ],
+    "lnkd-csm-pycli-test": [
+      {
+        "cask": "lnkd-csm-pycli-test",
+        "count": "15,096"
+      }
+    ],
+    "lnkd-curli": [
+      {
+        "cask": "lnkd-curli",
+        "count": "24,789"
+      }
+    ],
+    "lnkd-d2-config-cli": [
+      {
+        "cask": "lnkd-d2-config-cli",
+        "count": "34,516"
+      }
+    ],
+    "lnkd-d2-staging-cli": [
+      {
+        "cask": "lnkd-d2-staging-cli",
+        "count": "22,410"
+      }
+    ],
+    "lnkd-d2autotuner": [
+      {
+        "cask": "lnkd-d2autotuner",
+        "count": "27,666"
+      }
+    ],
+    "lnkd-dali-cli": [
+      {
+        "cask": "lnkd-dali-cli",
+        "count": "17,461"
+      }
+    ],
+    "lnkd-dash": [
+      {
+        "cask": "lnkd-dash",
+        "count": "17,091"
+      }
+    ],
+    "lnkd-dasre-tableau-insights-cli": [
+      {
+        "cask": "lnkd-dasre-tableau-insights-cli",
+        "count": "29,700"
+      }
+    ],
+    "lnkd-dasre-tools": [
+      {
+        "cask": "lnkd-dasre-tools",
+        "count": "31,477"
+      }
+    ],
+    "lnkd-data-derived": [
+      {
+        "cask": "lnkd-data-derived",
+        "count": "9,820"
+      }
+    ],
+    "lnkd-deadpool": [
+      {
+        "cask": "lnkd-deadpool",
+        "count": "17,643"
+      }
+    ],
+    "lnkd-debug-ssh": [
+      {
+        "cask": "lnkd-debug-ssh",
+        "count": "62,676"
+      }
+    ],
+    "lnkd-delta": [
+      {
+        "cask": "lnkd-delta",
+        "count": "18,035"
+      }
+    ],
+    "lnkd-dependency-test-cli": [
+      {
+        "cask": "lnkd-dependency-test-cli",
+        "count": "25,696"
+      }
+    ],
+    "lnkd-deployment-tools": [
+      {
+        "cask": "lnkd-deployment-tools",
+        "count": "57,795"
+      }
+    ],
+    "lnkd-diffoscope-cli": [
+      {
+        "cask": "lnkd-diffoscope-cli",
+        "count": "29,372"
+      }
+    ],
+    "lnkd-disre-cli-tools": [
+      {
+        "cask": "lnkd-disre-cli-tools",
+        "count": "30,016"
+      }
+    ],
+    "lnkd-docin-cli": [
+      {
+        "cask": "lnkd-docin-cli",
+        "count": "22,702"
+      }
+    ],
+    "lnkd-dss-cli": [
+      {
+        "cask": "lnkd-dss-cli",
+        "count": "17,746"
+      }
+    ],
+    "lnkd-dynamic-acl-tool": [
+      {
+        "cask": "lnkd-dynamic-acl-tool",
+        "count": "40,783"
+      }
+    ],
+    "lnkd-e2d": [
+      {
+        "cask": "lnkd-e2d",
+        "count": "30,528"
+      }
+    ],
+    "lnkd-e8-cli": [
+      {
+        "cask": "lnkd-e8-cli",
+        "count": "29,378"
+      }
+    ],
+    "lnkd-ecl": [
+      {
+        "cask": "lnkd-ecl",
+        "count": "599,403"
+      }
+    ],
+    "lnkd-eh": [
+      {
+        "cask": "lnkd-eh",
+        "count": "29,233"
+      }
+    ],
+    "lnkd-ehssh": [
+      {
+        "cask": "lnkd-ehssh",
+        "count": "30,520"
+      }
+    ],
+    "lnkd-ekg-cli": [
+      {
+        "cask": "lnkd-ekg-cli",
+        "count": "30,696"
+      }
+    ],
+    "lnkd-elkb-tools": [
+      {
+        "cask": "lnkd-elkb-tools",
+        "count": "17,315"
+      }
+    ],
+    "lnkd-encryption-tools": [
+      {
+        "cask": "lnkd-encryption-tools",
+        "count": "17,059"
+      }
+    ],
+    "lnkd-epsilon-cli": [
+      {
+        "cask": "lnkd-epsilon-cli",
+        "count": "18,124"
+      }
+    ],
+    "lnkd-ergo": [
+      {
+        "cask": "lnkd-ergo",
+        "count": "30,141"
+      }
+    ],
+    "lnkd-ers-new": [
+      {
+        "cask": "lnkd-ers-new",
+        "count": "17,211"
+      }
+    ],
+    "lnkd-espresso-storage-node-hooks": [
+      {
+        "cask": "lnkd-espresso-storage-node-hooks",
+        "count": "71,052"
+      }
+    ],
+    "lnkd-espresso-utilities": [
+      {
+        "cask": "lnkd-espresso-utilities",
+        "count": "89,091"
+      }
+    ],
+    "lnkd-et": [
+      {
+        "cask": "lnkd-et",
+        "count": "28,443"
+      }
+    ],
+    "lnkd-filtercall": [
+      {
+        "cask": "lnkd-filtercall",
+        "count": "46,991"
+      }
+    ],
+    "lnkd-flagship-bundle": [
+      {
+        "cask": "lnkd-flagship-bundle",
+        "count": "57,408"
+      }
+    ],
+    "lnkd-flashdisag-amf": [
+      {
+        "cask": "lnkd-flashdisag-amf",
+        "count": "30,646"
+      }
+    ],
+    "lnkd-flatc": [
+      {
+        "cask": "lnkd-flatc",
+        "count": "17,770"
+      }
+    ],
+    "lnkd-flood": [
+      {
+        "cask": "lnkd-flood",
+        "count": "17,028"
+      }
+    ],
+    "lnkd-fossor-li": [
+      {
+        "cask": "lnkd-fossor-li",
+        "count": "30,174"
+      }
+    ],
+    "lnkd-fua-cli": [
+      {
+        "cask": "lnkd-fua-cli",
+        "count": "16,434"
+      }
+    ],
+    "lnkd-gaas-client": [
+      {
+        "cask": "lnkd-gaas-client",
+        "count": "60,206"
+      }
+    ],
+    "lnkd-galene-index-cli": [
+      {
+        "cask": "lnkd-galene-index-cli",
+        "count": "35,923"
+      }
+    ],
+    "lnkd-get-oncall": [
+      {
+        "cask": "lnkd-get-oncall",
+        "count": "30,990"
+      }
+    ],
+    "lnkd-git-commands": [
+      {
+        "cask": "lnkd-git-commands",
+        "count": "76,216"
+      }
+    ],
+    "lnkd-git-submit": [
+      {
+        "cask": "lnkd-git-submit",
+        "count": "67,941"
+      }
+    ],
+    "lnkd-gnsops-tools": [
+      {
+        "cask": "lnkd-gnsops-tools",
+        "count": "39,737"
+      }
+    ],
+    "lnkd-go-log-replay": [
+      {
+        "cask": "lnkd-go-log-replay",
+        "count": "31,349"
+      }
+    ],
+    "lnkd-go-map": [
+      {
+        "cask": "lnkd-go-map",
+        "count": "17,784"
+      }
+    ],
+    "lnkd-go-redliner": [
+      {
+        "cask": "lnkd-go-redliner",
+        "count": "35,411"
+      }
+    ],
+    "lnkd-go-status": [
+      {
+        "cask": "lnkd-go-status",
+        "count": "42,220"
+      }
+    ],
+    "lnkd-gobblin-hooks": [
+      {
+        "cask": "lnkd-gobblin-hooks",
+        "count": "32,656"
+      }
+    ],
+    "lnkd-gobroke": [
+      {
+        "cask": "lnkd-gobroke",
+        "count": "43,802"
+      }
+    ],
+    "lnkd-gogo": [
+      {
+        "cask": "lnkd-gogo",
+        "count": "16,300"
+      }
+    ],
+    "lnkd-gradle-abtest-cli": [
+      {
+        "cask": "lnkd-gradle-abtest-cli",
+        "count": "26,591"
+      }
+    ],
+    "lnkd-hac-ai-tool": [
+      {
+        "cask": "lnkd-hac-ai-tool",
+        "count": "31,223"
+      }
+    ],
+    "lnkd-hadoop-cli": [
+      {
+        "cask": "lnkd-hadoop-cli",
+        "count": "22,242"
+      }
+    ],
+    "lnkd-harbor": [
+      {
+        "cask": "lnkd-harbor",
+        "count": "16,945"
+      }
+    ],
+    "lnkd-hardware-info": [
+      {
+        "cask": "lnkd-hardware-info",
+        "count": "30,524"
+      }
+    ],
+    "lnkd-hbfgradle": [
+      {
+        "cask": "lnkd-hbfgradle",
+        "count": "46,821"
+      }
+    ],
+    "lnkd-helios-cli": [
+      {
+        "cask": "lnkd-helios-cli",
+        "count": "30,223"
+      }
+    ],
+    "lnkd-helix-sre-tools": [
+      {
+        "cask": "lnkd-helix-sre-tools",
+        "count": "16,909"
+      }
+    ],
+    "lnkd-histogram": [
+      {
+        "cask": "lnkd-histogram",
+        "count": "17,132"
+      }
+    ],
+    "lnkd-hodor": [
+      {
+        "cask": "lnkd-hodor",
+        "count": "31,035"
+      }
+    ],
+    "lnkd-hong-kong": [
+      {
+        "cask": "lnkd-hong-kong",
+        "count": "31,406"
+      }
+    ],
+    "lnkd-host-information-tool-cli": [
+      {
+        "cask": "lnkd-host-information-tool-cli",
+        "count": "28,914"
+      }
+    ],
+    "lnkd-hosted-search-cli": [
+      {
+        "cask": "lnkd-hosted-search-cli",
+        "count": "45,605"
+      }
+    ],
+    "lnkd-hostli": [
+      {
+        "cask": "lnkd-hostli",
+        "count": "29,479"
+      }
+    ],
+    "lnkd-i18n-orphan": [
+      {
+        "cask": "lnkd-i18n-orphan",
+        "count": "16,305"
+      }
+    ],
+    "lnkd-id-tools": [
+      {
+        "cask": "lnkd-id-tools",
+        "count": "56,195"
+      }
+    ],
+    "lnkd-image-tool": [
+      {
+        "cask": "lnkd-image-tool",
+        "count": "99,483"
+      }
+    ],
+    "lnkd-informed-cli": [
+      {
+        "cask": "lnkd-informed-cli",
+        "count": "18,074"
+      }
+    ],
+    "lnkd-informed2-cli": [
+      {
+        "cask": "lnkd-informed2-cli",
+        "count": "40,558"
+      }
+    ],
+    "lnkd-ingraphs-cli": [
+      {
+        "cask": "lnkd-ingraphs-cli",
+        "count": "30,125"
+      }
+    ],
+    "lnkd-ingraphs-jinja": [
+      {
+        "cask": "lnkd-ingraphs-jinja",
+        "count": "30,480"
+      }
+    ],
+    "lnkd-inlogs-cli": [
+      {
+        "cask": "lnkd-inlogs-cli",
+        "count": "69,052"
+      }
+    ],
+    "lnkd-inmon-cli": [
+      {
+        "cask": "lnkd-inmon-cli",
+        "count": "16,511"
+      }
+    ],
+    "lnkd-inphone": [
+      {
+        "cask": "lnkd-inphone",
+        "count": "42,364"
+      }
+    ],
+    "lnkd-insearch-cli": [
+      {
+        "cask": "lnkd-insearch-cli",
+        "count": "30,323"
+      }
+    ],
+    "lnkd-inuse-cli": [
+      {
+        "cask": "lnkd-inuse-cli",
+        "count": "43,403"
+      }
+    ],
+    "lnkd-invincible-runner": [
+      {
+        "cask": "lnkd-invincible-runner",
+        "count": "31,455"
+      }
+    ],
+    "lnkd-invips-cli": [
+      {
+        "cask": "lnkd-invips-cli",
+        "count": "17,757"
+      }
+    ],
+    "lnkd-irresistible-force-cli": [
+      {
+        "cask": "lnkd-irresistible-force-cli",
+        "count": "33,989"
+      }
+    ],
+    "lnkd-java-11-zulu": [
+      {
+        "cask": "lnkd-java-11-zulu",
+        "count": "436"
+      }
+    ],
+    "lnkd-java-7u51": [
+      {
+        "cask": "lnkd-java-7u51",
+        "count": "11"
+      }
+    ],
+    "lnkd-java-8u121": [
+      {
+        "cask": "lnkd-java-8u121",
+        "count": "10"
+      }
+    ],
+    "lnkd-java-8u172": [
+      {
+        "cask": "lnkd-java-8u172",
+        "count": "21"
+      }
+    ],
+    "lnkd-java-8u172-zulu": [
+      {
+        "cask": "lnkd-java-8u172-zulu",
+        "count": "8"
+      }
+    ],
+    "lnkd-java-8u40": [
+      {
+        "cask": "lnkd-java-8u40",
+        "count": "10"
+      }
+    ],
+    "lnkd-java-8u5": [
+      {
+        "cask": "lnkd-java-8u5",
+        "count": "8"
+      }
+    ],
+    "lnkd-java-8u72": [
+      {
+        "cask": "lnkd-java-8u72",
+        "count": "9"
+      }
+    ],
+    "lnkd-java-cli-example": [
+      {
+        "cask": "lnkd-java-cli-example",
+        "count": "16,532"
+      }
+    ],
+    "lnkd-java-launcher": [
+      {
+        "cask": "lnkd-java-launcher",
+        "count": "26,643"
+      }
+    ],
+    "lnkd-java-sre-cli": [
+      {
+        "cask": "lnkd-java-sre-cli",
+        "count": "25,860"
+      }
+    ],
+    "lnkd-java-version-check": [
+      {
+        "cask": "lnkd-java-version-check",
+        "count": "16,723"
+      }
+    ],
+    "lnkd-jdk11u5-zulu": [
+      {
+        "cask": "lnkd-jdk11u5-zulu",
+        "count": "6"
+      }
+    ],
+    "lnkd-jeeves-cli": [
+      {
+        "cask": "lnkd-jeeves-cli",
+        "count": "37,014"
+      }
+    ],
+    "lnkd-jet-unminify-cli": [
+      {
+        "cask": "lnkd-jet-unminify-cli",
+        "count": "30,636"
+      }
+    ],
+    "lnkd-jit-acl-cli": [
+      {
+        "cask": "lnkd-jit-acl-cli",
+        "count": "30,472"
+      }
+    ],
+    "lnkd-jobs-tool": [
+      {
+        "cask": "lnkd-jobs-tool",
+        "count": "29,022"
+      }
+    ],
+    "lnkd-jpulse": [
+      {
+        "cask": "lnkd-jpulse",
+        "count": "31,391"
+      }
+    ],
+    "lnkd-jqtop": [
+      {
+        "cask": "lnkd-jqtop",
+        "count": "29,582"
+      }
+    ],
+    "lnkd-jstf": [
+      {
+        "cask": "lnkd-jstf",
+        "count": "36,156"
+      }
+    ],
+    "lnkd-just": [
+      {
+        "cask": "lnkd-just",
+        "count": "31,162"
+      }
+    ],
+    "lnkd-jvmtop-cli": [
+      {
+        "cask": "lnkd-jvmtop-cli",
+        "count": "17,727"
+      }
+    ],
+    "lnkd-kafka-tool": [
+      {
+        "cask": "lnkd-kafka-tool",
+        "count": "20,924"
+      }
+    ],
+    "lnkd-kcap": [
+      {
+        "cask": "lnkd-kcap",
+        "count": "16,444"
+      }
+    ],
+    "lnkd-keep-running": [
+      {
+        "cask": "lnkd-keep-running",
+        "count": "16,542"
+      }
+    ],
+    "lnkd-kevin-cli": [
+      {
+        "cask": "lnkd-kevin-cli",
+        "count": "16,949"
+      }
+    ],
+    "lnkd-kms-cli": [
+      {
+        "cask": "lnkd-kms-cli",
+        "count": "68,019"
+      }
+    ],
+    "lnkd-ksre-tool": [
+      {
+        "cask": "lnkd-ksre-tool",
+        "count": "16,918"
+      }
+    ],
+    "lnkd-ktool": [
+      {
+        "cask": "lnkd-ktool",
+        "count": "42,345"
+      }
+    ],
+    "lnkd-labservice-tools": [
+      {
+        "cask": "lnkd-labservice-tools",
+        "count": "104,675"
+      }
+    ],
+    "lnkd-learning-sre-tools": [
+      {
+        "cask": "lnkd-learning-sre-tools",
+        "count": "15,752"
+      }
+    ],
+    "lnkd-li-idea": [
+      {
+        "cask": "lnkd-li-idea",
+        "count": "1,278"
+      }
+    ],
+    "lnkd-lid-host-history": [
+      {
+        "cask": "lnkd-lid-host-history",
+        "count": "31,242"
+      }
+    ],
+    "lnkd-lid-image-runner": [
+      {
+        "cask": "lnkd-lid-image-runner",
+        "count": "32,475"
+      }
+    ],
+    "lnkd-lid-runner": [
+      {
+        "cask": "lnkd-lid-runner",
+        "count": "29,126"
+      }
+    ],
+    "lnkd-lid-server-cli": [
+      {
+        "cask": "lnkd-lid-server-cli",
+        "count": "33,057"
+      }
+    ],
+    "lnkd-ligradle": [
+      {
+        "cask": "lnkd-ligradle",
+        "count": "33,424"
+      }
+    ],
+    "lnkd-lintellijps-cli": [
+      {
+        "cask": "lnkd-lintellijps-cli",
+        "count": "29,537"
+      }
+    ],
+    "lnkd-lintli-cli": [
+      {
+        "cask": "lnkd-lintli-cli",
+        "count": "56,499"
+      }
+    ],
+    "lnkd-lipy-followfeed": [
+      {
+        "cask": "lnkd-lipy-followfeed",
+        "count": "40,672"
+      }
+    ],
+    "lnkd-lipy-javaformat-app": [
+      {
+        "cask": "lnkd-lipy-javaformat-app",
+        "count": "16,616"
+      }
+    ],
+    "lnkd-lipy-kubectl": [
+      {
+        "cask": "lnkd-lipy-kubectl",
+        "count": "36,855"
+      }
+    ],
+    "lnkd-lipy-mdc": [
+      {
+        "cask": "lnkd-lipy-mdc",
+        "count": "39,716"
+      }
+    ],
+    "lnkd-lipy-pd-aggregator-app": [
+      {
+        "cask": "lnkd-lipy-pd-aggregator-app",
+        "count": "26,832"
+      }
+    ],
+    "lnkd-lipy-ranking-benchmark": [
+      {
+        "cask": "lnkd-lipy-ranking-benchmark",
+        "count": "17,769"
+      }
+    ],
+    "lnkd-lipy-security-scanner-app": [
+      {
+        "cask": "lnkd-lipy-security-scanner-app",
+        "count": "17,686"
+      }
+    ],
+    "lnkd-lipy-sourcecount-app": [
+      {
+        "cask": "lnkd-lipy-sourcecount-app",
+        "count": "16,389"
+      }
+    ],
+    "lnkd-lipy-uberlint": [
+      {
+        "cask": "lnkd-lipy-uberlint",
+        "count": "31,184"
+      }
+    ],
+    "lnkd-lipy-whatami-cli": [
+      {
+        "cask": "lnkd-lipy-whatami-cli",
+        "count": "18,061"
+      }
+    ],
+    "lnkd-lix-cli": [
+      {
+        "cask": "lnkd-lix-cli",
+        "count": "29,213"
+      }
+    ],
+    "lnkd-lls-cp-cli": [
+      {
+        "cask": "lnkd-lls-cp-cli",
+        "count": "32,791"
+      }
+    ],
+    "lnkd-lms-productivity-analysis-tools": [
+      {
+        "cask": "lnkd-lms-productivity-analysis-tools",
+        "count": "31,479"
+      }
+    ],
+    "lnkd-locker-cli": [
+      {
+        "cask": "lnkd-locker-cli",
+        "count": "39,074"
+      }
+    ],
+    "lnkd-lodgeit-cli": [
+      {
+        "cask": "lnkd-lodgeit-cli",
+        "count": "17,215"
+      }
+    ],
+    "lnkd-log-analyze": [
+      {
+        "cask": "lnkd-log-analyze",
+        "count": "30,208"
+      }
+    ],
+    "lnkd-logli": [
+      {
+        "cask": "lnkd-logli",
+        "count": "27,563"
+      }
+    ],
+    "lnkd-lps-cli": [
+      {
+        "cask": "lnkd-lps-cli",
+        "count": "53,317"
+      }
+    ],
+    "lnkd-luigi-cli": [
+      {
+        "cask": "lnkd-luigi-cli",
+        "count": "30,274"
+      }
+    ],
+    "lnkd-maestro-cli": [
+      {
+        "cask": "lnkd-maestro-cli",
+        "count": "54,100"
+      }
+    ],
+    "lnkd-manage-ssh": [
+      {
+        "cask": "lnkd-manage-ssh",
+        "count": "100,396"
+      }
+    ],
+    "lnkd-manifold": [
+      {
+        "cask": "lnkd-manifold",
+        "count": "31,487"
+      }
+    ],
+    "lnkd-media-tools": [
+      {
+        "cask": "lnkd-media-tools",
+        "count": "65,196"
+      }
+    ],
+    "lnkd-member-id-obftable-gen": [
+      {
+        "cask": "lnkd-member-id-obftable-gen",
+        "count": "30,328"
+      }
+    ],
+    "lnkd-member-restriction-benchmark": [
+      {
+        "cask": "lnkd-member-restriction-benchmark",
+        "count": "18,262"
+      }
+    ],
+    "lnkd-messaging-dev-tools": [
+      {
+        "cask": "lnkd-messaging-dev-tools",
+        "count": "17,199"
+      }
+    ],
+    "lnkd-metal-cli": [
+      {
+        "cask": "lnkd-metal-cli",
+        "count": "34,477"
+      }
+    ],
+    "lnkd-metget": [
+      {
+        "cask": "lnkd-metget",
+        "count": "16,838"
+      }
+    ],
+    "lnkd-metrics-client": [
+      {
+        "cask": "lnkd-metrics-client",
+        "count": "27,206"
+      }
+    ],
+    "lnkd-metrics-validator": [
+      {
+        "cask": "lnkd-metrics-validator",
+        "count": "46,896"
+      }
+    ],
+    "lnkd-midgard-utils": [
+      {
+        "cask": "lnkd-midgard-utils",
+        "count": "29,764"
+      }
+    ],
+    "lnkd-min": [
+      {
+        "cask": "lnkd-min",
+        "count": "31,283"
+      }
+    ],
+    "lnkd-mint": [
+      {
+        "cask": "lnkd-mint",
+        "count": "52,480"
+      }
+    ],
+    "lnkd-mint-integration": [
+      {
+        "cask": "lnkd-mint-integration",
+        "count": "18,395"
+      }
+    ],
+    "lnkd-model-creation-tool": [
+      {
+        "cask": "lnkd-model-creation-tool",
+        "count": "49,514"
+      }
+    ],
+    "lnkd-mp-maker": [
+      {
+        "cask": "lnkd-mp-maker",
+        "count": "35,366"
+      }
+    ],
+    "lnkd-mri": [
+      {
+        "cask": "lnkd-mri",
+        "count": "30,559"
+      }
+    ],
+    "lnkd-mysql-backup": [
+      {
+        "cask": "lnkd-mysql-backup",
+        "count": "18,109"
+      }
+    ],
+    "lnkd-mysqlmon-control": [
+      {
+        "cask": "lnkd-mysqlmon-control",
+        "count": "69,845"
+      }
+    ],
+    "lnkd-neo-builder": [
+      {
+        "cask": "lnkd-neo-builder",
+        "count": "55,993"
+      }
+    ],
+    "lnkd-neo-decom": [
+      {
+        "cask": "lnkd-neo-decom",
+        "count": "30,240"
+      }
+    ],
+    "lnkd-neo-silencer": [
+      {
+        "cask": "lnkd-neo-silencer",
+        "count": "17,092"
+      }
+    ],
+    "lnkd-norbert-cli": [
+      {
+        "cask": "lnkd-norbert-cli",
+        "count": "30,921"
+      }
+    ],
+    "lnkd-notgot": [
+      {
+        "cask": "lnkd-notgot",
+        "count": "27,107"
+      }
+    ],
+    "lnkd-nuage-auto-tools": [
+      {
+        "cask": "lnkd-nuage-auto-tools",
+        "count": "17,066"
+      }
+    ],
+    "lnkd-nurse-cli": [
+      {
+        "cask": "lnkd-nurse-cli",
+        "count": "17,890"
+      }
+    ],
+    "lnkd-odp": [
+      {
+        "cask": "lnkd-odp",
+        "count": "28,386"
+      }
+    ],
+    "lnkd-oncall-cli": [
+      {
+        "cask": "lnkd-oncall-cli",
+        "count": "17,784"
+      }
+    ],
+    "lnkd-oncall-custom-shifts": [
+      {
+        "cask": "lnkd-oncall-custom-shifts",
+        "count": "18,040"
+      }
+    ],
+    "lnkd-ondemand-sflow": [
+      {
+        "cask": "lnkd-ondemand-sflow",
+        "count": "18,159"
+      }
+    ],
+    "lnkd-oops": [
+      {
+        "cask": "lnkd-oops",
+        "count": "30,226"
+      }
+    ],
+    "lnkd-oracle-compliance-check": [
+      {
+        "cask": "lnkd-oracle-compliance-check",
+        "count": "25,368"
+      }
+    ],
+    "lnkd-orca-cli": [
+      {
+        "cask": "lnkd-orca-cli",
+        "count": "63,936"
+      }
+    ],
+    "lnkd-p4p-espresso": [
+      {
+        "cask": "lnkd-p4p-espresso",
+        "count": "33,442"
+      }
+    ],
+    "lnkd-p4p-jmx": [
+      {
+        "cask": "lnkd-p4p-jmx",
+        "count": "64,234"
+      }
+    ],
+    "lnkd-p4p-logrep": [
+      {
+        "cask": "lnkd-p4p-logrep",
+        "count": "42,774"
+      }
+    ],
+    "lnkd-p4p-oncall": [
+      {
+        "cask": "lnkd-p4p-oncall",
+        "count": "36,862"
+      }
+    ],
+    "lnkd-p4p-restli": [
+      {
+        "cask": "lnkd-p4p-restli",
+        "count": "49,228"
+      }
+    ],
+    "lnkd-parsein": [
+      {
+        "cask": "lnkd-parsein",
+        "count": "30,531"
+      }
+    ],
+    "lnkd-pem-cli": [
+      {
+        "cask": "lnkd-pem-cli",
+        "count": "34,073"
+      }
+    ],
+    "lnkd-perf-runner": [
+      {
+        "cask": "lnkd-perf-runner",
+        "count": "17,218"
+      }
+    ],
+    "lnkd-perseustool": [
+      {
+        "cask": "lnkd-perseustool",
+        "count": "74,710"
+      }
+    ],
+    "lnkd-pexcacheclean": [
+      {
+        "cask": "lnkd-pexcacheclean",
+        "count": "30,247"
+      }
+    ],
+    "lnkd-pillar-review-tool": [
+      {
+        "cask": "lnkd-pillar-review-tool",
+        "count": "69,170"
+      }
+    ],
+    "lnkd-pinot-utils": [
+      {
+        "cask": "lnkd-pinot-utils",
+        "count": "32,458"
+      }
+    ],
+    "lnkd-platform-sre-tools": [
+      {
+        "cask": "lnkd-platform-sre-tools",
+        "count": "22,294"
+      }
+    ],
+    "lnkd-pmu-cli": [
+      {
+        "cask": "lnkd-pmu-cli",
+        "count": "24,244"
+      }
+    ],
+    "lnkd-pop-buildout-tools": [
+      {
+        "cask": "lnkd-pop-buildout-tools",
+        "count": "31,528"
+      }
+    ],
+    "lnkd-pq-batch-cli": [
+      {
+        "cask": "lnkd-pq-batch-cli",
+        "count": "29,586"
+      }
+    ],
+    "lnkd-production-cli": [
+      {
+        "cask": "lnkd-production-cli",
+        "count": "29,769"
+      }
+    ],
+    "lnkd-prom-devices": [
+      {
+        "cask": "lnkd-prom-devices",
+        "count": "18,140"
+      }
+    ],
+    "lnkd-pylene-cli": [
+      {
+        "cask": "lnkd-pylene-cli",
+        "count": "128,973"
+      }
+    ],
+    "lnkd-python-dependency-inspector": [
+      {
+        "cask": "lnkd-python-dependency-inspector",
+        "count": "16,416"
+      }
+    ],
+    "lnkd-pyusage": [
+      {
+        "cask": "lnkd-pyusage",
+        "count": "29,320"
+      }
+    ],
+    "lnkd-qdt-cli": [
+      {
+        "cask": "lnkd-qdt-cli",
+        "count": "29,734"
+      }
+    ],
+    "lnkd-qei-cli": [
+      {
+        "cask": "lnkd-qei-cli",
+        "count": "16,642"
+      }
+    ],
+    "lnkd-querylog-parser": [
+      {
+        "cask": "lnkd-querylog-parser",
+        "count": "19,202"
+      }
+    ],
+    "lnkd-quotas": [
+      {
+        "cask": "lnkd-quotas",
+        "count": "31,409"
+      }
+    ],
+    "lnkd-race-cli": [
+      {
+        "cask": "lnkd-race-cli",
+        "count": "17,707"
+      }
+    ],
+    "lnkd-race-marshal-cli": [
+      {
+        "cask": "lnkd-race-marshal-cli",
+        "count": "17,820"
+      }
+    ],
+    "lnkd-rack-check-cli": [
+      {
+        "cask": "lnkd-rack-check-cli",
+        "count": "29,999"
+      }
+    ],
+    "lnkd-rain-adoption-utils": [
+      {
+        "cask": "lnkd-rain-adoption-utils",
+        "count": "17,780"
+      }
+    ],
+    "lnkd-rain-agent": [
+      {
+        "cask": "lnkd-rain-agent",
+        "count": "29,965"
+      }
+    ],
+    "lnkd-rain-cli": [
+      {
+        "cask": "lnkd-rain-cli",
+        "count": "69,342"
+      }
+    ],
+    "lnkd-rain-free": [
+      {
+        "cask": "lnkd-rain-free",
+        "count": "40,690"
+      }
+    ],
+    "lnkd-rainicorn": [
+      {
+        "cask": "lnkd-rainicorn",
+        "count": "18,742"
+      }
+    ],
+    "lnkd-rate-my-build": [
+      {
+        "cask": "lnkd-rate-my-build",
+        "count": "65,654"
+      }
+    ],
+    "lnkd-rb-cli": [
+      {
+        "cask": "lnkd-rb-cli",
+        "count": "27,692"
+      }
+    ],
+    "lnkd-rb-status": [
+      {
+        "cask": "lnkd-rb-status",
+        "count": "15,825"
+      }
+    ],
+    "lnkd-rdev-cli": [
+      {
+        "cask": "lnkd-rdev-cli",
+        "count": "78,725"
+      }
+    ],
+    "lnkd-rdt": [
+      {
+        "cask": "lnkd-rdt",
+        "count": "30,508"
+      }
+    ],
+    "lnkd-redliner-checks": [
+      {
+        "cask": "lnkd-redliner-checks",
+        "count": "52,512"
+      }
+    ],
+    "lnkd-redliner-cli": [
+      {
+        "cask": "lnkd-redliner-cli",
+        "count": "45,210"
+      }
+    ],
+    "lnkd-roomcheck": [
+      {
+        "cask": "lnkd-roomcheck",
+        "count": "26,875"
+      }
+    ],
+    "lnkd-rover-cli": [
+      {
+        "cask": "lnkd-rover-cli",
+        "count": "30,018"
+      }
+    ],
+    "lnkd-samples": [
+      {
+        "cask": "lnkd-samples",
+        "count": "31,558"
+      }
+    ],
+    "lnkd-samza-build-cli": [
+      {
+        "cask": "lnkd-samza-build-cli",
+        "count": "25,451"
+      }
+    ],
+    "lnkd-samza-hacks-cli": [
+      {
+        "cask": "lnkd-samza-hacks-cli",
+        "count": "17,235"
+      }
+    ],
+    "lnkd-samza-nurse-cli": [
+      {
+        "cask": "lnkd-samza-nurse-cli",
+        "count": "30,836"
+      }
+    ],
+    "lnkd-samza-sql-shell": [
+      {
+        "cask": "lnkd-samza-sql-shell",
+        "count": "25,737"
+      }
+    ],
+    "lnkd-samza-tool": [
+      {
+        "cask": "lnkd-samza-tool",
+        "count": "39,467"
+      }
+    ],
+    "lnkd-samza-tools": [
+      {
+        "cask": "lnkd-samza-tools",
+        "count": "54,185"
+      }
+    ],
+    "lnkd-sar-collector": [
+      {
+        "cask": "lnkd-sar-collector",
+        "count": "30,660"
+      }
+    ],
+    "lnkd-search-cloud-cli": [
+      {
+        "cask": "lnkd-search-cloud-cli",
+        "count": "65,902"
+      }
+    ],
+    "lnkd-search-sre-tools": [
+      {
+        "cask": "lnkd-search-sre-tools",
+        "count": "17,828"
+      }
+    ],
+    "lnkd-seas-logfilter": [
+      {
+        "cask": "lnkd-seas-logfilter",
+        "count": "38,450"
+      }
+    ],
+    "lnkd-secsre-tools": [
+      {
+        "cask": "lnkd-secsre-tools",
+        "count": "16,561"
+      }
+    ],
+    "lnkd-shrimp-cli": [
+      {
+        "cask": "lnkd-shrimp-cli",
+        "count": "30,548"
+      }
+    ],
+    "lnkd-shuffle-cli": [
+      {
+        "cask": "lnkd-shuffle-cli",
+        "count": "18,127"
+      }
+    ],
+    "lnkd-si-ops-tools": [
+      {
+        "cask": "lnkd-si-ops-tools",
+        "count": "26,504"
+      }
+    ],
+    "lnkd-sideload-cli": [
+      {
+        "cask": "lnkd-sideload-cli",
+        "count": "14,298"
+      }
+    ],
+    "lnkd-simple-ingraphs": [
+      {
+        "cask": "lnkd-simple-ingraphs",
+        "count": "79,660"
+      }
+    ],
+    "lnkd-singlemaster": [
+      {
+        "cask": "lnkd-singlemaster",
+        "count": "17,267"
+      }
+    ],
+    "lnkd-snapdragon": [
+      {
+        "cask": "lnkd-snapdragon",
+        "count": "31,548"
+      }
+    ],
+    "lnkd-snapshot-service-worker-hooks": [
+      {
+        "cask": "lnkd-snapshot-service-worker-hooks",
+        "count": "42,966"
+      }
+    ],
+    "lnkd-sos-cli": [
+      {
+        "cask": "lnkd-sos-cli",
+        "count": "31,642"
+      }
+    ],
+    "lnkd-spark-notebook": [
+      {
+        "cask": "lnkd-spark-notebook",
+        "count": "30,872"
+      }
+    ],
+    "lnkd-sparkjoy-cli": [
+      {
+        "cask": "lnkd-sparkjoy-cli",
+        "count": "41,452"
+      }
+    ],
+    "lnkd-srd-cli": [
+      {
+        "cask": "lnkd-srd-cli",
+        "count": "24,808"
+      }
+    ],
+    "lnkd-sre-cli": [
+      {
+        "cask": "lnkd-sre-cli",
+        "count": "40,961"
+      }
+    ],
+    "lnkd-sre-decom": [
+      {
+        "cask": "lnkd-sre-decom",
+        "count": "30,342"
+      }
+    ],
+    "lnkd-sre-gc-report": [
+      {
+        "cask": "lnkd-sre-gc-report",
+        "count": "17,251"
+      }
+    ],
+    "lnkd-ssh-ca-cli": [
+      {
+        "cask": "lnkd-ssh-ca-cli",
+        "count": "95,630"
+      }
+    ],
+    "lnkd-ssh-range": [
+      {
+        "cask": "lnkd-ssh-range",
+        "count": "40,931"
+      }
+    ],
+    "lnkd-st-dashboard-cli": [
+      {
+        "cask": "lnkd-st-dashboard-cli",
+        "count": "31,715"
+      }
+    ],
+    "lnkd-stickyrouting-ops": [
+      {
+        "cask": "lnkd-stickyrouting-ops",
+        "count": "22,258"
+      }
+    ],
+    "lnkd-svin": [
+      {
+        "cask": "lnkd-svin",
+        "count": "34,362"
+      }
+    ],
+    "lnkd-svn2git": [
+      {
+        "cask": "lnkd-svn2git",
+        "count": "45,083"
+      }
+    ],
+    "lnkd-tabby-mctabface": [
+      {
+        "cask": "lnkd-tabby-mctabface",
+        "count": "15,848"
+      }
+    ],
+    "lnkd-tail-metrics": [
+      {
+        "cask": "lnkd-tail-metrics",
+        "count": "17,692"
+      }
+    ],
+    "lnkd-test-cli": [
+      {
+        "cask": "lnkd-test-cli",
+        "count": "29,235"
+      }
+    ],
+    "lnkd-thin-archive": [
+      {
+        "cask": "lnkd-thin-archive",
+        "count": "17,330"
+      }
+    ],
+    "lnkd-tjacker": [
+      {
+        "cask": "lnkd-tjacker",
+        "count": "17,257"
+      }
+    ],
+    "lnkd-tm2-execution-engine": [
+      {
+        "cask": "lnkd-tm2-execution-engine",
+        "count": "47,187"
+      }
+    ],
+    "lnkd-tms-cli": [
+      {
+        "cask": "lnkd-tms-cli",
+        "count": "64,458"
+      }
+    ],
+    "lnkd-tools-slo": [
+      {
+        "cask": "lnkd-tools-slo",
+        "count": "29,547"
+      }
+    ],
+    "lnkd-tor1up-cli": [
+      {
+        "cask": "lnkd-tor1up-cli",
+        "count": "38,866"
+      }
+    ],
+    "lnkd-track-tools-cli": [
+      {
+        "cask": "lnkd-track-tools-cli",
+        "count": "22,720"
+      }
+    ],
+    "lnkd-traffic-remap-builder": [
+      {
+        "cask": "lnkd-traffic-remap-builder",
+        "count": "56,703"
+      }
+    ],
+    "lnkd-trigger-build": [
+      {
+        "cask": "lnkd-trigger-build",
+        "count": "29,943"
+      }
+    ],
+    "lnkd-trjson": [
+      {
+        "cask": "lnkd-trjson",
+        "count": "16,531"
+      }
+    ],
+    "lnkd-umbrella": [
+      {
+        "cask": "lnkd-umbrella",
+        "count": "29,949"
+      }
+    ],
+    "lnkd-ump-tool": [
+      {
+        "cask": "lnkd-ump-tool",
+        "count": "31,248"
+      }
+    ],
+    "lnkd-uss-azure-cli": [
+      {
+        "cask": "lnkd-uss-azure-cli",
+        "count": "38,787"
+      }
+    ],
+    "lnkd-validate-range-yaml-precommit": [
+      {
+        "cask": "lnkd-validate-range-yaml-precommit",
+        "count": "29,819"
+      }
+    ],
+    "lnkd-venice-tools": [
+      {
+        "cask": "lnkd-venice-tools",
+        "count": "63,578"
+      }
+    ],
+    "lnkd-venus-ull": [
+      {
+        "cask": "lnkd-venus-ull",
+        "count": "31,493"
+      }
+    ],
+    "lnkd-veritas-cli": [
+      {
+        "cask": "lnkd-veritas-cli",
+        "count": "16,664"
+      }
+    ],
+    "lnkd-video-cli": [
+      {
+        "cask": "lnkd-video-cli",
+        "count": "30,177"
+      }
+    ],
+    "lnkd-volta": [
+      {
+        "cask": "lnkd-volta",
+        "count": "36,783"
+      }
+    ],
+    "lnkd-volta-install": [
+      {
+        "cask": "lnkd-volta-install",
+        "count": "32,036"
+      }
+    ],
+    "lnkd-wastin-triage": [
+      {
+        "cask": "lnkd-wastin-triage",
+        "count": "16,761"
+      }
+    ],
+    "lnkd-waterbear-cli": [
+      {
+        "cask": "lnkd-waterbear-cli",
+        "count": "56,269"
+      }
+    ],
+    "lnkd-wk": [
+      {
+        "cask": "lnkd-wk",
+        "count": "25,819"
+      }
+    ],
+    "lnkd-wormhole-cli": [
+      {
+        "cask": "lnkd-wormhole-cli",
+        "count": "59,250"
+      }
+    ],
+    "lnkd-wrapped-python-tools": [
+      {
+        "cask": "lnkd-wrapped-python-tools",
+        "count": "28,989"
+      }
+    ],
+    "lnkd-yoda": [
+      {
+        "cask": "lnkd-yoda",
+        "count": "53,569"
+      }
+    ],
+    "lnkd-zing-tool": [
+      {
+        "cask": "lnkd-zing-tool",
+        "count": "17,985"
+      }
+    ],
+    "lnkd-zipline-cli": [
+      {
+        "cask": "lnkd-zipline-cli",
+        "count": "31,122"
+      }
+    ],
+    "lnkd-zoidberg": [
+      {
+        "cask": "lnkd-zoidberg",
+        "count": "30,952"
+      }
+    ],
+    "lnkd-zookeeper-hooks": [
+      {
+        "cask": "lnkd-zookeeper-hooks",
+        "count": "31,595"
+      }
+    ],
+    "lnkd-zookeeper-tools": [
+      {
+        "cask": "lnkd-zookeeper-tools",
+        "count": "30,923"
+      }
+    ],
+    "lnkd-zulu-jdk": [
+      {
+        "cask": "lnkd-zulu-jdk",
+        "count": "7,091"
+      }
+    ],
+    "lnkd-zulu-jdk-11": [
+      {
+        "cask": "lnkd-zulu-jdk-11",
+        "count": "6,102"
+      }
+    ],
+    "lnkd-zulu-jdk-8": [
+      {
+        "cask": "lnkd-zulu-jdk-8",
+        "count": "4,556"
+      }
+    ],
+    "loading": [
+      {
+        "cask": "loading",
+        "count": "90"
+      }
+    ],
+    "loadmytracks": [
+      {
+        "cask": "loadmytracks",
+        "count": "1"
+      }
+    ],
+    "local": [
+      {
+        "cask": "local",
+        "count": "322"
+      }
+    ],
+    "local-by-flywheel": [
+      {
+        "cask": "local-by-flywheel",
+        "count": "161"
+      }
+    ],
+    "local-caffeine": [
+      {
+        "cask": "local-caffeine",
+        "count": "15"
+      }
+    ],
+    "local-transmission": [
+      {
+        "cask": "local-transmission",
+        "count": "6"
+      }
+    ],
+    "localdev": [
+      {
+        "cask": "localdev",
+        "count": "15"
+      }
+    ],
+    "localizationeditor": [
+      {
+        "cask": "localizationeditor",
+        "count": "134"
+      }
+    ],
+    "localswitch": [
+      {
+        "cask": "localswitch",
+        "count": "23"
+      }
+    ],
+    "lock": [
+      {
+        "cask": "lock",
+        "count": "3"
+      }
+    ],
+    "lockdown": [
+      {
+        "cask": "lockdown",
+        "count": "185"
+      }
+    ],
+    "lockrattler": [
+      {
+        "cask": "lockrattler",
+        "count": "69"
+      }
+    ],
+    "logdna-agent": [
+      {
+        "cask": "logdna-agent",
+        "count": "181"
+      }
+    ],
+    "logdna-cli": [
+      {
+        "cask": "logdna-cli",
+        "count": "187"
+      }
+    ],
+    "logicsniffer": [
+      {
+        "cask": "logicsniffer",
+        "count": "38"
+      }
+    ],
+    "loginputmac": [
+      {
+        "cask": "loginputmac",
+        "count": "182"
+      }
+    ],
+    "logisim": [
+      {
+        "cask": "logisim",
+        "count": "574"
+      }
+    ],
+    "logisim-evolution": [
+      {
+        "cask": "logisim-evolution",
+        "count": "74"
+      }
+    ],
+    "logisim-evolution-dev": [
+      {
+        "cask": "logisim-evolution-dev",
+        "count": "4"
+      }
+    ],
+    "logisim-ita": [
+      {
+        "cask": "logisim-ita",
+        "count": "2"
+      }
+    ],
+    "logitech-camera-settings": [
+      {
+        "cask": "logitech-camera-settings",
+        "count": "283"
+      }
+    ],
+    "logitech-control-center": [
+      {
+        "cask": "logitech-control-center",
+        "count": "718"
+      }
+    ],
+    "logitech-firmware": [
+      {
+        "cask": "logitech-firmware",
+        "count": "1"
+      }
+    ],
+    "logitech-firmware-update-tool": [
+      {
+        "cask": "logitech-firmware-update-tool",
+        "count": "1"
+      }
+    ],
+    "logitech-firmwareupdatetool": [
+      {
+        "cask": "logitech-firmwareupdatetool",
+        "count": "72"
+      }
+    ],
+    "logitech-gaming-software": [
+      {
+        "cask": "logitech-gaming-software",
+        "count": "596"
+      }
+    ],
+    "logitech-harmony-remote": [
+      {
+        "cask": "logitech-harmony-remote",
+        "count": "1"
+      }
+    ],
+    "logitech-myharmony": [
+      {
+        "cask": "logitech-myharmony",
+        "count": "147"
+      }
+    ],
+    "logitech-options": [
+      {
+        "cask": "logitech-options",
+        "count": "5,342"
+      }
+    ],
+    "logitech-presentation": [
+      {
+        "cask": "logitech-presentation",
+        "count": "259"
+      }
+    ],
+    "logitech-unifying": [
+      {
+        "cask": "logitech-unifying",
+        "count": "291"
+      }
+    ],
+    "logmein-client": [
+      {
+        "cask": "logmein-client",
+        "count": "86"
+      }
+    ],
+    "logmein-hamachi": [
+      {
+        "cask": "logmein-hamachi",
+        "count": "428"
+      }
+    ],
+    "logoist": [
+      {
+        "cask": "logoist",
+        "count": "5"
+      }
+    ],
+    "logophile": [
+      {
+        "cask": "logophile",
+        "count": "3"
+      }
+    ],
+    "logos": [
+      {
+        "cask": "logos",
+        "count": "116"
+      }
+    ],
+    "lokomotiv": [
+      {
+        "cask": "lokomotiv",
+        "count": "3"
+      }
+    ],
+    "lookin": [
+      {
+        "cask": "lookin",
+        "count": "14"
+      }
+    ],
+    "loom": [
+      {
+        "cask": "loom",
+        "count": "329"
+      }
+    ],
+    "loopback": [
+      {
+        "cask": "loopback",
+        "count": "813"
+      }
+    ],
+    "loopback1": [
+      {
+        "cask": "loopback1",
+        "count": "8"
+      }
+    ],
+    "loopcloud": [
+      {
+        "cask": "loopcloud",
+        "count": "3"
+      }
+    ],
+    "losslesscut": [
+      {
+        "cask": "losslesscut",
+        "count": "485"
+      }
+    ],
+    "lottie": [
+      {
+        "cask": "lottie",
+        "count": "19"
+      }
+    ],
+    "loupedeck": [
+      {
+        "cask": "loupedeck",
+        "count": "6"
+      }
+    ],
+    "love": [
+      {
+        "cask": "love",
+        "count": "730"
+      }
+    ],
+    "lp-webapp": [
+      {
+        "cask": "lp-webapp",
+        "count": "1"
+      }
+    ],
+    "lpcxpresso": [
+      {
+        "cask": "lpcxpresso",
+        "count": "1"
+      }
+    ],
+    "lpk25-editor": [
+      {
+        "cask": "lpk25-editor",
+        "count": "5"
+      }
+    ],
+    "lrtimelapse": [
+      {
+        "cask": "lrtimelapse",
+        "count": "32"
+      }
+    ],
+    "lsock": [
+      {
+        "cask": "lsock",
+        "count": "1"
+      }
+    ],
+    "ltechagent": [
+      {
+        "cask": "LTechAgent",
+        "count": "1"
+      }
+    ],
+    "ltspice": [
+      {
+        "cask": "ltspice",
+        "count": "675"
+      }
+    ],
+    "lucky-pre-release": [
+      {
+        "cask": "lucky-pre-release",
+        "count": "1"
+      }
+    ],
+    "ludwig": [
+      {
+        "cask": "ludwig",
+        "count": "2"
+      }
+    ],
+    "luftdateninfo-flashing-tool": [
+      {
+        "cask": "luftdateninfo-flashing-tool",
+        "count": "8"
+      }
+    ],
+    "lulu": [
+      {
+        "cask": "lulu",
+        "count": "2,530"
+      }
+    ],
+    "lumen": [
+      {
+        "cask": "lumen",
+        "count": "401"
+      }
+    ],
+    "luminance-hdr": [
+      {
+        "cask": "luminance-hdr",
+        "count": "83"
+      }
+    ],
+    "luminetmonitor": [
+      {
+        "cask": "luminetmonitor",
+        "count": "2"
+      }
+    ],
+    "luna-display": [
+      {
+        "cask": "luna-display",
+        "count": "130"
+      }
+    ],
+    "luna-secondary": [
+      {
+        "cask": "luna-secondary",
+        "count": "21"
+      }
+    ],
+    "lunar": [
+      {
+        "cask": "lunar",
+        "count": "918"
+      }
+    ],
+    "lunastudio": [
+      {
+        "cask": "lunastudio",
+        "count": "73"
+      }
+    ],
+    "lunchy": [
+      {
+        "cask": "lunchy",
+        "count": "405"
+      }
+    ],
+    "luxaforus": [
+      {
+        "cask": "luxaforus",
+        "count": "2"
+      }
+    ],
+    "luxmark": [
+      {
+        "cask": "luxmark",
+        "count": "126"
+      }
+    ],
+    "luyten": [
+      {
+        "cask": "luyten",
+        "count": "199"
+      }
+    ],
+    "lyn": [
+      {
+        "cask": "lyn",
+        "count": "90"
+      }
+    ],
+    "lynkeos": [
+      {
+        "cask": "lynkeos",
+        "count": "27"
+      }
+    ],
+    "lynx": [
+      {
+        "cask": "lynx",
+        "count": "254"
+      }
+    ],
+    "lynxlet": [
+      {
+        "cask": "lynxlet",
+        "count": "160"
+      }
+    ],
+    "lyrics-master": [
+      {
+        "cask": "lyrics-master",
+        "count": "107"
+      }
+    ],
+    "lyricsx": [
+      {
+        "cask": "lyricsx",
+        "count": "634"
+      }
+    ],
+    "lyx": [
+      {
+        "cask": "lyx",
+        "count": "1,381"
+      }
+    ],
+    "m-iina": [
+      {
+        "cask": "m-iina",
+        "count": "1"
+      }
+    ],
+    "m3unify": [
+      {
+        "cask": "m3unify",
+        "count": "32"
+      }
+    ],
+    "m64py": [
+      {
+        "cask": "m64py",
+        "count": "7"
+      }
+    ],
+    "mac-chromium": [
+      {
+        "cask": "mac-chromium",
+        "count": "179"
+      }
+    ],
+    "mac2imgur": [
+      {
+        "cask": "mac2imgur",
+        "count": "177"
+      }
+    ],
+    "macbreakz": [
+      {
+        "cask": "macbreakz",
+        "count": "201"
+      }
+    ],
+    "macclean": [
+      {
+        "cask": "macclean",
+        "count": "139"
+      }
+    ],
+    "maccpuid": [
+      {
+        "cask": "maccpuid",
+        "count": "200"
+      }
+    ],
+    "maccy": [
+      {
+        "cask": "maccy",
+        "count": "2,100"
+      }
+    ],
+    "macdependency": [
+      {
+        "cask": "macdependency",
+        "count": "37"
+      }
+    ],
+    "macdive": [
+      {
+        "cask": "macdive",
+        "count": "39"
+      }
+    ],
+    "macdjview": [
+      {
+        "cask": "macdjview",
+        "count": "158"
+      }
+    ],
+    "macdoppler": [
+      {
+        "cask": "macdoppler",
+        "count": "1"
+      }
+    ],
+    "macdown": [
+      {
+        "cask": "macdown",
+        "count": "21,186"
+      }
+    ],
+    "macdropany": [
+      {
+        "cask": "macdropany",
+        "count": "47"
+      }
+    ],
+    "macdrops": [
+      {
+        "cask": "macdrops",
+        "count": "3"
+      }
+    ],
+    "macfeh": [
+      {
+        "cask": "macfeh",
+        "count": "18"
+      }
+    ],
+    "macforge": [
+      {
+        "cask": "macforge",
+        "count": "10"
+      }
+    ],
+    "macfusion": [
+      {
+        "cask": "macfusion",
+        "count": "274"
+      }
+    ],
+    "macfusion-ng": [
+      {
+        "cask": "macfusion-ng",
+        "count": "125"
+      }
+    ],
+    "macgamestore": [
+      {
+        "cask": "macgamestore",
+        "count": "88"
+      }
+    ],
+    "macgdbp": [
+      {
+        "cask": "macgdbp",
+        "count": "84"
+      }
+    ],
+    "macgesture": [
+      {
+        "cask": "macgesture",
+        "count": "207"
+      }
+    ],
+    "machacha": [
+      {
+        "cask": "machacha",
+        "count": "42"
+      }
+    ],
+    "machg": [
+      {
+        "cask": "machg",
+        "count": "34"
+      }
+    ],
+    "machider1": [
+      {
+        "cask": "machider1",
+        "count": "1"
+      }
+    ],
+    "machoedit": [
+      {
+        "cask": "machoedit",
+        "count": "1"
+      }
+    ],
+    "machoexplorer": [
+      {
+        "cask": "machoexplorer",
+        "count": "95"
+      }
+    ],
+    "machoview": [
+      {
+        "cask": "machoview",
+        "count": "36"
+      }
+    ],
+    "maciasl": [
+      {
+        "cask": "maciasl",
+        "count": "339"
+      }
+    ],
+    "macid": [
+      {
+        "cask": "macid",
+        "count": "3"
+      }
+    ],
+    "macintosh-explorer": [
+      {
+        "cask": "macintosh-explorer",
+        "count": "29"
+      }
+    ],
+    "mackerelappactivity": [
+      {
+        "cask": "mackerelappactivity",
+        "count": "1"
+      }
+    ],
+    "macmediakeyforwarder": [
+      {
+        "cask": "macmediakeyforwarder",
+        "count": "1,385"
+      }
+    ],
+    "maconomy": [
+      {
+        "cask": "maconomy",
+        "count": "6"
+      }
+    ],
+    "macos-catalina-patcher": [
+      {
+        "cask": "macos-catalina-patcher",
+        "count": "22"
+      }
+    ],
+    "macos-catalina-patcher@1.3.0": [
+      {
+        "cask": "macos-catalina-patcher@1.3.0",
+        "count": "6"
+      }
+    ],
+    "macos-sdk-headers": [
+      {
+        "cask": "macos-sdk-headers",
+        "count": "1"
+      }
+    ],
+    "macpar-deluxe": [
+      {
+        "cask": "macpar-deluxe",
+        "count": "105"
+      }
+    ],
+    "macpass": [
+      {
+        "cask": "macpass",
+        "count": "4,820"
+      }
+    ],
+    "macpilot": [
+      {
+        "cask": "macpilot",
+        "count": "89"
+      }
+    ],
+    "macports": [
+      {
+        "cask": "macports",
+        "count": "3"
+      }
+    ],
+    "macs-fan-control": [
+      {
+        "cask": "macs-fan-control",
+        "count": "5,924"
+      }
+    ],
+    "macs-fan-control-legacy": [
+      {
+        "cask": "macs-fan-control-legacy",
+        "count": "4"
+      }
+    ],
+    "macserve-ivpn": [
+      {
+        "cask": "macserve-ivpn",
+        "count": "10"
+      }
+    ],
+    "macspice": [
+      {
+        "cask": "macspice",
+        "count": "125"
+      }
+    ],
+    "macstroke": [
+      {
+        "cask": "macstroke",
+        "count": "2"
+      }
+    ],
+    "macsvg": [
+      {
+        "cask": "macsvg",
+        "count": "659"
+      }
+    ],
+    "macswear": [
+      {
+        "cask": "macswear",
+        "count": "4"
+      }
+    ],
+    "macterm": [
+      {
+        "cask": "macterm",
+        "count": "244"
+      }
+    ],
+    "mactex": [
+      {
+        "cask": "mactex",
+        "count": "37,306"
+      }
+    ],
+    "mactex-no-gui": [
+      {
+        "cask": "mactex-no-gui",
+        "count": "9,119"
+      }
+    ],
+    "mactracker": [
+      {
+        "cask": "mactracker",
+        "count": "1,004"
+      }
+    ],
+    "macupdate": [
+      {
+        "cask": "macupdate",
+        "count": "121"
+      }
+    ],
+    "macupdate-installer": [
+      {
+        "cask": "macupdate-installer",
+        "count": "2"
+      }
+    ],
+    "macupdater": [
+      {
+        "cask": "macupdater",
+        "count": "892"
+      }
+    ],
+    "macvim": [
+      {
+        "cask": "macvim",
+        "count": "13,987"
+      }
+    ],
+    "macvim-kaoriya": [
+      {
+        "cask": "macvim-kaoriya",
+        "count": "13"
+      }
+    ],
+    "macvim-kaoriya-override": [
+      {
+        "cask": "macvim-kaoriya-override",
+        "count": "2"
+      }
+    ],
+    "macwinzipper": [
+      {
+        "cask": "macwinzipper",
+        "count": "385"
+      }
+    ],
+    "macx-dvd-ripper-mac-free-edition": [
+      {
+        "cask": "macx-dvd-ripper-mac-free-edition",
+        "count": "130"
+      }
+    ],
+    "macx-dvd-ripper-pro": [
+      {
+        "cask": "macx-dvd-ripper-pro",
+        "count": "60"
+      }
+    ],
+    "macx-video-converter-pro": [
+      {
+        "cask": "macx-video-converter-pro",
+        "count": "114"
+      }
+    ],
+    "macx-youtube-downloader": [
+      {
+        "cask": "macx-youtube-downloader",
+        "count": "608"
+      }
+    ],
+    "maczip4win": [
+      {
+        "cask": "maczip4win",
+        "count": "240"
+      }
+    ],
+    "madruby": [
+      {
+        "cask": "madruby",
+        "count": "12"
+      }
+    ],
+    "maelstrom": [
+      {
+        "cask": "maelstrom",
+        "count": "30"
+      }
+    ],
+    "maestral": [
+      {
+        "cask": "maestral",
+        "count": "3"
+      }
+    ],
+    "magic-launch": [
+      {
+        "cask": "magic-launch",
+        "count": "24"
+      }
+    ],
+    "magicavoxel": [
+      {
+        "cask": "magicavoxel",
+        "count": "593"
+      }
+    ],
+    "magiccap": [
+      {
+        "cask": "magiccap",
+        "count": "11"
+      }
+    ],
+    "magicplot-pro": [
+      {
+        "cask": "magicplot-pro",
+        "count": "1"
+      }
+    ],
+    "magicplot-student": [
+      {
+        "cask": "magicplot-student",
+        "count": "3"
+      }
+    ],
+    "magicplotpro": [
+      {
+        "cask": "magicplotpro",
+        "count": "2"
+      }
+    ],
+    "magicplotstudent": [
+      {
+        "cask": "magicplotstudent",
+        "count": "1"
+      }
+    ],
+    "magicprefs": [
+      {
+        "cask": "magicprefs",
+        "count": "377"
+      }
+    ],
+    "mailbutler": [
+      {
+        "cask": "mailbutler",
+        "count": "167"
+      }
+    ],
+    "mailmaster": [
+      {
+        "cask": "mailmaster",
+        "count": "220"
+      }
+    ],
+    "mailmate": [
+      {
+        "cask": "mailmate",
+        "count": "407"
+      }
+    ],
+    "mailplane": [
+      {
+        "cask": "mailplane",
+        "count": "473"
+      }
+    ],
+    "mailspring": [
+      {
+        "cask": "mailspring",
+        "count": "885"
+      }
+    ],
+    "maintenance": [
+      {
+        "cask": "maintenance",
+        "count": "236"
+      }
+    ],
+    "majestic": [
+      {
+        "cask": "majestic",
+        "count": "14"
+      }
+    ],
+    "majsoul-plus": [
+      {
+        "cask": "majsoul-plus",
+        "count": "25"
+      }
+    ],
+    "makehuman": [
+      {
+        "cask": "makehuman",
+        "count": "153"
+      }
+    ],
+    "makeiphoneringtone": [
+      {
+        "cask": "makeiphoneringtone",
+        "count": "4"
+      }
+    ],
+    "makemkv": [
+      {
+        "cask": "makemkv",
+        "count": "2,353"
+      }
+    ],
+    "makerbot-print": [
+      {
+        "cask": "makerbot-print",
+        "count": "16"
+      }
+    ],
+    "mal-updater": [
+      {
+        "cask": "mal-updater",
+        "count": "1"
+      }
+    ],
+    "maltego": [
+      {
+        "cask": "maltego",
+        "count": "592"
+      }
+    ],
+    "malus": [
+      {
+        "cask": "malus",
+        "count": "34"
+      }
+    ],
+    "malwarebytes": [
+      {
+        "cask": "malwarebytes",
+        "count": "2,696"
+      }
+    ],
+    "mame": [
+      {
+        "cask": "mame",
+        "count": "398"
+      }
+    ],
+    "mammon": [
+      {
+        "cask": "mammon",
+        "count": "16"
+      }
+    ],
+    "mamp": [
+      {
+        "cask": "mamp",
+        "count": "3,141"
+      }
+    ],
+    "mamp4": [
+      {
+        "cask": "mamp4",
+        "count": "28"
+      }
+    ],
+    "manageengine-mibbrowser": [
+      {
+        "cask": "manageengine-mibbrowser",
+        "count": "104"
+      }
+    ],
+    "mancy": [
+      {
+        "cask": "mancy",
+        "count": "13"
+      }
+    ],
+    "manico": [
+      {
+        "cask": "manico",
+        "count": "214"
+      }
+    ],
+    "manictime": [
+      {
+        "cask": "manictime",
+        "count": "30"
+      }
+    ],
+    "manopen": [
+      {
+        "cask": "manopen",
+        "count": "74"
+      }
+    ],
+    "manta": [
+      {
+        "cask": "manta",
+        "count": "51"
+      }
+    ],
+    "mantautil": [
+      {
+        "cask": "mantautil",
+        "count": "2"
+      }
+    ],
+    "manuscripts": [
+      {
+        "cask": "manuscripts",
+        "count": "118"
+      }
+    ],
+    "manuskript": [
+      {
+        "cask": "manuskript",
+        "count": "124"
+      }
+    ],
+    "mapillary-uploader": [
+      {
+        "cask": "mapillary-uploader",
+        "count": "7"
+      }
+    ],
+    "mapture": [
+      {
+        "cask": "mapture",
+        "count": "151"
+      }
+    ],
+    "marathon": [
+      {
+        "cask": "marathon",
+        "count": "36"
+      }
+    ],
+    "marathon-infinity": [
+      {
+        "cask": "marathon-infinity",
+        "count": "4"
+      }
+    ],
+    "marble": [
+      {
+        "cask": "marble",
+        "count": "60"
+      }
+    ],
+    "marcedit": [
+      {
+        "cask": "marcedit",
+        "count": "2"
+      }
+    ],
+    "marginnote": [
+      {
+        "cask": "marginnote",
+        "count": "423"
+      }
+    ],
+    "mari0": [
+      {
+        "cask": "mari0",
+        "count": "40"
+      }
+    ],
+    "maria": [
+      {
+        "cask": "maria",
+        "count": "71"
+      }
+    ],
+    "mark-text": [
+      {
+        "cask": "mark-text",
+        "count": "3,282"
+      }
+    ],
+    "markcat": [
+      {
+        "cask": "markcat",
+        "count": "1"
+      }
+    ],
+    "markdown": [
+      {
+        "cask": "markdown",
+        "count": "2"
+      }
+    ],
+    "markdown-service-tools": [
+      {
+        "cask": "markdown-service-tools",
+        "count": "116"
+      }
+    ],
+    "markdownmdimporter": [
+      {
+        "cask": "markdownmdimporter",
+        "count": "42"
+      }
+    ],
+    "marked": [
+      {
+        "cask": "marked",
+        "count": "798"
+      }
+    ],
+    "marker-import": [
+      {
+        "cask": "marker-import",
+        "count": "1"
+      }
+    ],
+    "markright": [
+      {
+        "cask": "markright",
+        "count": "33"
+      }
+    ],
+    "marmaduke-chromium": [
+      {
+        "cask": "marmaduke-chromium",
+        "count": "243"
+      }
+    ],
+    "marmaduke-chromium-nosync": [
+      {
+        "cask": "marmaduke-chromium-nosync",
+        "count": "31"
+      }
+    ],
+    "marmaduke-chromium-ungoogled": [
+      {
+        "cask": "marmaduke-chromium-ungoogled",
+        "count": "96"
+      }
+    ],
+    "marp": [
+      {
+        "cask": "marp",
+        "count": "253"
+      }
+    ],
+    "mars": [
+      {
+        "cask": "mars",
+        "count": "96"
+      }
+    ],
+    "mars24": [
+      {
+        "cask": "mars24",
+        "count": "3"
+      }
+    ],
+    "marsedit": [
+      {
+        "cask": "marsedit",
+        "count": "63"
+      }
+    ],
+    "marshallofsound-google-play-music-player": [
+      {
+        "cask": "marshallofsound-google-play-music-player",
+        "count": "1,121"
+      }
+    ],
+    "marta": [
+      {
+        "cask": "marta",
+        "count": "1,736"
+      }
+    ],
+    "marvel": [
+      {
+        "cask": "marvel",
+        "count": "111"
+      }
+    ],
+    "marvin": [
+      {
+        "cask": "marvin",
+        "count": "88"
+      }
+    ],
+    "masscode": [
+      {
+        "cask": "masscode",
+        "count": "71"
+      }
+    ],
+    "massreplaceit": [
+      {
+        "cask": "massreplaceit",
+        "count": "31"
+      }
+    ],
+    "master-password": [
+      {
+        "cask": "master-password",
+        "count": "81"
+      }
+    ],
+    "master-pdf-editor": [
+      {
+        "cask": "master-pdf-editor",
+        "count": "319"
+      }
+    ],
+    "masterway-note": [
+      {
+        "cask": "masterway-note",
+        "count": "3"
+      }
+    ],
+    "mat": [
+      {
+        "cask": "mat",
+        "count": "881"
+      }
+    ],
+    "mate-translate": [
+      {
+        "cask": "mate-translate",
+        "count": "124"
+      }
+    ],
+    "mater": [
+      {
+        "cask": "mater",
+        "count": "6"
+      }
+    ],
+    "material-colors": [
+      {
+        "cask": "material-colors",
+        "count": "39"
+      }
+    ],
+    "mathpix-snipping-tool": [
+      {
+        "cask": "mathpix-snipping-tool",
+        "count": "813"
+      }
+    ],
+    "mathtype": [
+      {
+        "cask": "mathtype",
+        "count": "298"
+      }
+    ],
+    "matterhorn": [
+      {
+        "cask": "matterhorn",
+        "count": "87"
+      }
+    ],
+    "mattermost": [
+      {
+        "cask": "mattermost",
+        "count": "5,574"
+      }
+    ],
+    "mattr-slate": [
+      {
+        "cask": "mattr-slate",
+        "count": "255"
+      }
+    ],
+    "mauve": [
+      {
+        "cask": "mauve",
+        "count": "22"
+      }
+    ],
+    "mavensmate": [
+      {
+        "cask": "mavensmate",
+        "count": "40"
+      }
+    ],
+    "max": [
+      {
+        "cask": "max",
+        "count": "242"
+      }
+    ],
+    "maxrio": [
+      {
+        "cask": "maxrio",
+        "count": "14"
+      }
+    ],
+    "mazda-toolbox": [
+      {
+        "cask": "mazda-toolbox",
+        "count": "19"
+      }
+    ],
+    "mbed-cli": [
+      {
+        "cask": "mbed-cli",
+        "count": "2"
+      }
+    ],
+    "mbed-studio": [
+      {
+        "cask": "mbed-studio",
+        "count": "32"
+      }
+    ],
+    "mblock": [
+      {
+        "cask": "mblock",
+        "count": "38"
+      }
+    ],
+    "mcbopomofo": [
+      {
+        "cask": "mcbopomofo",
+        "count": "44"
+      }
+    ],
+    "mcedit": [
+      {
+        "cask": "mcedit",
+        "count": "236"
+      }
+    ],
+    "mcedit-beta": [
+      {
+        "cask": "mcedit-beta",
+        "count": "2"
+      }
+    ],
+    "mcgimp": [
+      {
+        "cask": "mcgimp",
+        "count": "237"
+      }
+    ],
+    "mcrl2-nightly": [
+      {
+        "cask": "mcrl2-nightly",
+        "count": "1"
+      }
+    ],
+    "mcuxpresso": [
+      {
+        "cask": "mcuxpresso",
+        "count": "4"
+      }
+    ],
+    "mdimagesizemdimporter": [
+      {
+        "cask": "mdimagesizemdimporter",
+        "count": "179"
+      }
+    ],
+    "mdrp": [
+      {
+        "cask": "mdrp",
+        "count": "64"
+      }
+    ],
+    "media-center": [
+      {
+        "cask": "media-center",
+        "count": "37"
+      }
+    ],
+    "media-converter": [
+      {
+        "cask": "media-converter",
+        "count": "143"
+      }
+    ],
+    "mediaconch": [
+      {
+        "cask": "mediaconch",
+        "count": "1"
+      }
+    ],
+    "mediaconch-gui": [
+      {
+        "cask": "mediaconch-gui",
+        "count": "2"
+      }
+    ],
+    "mediaelch": [
+      {
+        "cask": "mediaelch",
+        "count": "135"
+      }
+    ],
+    "mediahuman-audio-converter": [
+      {
+        "cask": "mediahuman-audio-converter",
+        "count": "342"
+      }
+    ],
+    "mediahuman-youtube-downloader": [
+      {
+        "cask": "mediahuman-youtube-downloader",
+        "count": "184"
+      }
+    ],
+    "mediainfo": [
+      {
+        "cask": "mediainfo",
+        "count": "1,242"
+      }
+    ],
+    "mediathekview": [
+      {
+        "cask": "mediathekview",
+        "count": "733"
+      }
+    ],
+    "medibang": [
+      {
+        "cask": "medibang",
+        "count": "1"
+      }
+    ],
+    "medleytext": [
+      {
+        "cask": "medleytext",
+        "count": "11"
+      }
+    ],
+    "meerkat": [
+      {
+        "cask": "meerkat",
+        "count": "1"
+      }
+    ],
+    "mega": [
+      {
+        "cask": "mega",
+        "count": "234"
+      }
+    ],
+    "megacmd": [
+      {
+        "cask": "megacmd",
+        "count": "139"
+      }
+    ],
+    "megahertz-knotes": [
+      {
+        "cask": "megahertz-knotes",
+        "count": "7"
+      }
+    ],
+    "megasync": [
+      {
+        "cask": "megasync",
+        "count": "1,957"
+      }
+    ],
+    "meld": [
+      {
+        "cask": "meld",
+        "count": "21,820"
+      }
+    ],
+    "mellow": [
+      {
+        "cask": "mellow",
+        "count": "344"
+      }
+    ],
+    "mellowplayer": [
+      {
+        "cask": "mellowplayer",
+        "count": "51"
+      }
+    ],
+    "melodics": [
+      {
+        "cask": "melodics",
+        "count": "94"
+      }
+    ],
+    "melonbooksviewer": [
+      {
+        "cask": "melonbooksviewer",
+        "count": "4"
+      }
+    ],
+    "memo": [
+      {
+        "cask": "memo",
+        "count": "7"
+      }
+    ],
+    "memoio": [
+      {
+        "cask": "memoio",
+        "count": "28"
+      }
+    ],
+    "memory": [
+      {
+        "cask": "memory",
+        "count": "54"
+      }
+    ],
+    "memory-map": [
+      {
+        "cask": "memory-map",
+        "count": "19"
+      }
+    ],
+    "memory-tracker-by-timely": [
+      {
+        "cask": "memory-tracker-by-timely",
+        "count": "11"
+      }
+    ],
+    "mendeley": [
+      {
+        "cask": "mendeley",
+        "count": "1,088"
+      }
+    ],
+    "mendeley-desktop": [
+      {
+        "cask": "mendeley-desktop",
+        "count": "709"
+      }
+    ],
+    "mendeley-reference-manager": [
+      {
+        "cask": "mendeley-reference-manager",
+        "count": "456"
+      }
+    ],
+    "menu-bar-ticker": [
+      {
+        "cask": "menu-bar-ticker",
+        "count": "2"
+      }
+    ],
+    "menubar-colors": [
+      {
+        "cask": "menubar-colors",
+        "count": "108"
+      }
+    ],
+    "menubar-countdown": [
+      {
+        "cask": "menubar-countdown",
+        "count": "75"
+      }
+    ],
+    "menubar-stats": [
+      {
+        "cask": "menubar-stats",
+        "count": "140"
+      }
+    ],
+    "menubargmail": [
+      {
+        "cask": "menubargmail",
+        "count": "16"
+      }
+    ],
+    "menucalendarclock-ical": [
+      {
+        "cask": "menucalendarclock-ical",
+        "count": "56"
+      }
+    ],
+    "menumeters": [
+      {
+        "cask": "menumeters",
+        "count": "2,852"
+      }
+    ],
+    "menutube": [
+      {
+        "cask": "menutube",
+        "count": "115"
+      }
+    ],
+    "mercurymover": [
+      {
+        "cask": "mercurymover",
+        "count": "1"
+      }
+    ],
+    "merlin-project": [
+      {
+        "cask": "merlin-project",
+        "count": "94"
+      }
+    ],
+    "mesasqlite": [
+      {
+        "cask": "mesasqlite",
+        "count": "71"
+      }
+    ],
+    "meshcommander": [
+      {
+        "cask": "meshcommander",
+        "count": "58"
+      }
+    ],
+    "meshlab": [
+      {
+        "cask": "meshlab",
+        "count": "894"
+      }
+    ],
+    "meshmixer": [
+      {
+        "cask": "meshmixer",
+        "count": "297"
+      }
+    ],
+    "meslolgs-nf-font": [
+      {
+        "cask": "meslolgs-nf-font",
+        "count": "1"
+      }
+    ],
+    "messenger": [
+      {
+        "cask": "messenger",
+        "count": "1,343"
+      }
+    ],
+    "messenger-desktop": [
+      {
+        "cask": "messenger-desktop",
+        "count": "1"
+      }
+    ],
+    "messenger-native": [
+      {
+        "cask": "messenger-native",
+        "count": "77"
+      }
+    ],
+    "meta": [
+      {
+        "cask": "meta",
+        "count": "119"
+      }
+    ],
+    "metabase": [
+      {
+        "cask": "metabase",
+        "count": "416"
+      }
+    ],
+    "metadatics": [
+      {
+        "cask": "metadatics",
+        "count": "1"
+      }
+    ],
+    "metagrowler": [
+      {
+        "cask": "metagrowler",
+        "count": "1"
+      }
+    ],
+    "metasequoia": [
+      {
+        "cask": "metasequoia",
+        "count": "12"
+      }
+    ],
+    "metashape": [
+      {
+        "cask": "metashape",
+        "count": "8"
+      }
+    ],
+    "metashapepro": [
+      {
+        "cask": "metashapepro",
+        "count": "5"
+      }
+    ],
+    "metasploit": [
+      {
+        "cask": "metasploit",
+        "count": "2,752"
+      }
+    ],
+    "metaz": [
+      {
+        "cask": "metaz",
+        "count": "295"
+      }
+    ],
+    "meteorologist": [
+      {
+        "cask": "meteorologist",
+        "count": "138"
+      }
+    ],
+    "mgba": [
+      {
+        "cask": "mgba",
+        "count": "176"
+      }
+    ],
+    "mi": [
+      {
+        "cask": "mi",
+        "count": "482"
+      }
+    ],
+    "mia-for-gmail": [
+      {
+        "cask": "mia-for-gmail",
+        "count": "95"
+      }
+    ],
+    "miaforgmail": [
+      {
+        "cask": "miaforgmail",
+        "count": "1"
+      }
+    ],
+    "michaelvillar-timer": [
+      {
+        "cask": "michaelvillar-timer",
+        "count": "2,668"
+      }
+    ],
+    "micloud": [
+      {
+        "cask": "micloud",
+        "count": "13"
+      }
+    ],
+    "micro-snitch": [
+      {
+        "cask": "micro-snitch",
+        "count": "885"
+      }
+    ],
+    "microblog": [
+      {
+        "cask": "microblog",
+        "count": "85"
+      }
+    ],
+    "microk8s": [
+      {
+        "cask": "microk8s",
+        "count": "8"
+      }
+    ],
+    "microsoft-azure-storage-explorer": [
+      {
+        "cask": "microsoft-azure-storage-explorer",
+        "count": "1,457"
+      }
+    ],
+    "microsoft-edge": [
+      {
+        "cask": "microsoft-edge",
+        "count": "7,497"
+      }
+    ],
+    "microsoft-edge-beta": [
+      {
+        "cask": "microsoft-edge-beta",
+        "count": "2,077"
+      }
+    ],
+    "microsoft-edge-canary": [
+      {
+        "cask": "microsoft-edge-canary",
+        "count": "559"
+      }
+    ],
+    "microsoft-edge-dev": [
+      {
+        "cask": "microsoft-edge-dev",
+        "count": "1,653"
+      }
+    ],
+    "microsoft-excel": [
+      {
+        "cask": "microsoft-excel",
+        "count": "1,602"
+      }
+    ],
+    "microsoft-intellipoint": [
+      {
+        "cask": "microsoft-intellipoint",
+        "count": "82"
+      }
+    ],
+    "microsoft-intellitype": [
+      {
+        "cask": "microsoft-intellitype",
+        "count": "22"
+      }
+    ],
+    "microsoft-lync": [
+      {
+        "cask": "microsoft-lync",
+        "count": "263"
+      }
+    ],
+    "microsoft-office": [
+      {
+        "cask": "microsoft-office",
+        "count": "35,619"
+      }
+    ],
+    "microsoft-office-2011": [
+      {
+        "cask": "microsoft-office-2011",
+        "count": "87"
+      }
+    ],
+    "microsoft-office-2016": [
+      {
+        "cask": "microsoft-office-2016",
+        "count": "106"
+      }
+    ],
+    "microsoft-office-vl-serializer": [
+      {
+        "cask": "microsoft-office-vl-serializer",
+        "count": "11"
+      }
+    ],
+    "microsoft-openjdk": [
+      {
+        "cask": "microsoft-openjdk",
+        "count": "3"
+      }
+    ],
+    "microsoft-outlook": [
+      {
+        "cask": "microsoft-outlook",
+        "count": "312"
+      }
+    ],
+    "microsoft-powerpoint": [
+      {
+        "cask": "microsoft-powerpoint",
+        "count": "1,046"
+      }
+    ],
+    "microsoft-r-open": [
+      {
+        "cask": "microsoft-r-open",
+        "count": "113"
+      }
+    ],
+    "microsoft-remote-desktop-beta": [
+      {
+        "cask": "microsoft-remote-desktop-beta",
+        "count": "6,386"
+      }
+    ],
+    "microsoft-teams": [
+      {
+        "cask": "microsoft-teams",
+        "count": "27,760"
+      }
+    ],
+    "microsoft-word": [
+      {
+        "cask": "microsoft-word",
+        "count": "1,597"
+      }
+    ],
+    "microsoft_updater": [
+      {
+        "cask": "microsoft_updater",
+        "count": "65"
+      }
+    ],
+    "midclick": [
+      {
+        "cask": "midclick",
+        "count": "491"
+      }
+    ],
+    "middleclick": [
+      {
+        "cask": "middleclick",
+        "count": "2,349"
+      }
+    ],
+    "midi-monitor": [
+      {
+        "cask": "midi-monitor",
+        "count": "213"
+      }
+    ],
+    "midichords": [
+      {
+        "cask": "midichords",
+        "count": "1"
+      }
+    ],
+    "midikeys": [
+      {
+        "cask": "midikeys",
+        "count": "126"
+      }
+    ],
+    "midistroke": [
+      {
+        "cask": "midistroke",
+        "count": "32"
+      }
+    ],
+    "miditrail": [
+      {
+        "cask": "miditrail",
+        "count": "47"
+      }
+    ],
+    "mightytext": [
+      {
+        "cask": "mightytext",
+        "count": "5"
+      }
+    ],
+    "mikogo": [
+      {
+        "cask": "mikogo",
+        "count": "41"
+      }
+    ],
+    "miktex": [
+      {
+        "cask": "miktex",
+        "count": "5"
+      }
+    ],
+    "miktex-console": [
+      {
+        "cask": "miktex-console",
+        "count": "274"
+      }
+    ],
+    "milanote": [
+      {
+        "cask": "milanote",
+        "count": "100"
+      }
+    ],
+    "milkman": [
+      {
+        "cask": "milkman",
+        "count": "97"
+      }
+    ],
+    "milkytracker": [
+      {
+        "cask": "milkytracker",
+        "count": "120"
+      }
+    ],
+    "mimecast": [
+      {
+        "cask": "mimecast",
+        "count": "23"
+      }
+    ],
+    "mimersql": [
+      {
+        "cask": "mimersql",
+        "count": "1"
+      }
+    ],
+    "mimik-edge-macos": [
+      {
+        "cask": "mimik-edge-macos",
+        "count": "9"
+      }
+    ],
+    "mimik-edge-osx": [
+      {
+        "cask": "mimik-edge-osx",
+        "count": "127"
+      }
+    ],
+    "mimikedge": [
+      {
+        "cask": "mimikedge",
+        "count": "13"
+      }
+    ],
+    "mimikedgegui": [
+      {
+        "cask": "mimikedgegui",
+        "count": "6"
+      }
+    ],
+    "mimiq": [
+      {
+        "cask": "mimiq",
+        "count": "1"
+      }
+    ],
+    "mimiq-gui": [
+      {
+        "cask": "mimiq-gui",
+        "count": "1"
+      }
+    ],
+    "mimolive": [
+      {
+        "cask": "mimolive",
+        "count": "4"
+      }
+    ],
+    "min": [
+      {
+        "cask": "min",
+        "count": "392"
+      }
+    ],
+    "mindforger": [
+      {
+        "cask": "mindforger",
+        "count": "176"
+      }
+    ],
+    "mindjet-mindmanager": [
+      {
+        "cask": "mindjet-mindmanager",
+        "count": "208"
+      }
+    ],
+    "mindmaster": [
+      {
+        "cask": "mindmaster",
+        "count": "254"
+      }
+    ],
+    "minecraft": [
+      {
+        "cask": "minecraft",
+        "count": "4,447"
+      }
+    ],
+    "minecraft-bedrock-launcher": [
+      {
+        "cask": "minecraft-bedrock-launcher",
+        "count": "1"
+      }
+    ],
+    "minecraft-server": [
+      {
+        "cask": "minecraft-server",
+        "count": "237"
+      }
+    ],
+    "minecraftpe": [
+      {
+        "cask": "minecraftpe",
+        "count": "151"
+      }
+    ],
+    "mini-program-studio": [
+      {
+        "cask": "mini-program-studio",
+        "count": "42"
+      }
+    ],
+    "mini-program-studio-dmg": [
+      {
+        "cask": "mini-program-studio-dmg",
+        "count": "2"
+      }
+    ],
+    "mini-vmac": [
+      {
+        "cask": "mini-vmac",
+        "count": "108"
+      }
+    ],
+    "minibar": [
+      {
+        "cask": "minibar",
+        "count": "2"
+      }
+    ],
+    "miniconda": [
+      {
+        "cask": "miniconda",
+        "count": "11,566"
+      }
+    ],
+    "miniconda2": [
+      {
+        "cask": "miniconda2",
+        "count": "147"
+      }
+    ],
+    "minikube": [
+      {
+        "cask": "minikube",
+        "count": "82,562"
+      }
+    ],
+    "minikube-028": [
+      {
+        "cask": "minikube-028",
+        "count": "2"
+      }
+    ],
+    "minikube@1.3.1": [
+      {
+        "cask": "minikube@1.3.1",
+        "count": "1"
+      }
+    ],
+    "minikube_0_28": [
+      {
+        "cask": "minikube_0_28",
+        "count": "1"
+      }
+    ],
+    "minilyrics": [
+      {
+        "cask": "minilyrics",
+        "count": "5"
+      }
+    ],
+    "minimalmidiplayer": [
+      {
+        "cask": "minimalmidiplayer",
+        "count": "2"
+      }
+    ],
+    "minishift": [
+      {
+        "cask": "minishift",
+        "count": "19,274"
+      }
+    ],
+    "minitimer": [
+      {
+        "cask": "minitimer",
+        "count": "81"
+      }
+    ],
+    "minitube": [
+      {
+        "cask": "minitube",
+        "count": "58"
+      }
+    ],
+    "minizincide": [
+      {
+        "cask": "minizincide",
+        "count": "67"
+      }
+    ],
+    "mint-lang": [
+      {
+        "cask": "mint-lang",
+        "count": "1"
+      }
+    ],
+    "mipony": [
+      {
+        "cask": "mipony",
+        "count": "95"
+      }
+    ],
+    "mirador": [
+      {
+        "cask": "mirador",
+        "count": "6"
+      }
+    ],
+    "mirethmusic": [
+      {
+        "cask": "mirethmusic",
+        "count": "1"
+      }
+    ],
+    "miro-formerly-realtimeboard": [
+      {
+        "cask": "miro-formerly-realtimeboard",
+        "count": "676"
+      }
+    ],
+    "mirrordisplays": [
+      {
+        "cask": "mirrordisplays",
+        "count": "59"
+      }
+    ],
+    "mirrorop": [
+      {
+        "cask": "mirrorop",
+        "count": "80"
+      }
+    ],
+    "mirrors-font-firacode-nerdfont": [
+      {
+        "cask": "mirrors-font-firacode-nerdfont",
+        "count": "1"
+      }
+    ],
+    "miscord": [
+      {
+        "cask": "miscord",
+        "count": "2"
+      }
+    ],
+    "mission-control-plus": [
+      {
+        "cask": "mission-control-plus",
+        "count": "79"
+      }
+    ],
+    "missive": [
+      {
+        "cask": "missive",
+        "count": "59"
+      }
+    ],
+    "mist": [
+      {
+        "cask": "mist",
+        "count": "87"
+      }
+    ],
+    "misu": [
+      {
+        "cask": "misu",
+        "count": "1"
+      }
+    ],
+    "mitimgchecker": [
+      {
+        "cask": "mitimgchecker",
+        "count": "4"
+      }
+    ],
+    "mitsuba": [
+      {
+        "cask": "mitsuba",
+        "count": "2"
+      }
+    ],
+    "mixlr": [
+      {
+        "cask": "mixlr",
+        "count": "2"
+      }
+    ],
+    "mixxx": [
+      {
+        "cask": "mixxx",
+        "count": "238"
+      }
+    ],
+    "mjml": [
+      {
+        "cask": "mjml",
+        "count": "267"
+      }
+    ],
+    "mjolnir": [
+      {
+        "cask": "mjolnir",
+        "count": "102"
+      }
+    ],
+    "mkchromecast": [
+      {
+        "cask": "mkchromecast",
+        "count": "718"
+      }
+    ],
+    "mks": [
+      {
+        "cask": "mks",
+        "count": "121"
+      }
+    ],
+    "mkvtoolnix": [
+      {
+        "cask": "mkvtoolnix",
+        "count": "2,437"
+      }
+    ],
+    "mkvtoolnix-app": [
+      {
+        "cask": "mkvtoolnix-app",
+        "count": "1"
+      }
+    ],
+    "mkvtools": [
+      {
+        "cask": "mkvtools",
+        "count": "334"
+      }
+    ],
+    "mmex": [
+      {
+        "cask": "mmex",
+        "count": "74"
+      }
+    ],
+    "mnemosyne": [
+      {
+        "cask": "mnemosyne",
+        "count": "55"
+      }
+    ],
+    "mob": [
+      {
+        "cask": "mob",
+        "count": "245"
+      }
+    ],
+    "mobile-cop": [
+      {
+        "cask": "mobile-cop",
+        "count": "6"
+      }
+    ],
+    "mobile-mouse-server": [
+      {
+        "cask": "mobile-mouse-server",
+        "count": "28"
+      }
+    ],
+    "mobile-tools": [
+      {
+        "cask": "mobile-tools",
+        "count": "31"
+      }
+    ],
+    "mobirise": [
+      {
+        "cask": "mobirise",
+        "count": "93"
+      }
+    ],
+    "mobster": [
+      {
+        "cask": "mobster",
+        "count": "218"
+      }
+    ],
+    "mocha-keyboard": [
+      {
+        "cask": "mocha-keyboard",
+        "count": "5"
+      }
+    ],
+    "mochi": [
+      {
+        "cask": "mochi",
+        "count": "36"
+      }
+    ],
+    "mockolo": [
+      {
+        "cask": "mockolo",
+        "count": "1"
+      }
+    ],
+    "mockoon": [
+      {
+        "cask": "mockoon",
+        "count": "2,493"
+      }
+    ],
+    "mockplus": [
+      {
+        "cask": "mockplus",
+        "count": "103"
+      }
+    ],
+    "mockuuups-studio": [
+      {
+        "cask": "mockuuups-studio",
+        "count": "26"
+      }
+    ],
+    "modelio": [
+      {
+        "cask": "modelio",
+        "count": "286"
+      }
+    ],
+    "modmove": [
+      {
+        "cask": "modmove",
+        "count": "42"
+      }
+    ],
+    "modulair": [
+      {
+        "cask": "modulair",
+        "count": "7"
+      }
+    ],
+    "moedict": [
+      {
+        "cask": "moedict",
+        "count": "1"
+      }
+    ],
+    "moeditor": [
+      {
+        "cask": "moeditor",
+        "count": "11"
+      }
+    ],
+    "moefe-google-translate": [
+      {
+        "cask": "moefe-google-translate",
+        "count": "137"
+      }
+    ],
+    "mojave-cache-cleaner": [
+      {
+        "cask": "mojave-cache-cleaner",
+        "count": "41"
+      }
+    ],
+    "mojibar": [
+      {
+        "cask": "mojibar",
+        "count": "136"
+      }
+    ],
+    "mollyguard": [
+      {
+        "cask": "mollyguard",
+        "count": "34"
+      }
+    ],
+    "molot": [
+      {
+        "cask": "molot",
+        "count": "2"
+      }
+    ],
+    "molotov": [
+      {
+        "cask": "molotov",
+        "count": "411"
+      }
+    ],
+    "molsoft-browser": [
+      {
+        "cask": "molsoft-browser",
+        "count": "1"
+      }
+    ],
+    "molsoftbrowser": [
+      {
+        "cask": "molsoftbrowser",
+        "count": "1"
+      }
+    ],
+    "monal": [
+      {
+        "cask": "monal",
+        "count": "143"
+      }
+    ],
+    "monero": [
+      {
+        "cask": "monero",
+        "count": "1"
+      }
+    ],
+    "monero-wallet": [
+      {
+        "cask": "monero-wallet",
+        "count": "331"
+      }
+    ],
+    "moneydance": [
+      {
+        "cask": "moneydance",
+        "count": "56"
+      }
+    ],
+    "moneyguru": [
+      {
+        "cask": "moneyguru",
+        "count": "4"
+      }
+    ],
+    "moneymoney": [
+      {
+        "cask": "moneymoney",
+        "count": "377"
+      }
+    ],
+    "moneymoney-amazon": [
+      {
+        "cask": "moneymoney-amazon",
+        "count": "1"
+      }
+    ],
+    "moneymoney-coinbase": [
+      {
+        "cask": "moneymoney-coinbase",
+        "count": "2"
+      }
+    ],
+    "moneymoney-paylife": [
+      {
+        "cask": "moneymoney-paylife",
+        "count": "1"
+      }
+    ],
+    "moneymoney-ripple": [
+      {
+        "cask": "moneymoney-ripple",
+        "count": "1"
+      }
+    ],
+    "moneywiz": [
+      {
+        "cask": "moneywiz",
+        "count": "174"
+      }
+    ],
+    "mongodb": [
+      {
+        "cask": "mongodb",
+        "count": "16,131"
+      }
+    ],
+    "mongodb-3": [
+      {
+        "cask": "mongodb-3",
+        "count": "5"
+      }
+    ],
+    "mongodb-compass": [
+      {
+        "cask": "mongodb-compass",
+        "count": "5,504"
+      }
+    ],
+    "mongodb-compass-beta": [
+      {
+        "cask": "mongodb-compass-beta",
+        "count": "64"
+      }
+    ],
+    "mongodb-compass-community": [
+      {
+        "cask": "mongodb-compass-community",
+        "count": "3,029"
+      }
+    ],
+    "mongodb-compass-community-custom": [
+      {
+        "cask": "mongodb-compass-community-custom",
+        "count": "3"
+      }
+    ],
+    "mongodb-compass-isolated-edition": [
+      {
+        "cask": "mongodb-compass-isolated-edition",
+        "count": "27"
+      }
+    ],
+    "mongodb-compass-readonly": [
+      {
+        "cask": "mongodb-compass-readonly",
+        "count": "45"
+      }
+    ],
+    "mongodbpreferencepane": [
+      {
+        "cask": "mongodbpreferencepane",
+        "count": "71"
+      }
+    ],
+    "mongotron": [
+      {
+        "cask": "mongotron",
+        "count": "152"
+      }
+    ],
+    "monitorcontrol": [
+      {
+        "cask": "monitorcontrol",
+        "count": "4,576"
+      }
+    ],
+    "monitore": [
+      {
+        "cask": "monitore",
+        "count": "8"
+      }
+    ],
+    "monitorearth": [
+      {
+        "cask": "monitorearth",
+        "count": "15"
+      }
+    ],
+    "monity-helper": [
+      {
+        "cask": "monity-helper",
+        "count": "123"
+      }
+    ],
+    "mono-mdk": [
+      {
+        "cask": "mono-mdk",
+        "count": "11,614"
+      }
+    ],
+    "mono-mdk-for-visual-studio": [
+      {
+        "cask": "mono-mdk-for-visual-studio",
+        "count": "1,392"
+      }
+    ],
+    "mono-mdk-preview": [
+      {
+        "cask": "mono-mdk-preview",
+        "count": "1"
+      }
+    ],
+    "mono-mdk516": [
+      {
+        "cask": "mono-mdk516",
+        "count": "40"
+      }
+    ],
+    "monodraw": [
+      {
+        "cask": "monodraw",
+        "count": "670"
+      }
+    ],
+    "monofury": [
+      {
+        "cask": "monofury",
+        "count": "4"
+      }
+    ],
+    "monogame": [
+      {
+        "cask": "monogame",
+        "count": "159"
+      }
+    ],
+    "monolingual": [
+      {
+        "cask": "monolingual",
+        "count": "385"
+      }
+    ],
+    "monosnap": [
+      {
+        "cask": "monosnap",
+        "count": "1"
+      }
+    ],
+    "moodo": [
+      {
+        "cask": "moodo",
+        "count": "22"
+      }
+    ],
+    "moom": [
+      {
+        "cask": "moom",
+        "count": "1,875"
+      }
+    ],
+    "moonitor": [
+      {
+        "cask": "moonitor",
+        "count": "16"
+      }
+    ],
+    "moonlight": [
+      {
+        "cask": "moonlight",
+        "count": "299"
+      }
+    ],
+    "morkro-papyrus": [
+      {
+        "cask": "morkro-papyrus",
+        "count": "98"
+      }
+    ],
+    "morpheus": [
+      {
+        "cask": "morpheus",
+        "count": "10"
+      }
+    ],
+    "mortenjust-pocketcasts": [
+      {
+        "cask": "mortenjust-pocketcasts",
+        "count": "8"
+      }
+    ],
+    "mos": [
+      {
+        "cask": "mos",
+        "count": "4,278"
+      }
+    ],
+    "mos-beta": [
+      {
+        "cask": "mos-beta",
+        "count": "2"
+      }
+    ],
+    "mos3": [
+      {
+        "cask": "mos3",
+        "count": "4"
+      }
+    ],
+    "mosaic": [
+      {
+        "cask": "mosaic",
+        "count": "329"
+      }
+    ],
+    "moscow-ml": [
+      {
+        "cask": "moscow-ml",
+        "count": "30"
+      }
+    ],
+    "moter": [
+      {
+        "cask": "moter",
+        "count": "27"
+      }
+    ],
+    "motion": [
+      {
+        "cask": "motion",
+        "count": "30"
+      }
+    ],
+    "motrix": [
+      {
+        "cask": "motrix",
+        "count": "4,532"
+      }
+    ],
+    "mount-efi": [
+      {
+        "cask": "mount-efi",
+        "count": "6"
+      }
+    ],
+    "mountain": [
+      {
+        "cask": "mountain",
+        "count": "54"
+      }
+    ],
+    "mountain-duck": [
+      {
+        "cask": "mountain-duck",
+        "count": "957"
+      }
+    ],
+    "mounty": [
+      {
+        "cask": "mounty",
+        "count": "21,634"
+      }
+    ],
+    "mouse-fix": [
+      {
+        "cask": "mouse-fix",
+        "count": "3"
+      }
+    ],
+    "mouse-locator": [
+      {
+        "cask": "mouse-locator",
+        "count": "36"
+      }
+    ],
+    "mousecape": [
+      {
+        "cask": "mousecape",
+        "count": "2"
+      }
+    ],
+    "mousefix": [
+      {
+        "cask": "mousefix",
+        "count": "2"
+      }
+    ],
+    "mousepose": [
+      {
+        "cask": "mousepose",
+        "count": "59"
+      }
+    ],
+    "movist": [
+      {
+        "cask": "movist",
+        "count": "222"
+      }
+    ],
+    "movist-pro": [
+      {
+        "cask": "movist-pro",
+        "count": "189"
+      }
+    ],
+    "mozart": [
+      {
+        "cask": "mozart",
+        "count": "1"
+      }
+    ],
+    "mozart2": [
+      {
+        "cask": "mozart2",
+        "count": "136"
+      }
+    ],
+    "mp3gain-express": [
+      {
+        "cask": "mp3gain-express",
+        "count": "66"
+      }
+    ],
+    "mp3tag": [
+      {
+        "cask": "mp3tag",
+        "count": "446"
+      }
+    ],
+    "mp4tools": [
+      {
+        "cask": "mp4tools",
+        "count": "346"
+      }
+    ],
+    "mpeg-streamclip": [
+      {
+        "cask": "mpeg-streamclip",
+        "count": "323"
+      }
+    ],
+    "mpeg-streamclip-beta": [
+      {
+        "cask": "mpeg-streamclip-beta",
+        "count": "1"
+      }
+    ],
+    "mplab-xc32": [
+      {
+        "cask": "mplab-xc32",
+        "count": "8"
+      }
+    ],
+    "mplayer-osx-extended": [
+      {
+        "cask": "mplayer-osx-extended",
+        "count": "471"
+      }
+    ],
+    "mplayerx": [
+      {
+        "cask": "mplayerx",
+        "count": "1,912"
+      }
+    ],
+    "mps": [
+      {
+        "cask": "mps",
+        "count": "108"
+      }
+    ],
+    "mpv": [
+      {
+        "cask": "mpv",
+        "count": "13,242"
+      }
+    ],
+    "mqtt-explorer": [
+      {
+        "cask": "mqtt-explorer",
+        "count": "313"
+      }
+    ],
+    "mqttfx": [
+      {
+        "cask": "mqttfx",
+        "count": "543"
+      }
+    ],
+    "mribeiro-timetracker": [
+      {
+        "cask": "mribeiro-timetracker",
+        "count": "1"
+      }
+    ],
+    "ms-edge-devchannel": [
+      {
+        "cask": "ms-edge-devchannel",
+        "count": "3"
+      }
+    ],
+    "ms_office_volume": [
+      {
+        "cask": "ms_office_volume",
+        "count": "20"
+      }
+    ],
+    "msoft-remote-desktop-beta": [
+      {
+        "cask": "msoft-remote-desktop-beta",
+        "count": "3"
+      }
+    ],
+    "mstdn": [
+      {
+        "cask": "mstdn",
+        "count": "4"
+      }
+    ],
+    "mtasa": [
+      {
+        "cask": "mtasa",
+        "count": "1"
+      }
+    ],
+    "mtmr": [
+      {
+        "cask": "mtmr",
+        "count": "2,461"
+      }
+    ],
+    "mu-editor": [
+      {
+        "cask": "mu-editor",
+        "count": "227"
+      }
+    ],
+    "mubu": [
+      {
+        "cask": "mubu",
+        "count": "3"
+      }
+    ],
+    "mucommander": [
+      {
+        "cask": "mucommander",
+        "count": "917"
+      }
+    ],
+    "mudlet": [
+      {
+        "cask": "mudlet",
+        "count": "153"
+      }
+    ],
+    "mullvadvpn": [
+      {
+        "cask": "mullvadvpn",
+        "count": "925"
+      }
+    ],
+    "mullvadvpn-beta": [
+      {
+        "cask": "mullvadvpn-beta",
+        "count": "24"
+      }
+    ],
+    "multibit-hd": [
+      {
+        "cask": "multibit-hd",
+        "count": "25"
+      }
+    ],
+    "multidock": [
+      {
+        "cask": "multidock",
+        "count": "1"
+      }
+    ],
+    "multidoge": [
+      {
+        "cask": "multidoge",
+        "count": "6"
+      }
+    ],
+    "multifirefox": [
+      {
+        "cask": "multifirefox",
+        "count": "306"
+      }
+    ],
+    "multimc": [
+      {
+        "cask": "multimc",
+        "count": "430"
+      }
+    ],
+    "multipass": [
+      {
+        "cask": "multipass",
+        "count": "8,309"
+      }
+    ],
+    "multipatch": [
+      {
+        "cask": "multipatch",
+        "count": "62"
+      }
+    ],
+    "multiscan-3b": [
+      {
+        "cask": "multiscan-3b",
+        "count": "16"
+      }
+    ],
+    "multitouch": [
+      {
+        "cask": "multitouch",
+        "count": "55"
+      }
+    ],
+    "mumble": [
+      {
+        "cask": "mumble",
+        "count": "996"
+      }
+    ],
+    "munki": [
+      {
+        "cask": "munki",
+        "count": "410"
+      }
+    ],
+    "murus": [
+      {
+        "cask": "murus",
+        "count": "254"
+      }
+    ],
+    "murus-menulet": [
+      {
+        "cask": "murus-menulet",
+        "count": "43"
+      }
+    ],
+    "muruslogsvisualizer": [
+      {
+        "cask": "muruslogsvisualizer",
+        "count": "30"
+      }
+    ],
+    "musaicfm": [
+      {
+        "cask": "musaicfm",
+        "count": "423"
+      }
+    ],
+    "muse": [
+      {
+        "cask": "muse",
+        "count": "119"
+      }
+    ],
+    "museeks": [
+      {
+        "cask": "museeks",
+        "count": "38"
+      }
+    ],
+    "musescore": [
+      {
+        "cask": "musescore",
+        "count": "1,975"
+      }
+    ],
+    "music-bar": [
+      {
+        "cask": "music-bar",
+        "count": "2"
+      }
+    ],
+    "music-manager": [
+      {
+        "cask": "music-manager",
+        "count": "348"
+      }
+    ],
+    "music-tag-editor-pro": [
+      {
+        "cask": "music-tag-editor-pro",
+        "count": "1"
+      }
+    ],
+    "music-tags": [
+      {
+        "cask": "music-tags",
+        "count": "1"
+      }
+    ],
+    "musicbrainz-picard": [
+      {
+        "cask": "musicbrainz-picard",
+        "count": "1,719"
+      }
+    ],
+    "musictube": [
+      {
+        "cask": "musictube",
+        "count": "31"
+      }
+    ],
+    "musique": [
+      {
+        "cask": "musique",
+        "count": "12"
+      }
+    ],
+    "musixmatch": [
+      {
+        "cask": "musixmatch",
+        "count": "1"
+      }
+    ],
+    "mute-me": [
+      {
+        "cask": "mute-me",
+        "count": "4"
+      }
+    ],
+    "mutespotifyads": [
+      {
+        "cask": "mutespotifyads",
+        "count": "992"
+      }
+    ],
+    "mutify": [
+      {
+        "cask": "mutify",
+        "count": "68"
+      }
+    ],
+    "muzei": [
+      {
+        "cask": "muzei",
+        "count": "16"
+      }
+    ],
+    "muzie": [
+      {
+        "cask": "muzie",
+        "count": "9"
+      }
+    ],
+    "muzzle": [
+      {
+        "cask": "muzzle",
+        "count": "990"
+      }
+    ],
+    "mweb": [
+      {
+        "cask": "mweb",
+        "count": "554"
+      }
+    ],
+    "mweb2": [
+      {
+        "cask": "mweb2",
+        "count": "1"
+      }
+    ],
+    "my-budget": [
+      {
+        "cask": "my-budget",
+        "count": "6"
+      }
+    ],
+    "my-git": [
+      {
+        "cask": "my-git",
+        "count": "1"
+      }
+    ],
+    "my-image-garden": [
+      {
+        "cask": "my-image-garden",
+        "count": "5"
+      }
+    ],
+    "my-new-cask": [
+      {
+        "cask": "my-new-cask",
+        "count": "3"
+      }
+    ],
+    "my-oracle-8": [
+      {
+        "cask": "my-oracle-8",
+        "count": "1"
+      }
+    ],
+    "my-splashtop-wired-xdisplay": [
+      {
+        "cask": "my-splashtop-wired-xdisplay",
+        "count": "2"
+      }
+    ],
+    "my-zsh": [
+      {
+        "cask": "my-zsh",
+        "count": "1"
+      }
+    ],
+    "my_alacritty": [
+      {
+        "cask": "my_alacritty",
+        "count": "4"
+      }
+    ],
+    "mycloud": [
+      {
+        "cask": "mycloud",
+        "count": "25"
+      }
+    ],
+    "mycrypto": [
+      {
+        "cask": "mycrypto",
+        "count": "120"
+      }
+    ],
+    "mylio": [
+      {
+        "cask": "mylio",
+        "count": "52"
+      }
+    ],
+    "mymonero": [
+      {
+        "cask": "mymonero",
+        "count": "68"
+      }
+    ],
+    "myo-connect": [
+      {
+        "cask": "myo-connect",
+        "count": "2"
+      }
+    ],
+    "myphone": [
+      {
+        "cask": "myphone",
+        "count": "14"
+      }
+    ],
+    "mysafaribasedbrowser": [
+      {
+        "cask": "mysafaribasedbrowser",
+        "count": "5"
+      }
+    ],
+    "mysensors": [
+      {
+        "cask": "mysensors",
+        "count": "1"
+      }
+    ],
+    "mysides": [
+      {
+        "cask": "mysides",
+        "count": "394"
+      }
+    ],
+    "mysimbl": [
+      {
+        "cask": "mysimbl",
+        "count": "112"
+      }
+    ],
+    "mysql-connector-python": [
+      {
+        "cask": "mysql-connector-python",
+        "count": "1,013"
+      }
+    ],
+    "mysql-shell": [
+      {
+        "cask": "mysql-shell",
+        "count": "3,678"
+      }
+    ],
+    "mysql-utilities": [
+      {
+        "cask": "mysql-utilities",
+        "count": "683"
+      }
+    ],
+    "mysqlworkbench": [
+      {
+        "cask": "mysqlworkbench",
+        "count": "19,727"
+      }
+    ],
+    "mysqlworkbench6": [
+      {
+        "cask": "mysqlworkbench6",
+        "count": "1"
+      }
+    ],
+    "mystem": [
+      {
+        "cask": "mystem",
+        "count": "1"
+      }
+    ],
+    "mythfrontend": [
+      {
+        "cask": "mythfrontend",
+        "count": "2"
+      }
+    ],
+    "myworkspace": [
+      {
+        "cask": "myworkspace",
+        "count": "29"
+      }
+    ],
+    "nabla": [
+      {
+        "cask": "nabla",
+        "count": "6"
+      }
+    ],
+    "nagbar": [
+      {
+        "cask": "nagbar",
+        "count": "28"
+      }
+    ],
+    "nagstamon": [
+      {
+        "cask": "nagstamon",
+        "count": "368"
+      }
+    ],
+    "naked-executable": [
+      {
+        "cask": "naked-executable",
+        "count": "1"
+      }
+    ],
+    "nalaprop": [
+      {
+        "cask": "nalaprop",
+        "count": "9"
+      }
+    ],
+    "nally": [
+      {
+        "cask": "nally",
+        "count": "91"
+      }
+    ],
+    "name-mangler": [
+      {
+        "cask": "name-mangler",
+        "count": "113"
+      }
+    ],
+    "namebench": [
+      {
+        "cask": "namebench",
+        "count": "348"
+      }
+    ],
+    "namechanger": [
+      {
+        "cask": "namechanger",
+        "count": "706"
+      }
+    ],
+    "namecoin": [
+      {
+        "cask": "namecoin",
+        "count": "6"
+      }
+    ],
+    "namely": [
+      {
+        "cask": "namely",
+        "count": "3"
+      }
+    ],
+    "nano": [
+      {
+        "cask": "nano",
+        "count": "306"
+      }
+    ],
+    "nanostudio": [
+      {
+        "cask": "nanostudio",
+        "count": "9"
+      }
+    ],
+    "nanowallet": [
+      {
+        "cask": "nanowallet",
+        "count": "3"
+      }
+    ],
+    "nasas-eyes": [
+      {
+        "cask": "nasas-eyes",
+        "count": "45"
+      }
+    ],
+    "native-access": [
+      {
+        "cask": "native-access",
+        "count": "255"
+      }
+    ],
+    "native-instruments-absynth-5": [
+      {
+        "cask": "native-instruments-absynth-5",
+        "count": "1"
+      }
+    ],
+    "native-instruments-battery-4": [
+      {
+        "cask": "native-instruments-battery-4",
+        "count": "1"
+      }
+    ],
+    "native-instruments-driver": [
+      {
+        "cask": "native-instruments-driver",
+        "count": "1"
+      }
+    ],
+    "native-instruments-enhanced-eq": [
+      {
+        "cask": "native-instruments-enhanced-eq",
+        "count": "1"
+      }
+    ],
+    "native-instruments-flesh": [
+      {
+        "cask": "native-instruments-flesh",
+        "count": "1"
+      }
+    ],
+    "native-instruments-fm8": [
+      {
+        "cask": "native-instruments-fm8",
+        "count": "1"
+      }
+    ],
+    "native-instruments-form": [
+      {
+        "cask": "native-instruments-form",
+        "count": "1"
+      }
+    ],
+    "native-instruments-guitar-rig-5": [
+      {
+        "cask": "native-instruments-guitar-rig-5",
+        "count": "1"
+      }
+    ],
+    "native-instruments-kontakt-5": [
+      {
+        "cask": "native-instruments-kontakt-5",
+        "count": "1"
+      }
+    ],
+    "native-instruments-kontour": [
+      {
+        "cask": "native-instruments-kontour",
+        "count": "1"
+      }
+    ],
+    "native-instruments-massive": [
+      {
+        "cask": "native-instruments-massive",
+        "count": "1"
+      }
+    ],
+    "native-instruments-molekular": [
+      {
+        "cask": "native-instruments-molekular",
+        "count": "1"
+      }
+    ],
+    "native-instruments-monark": [
+      {
+        "cask": "native-instruments-monark",
+        "count": "1"
+      }
+    ],
+    "native-instruments-native-browser-previews": [
+      {
+        "cask": "native-instruments-native-browser-previews",
+        "count": "1"
+      }
+    ],
+    "native-instruments-passive-eq": [
+      {
+        "cask": "native-instruments-passive-eq",
+        "count": "1"
+      }
+    ],
+    "native-instruments-phasis": [
+      {
+        "cask": "native-instruments-phasis",
+        "count": "1"
+      }
+    ],
+    "native-instruments-polyplex": [
+      {
+        "cask": "native-instruments-polyplex",
+        "count": "1"
+      }
+    ],
+    "native-instruments-rammfire": [
+      {
+        "cask": "native-instruments-rammfire",
+        "count": "1"
+      }
+    ],
+    "native-instruments-razor": [
+      {
+        "cask": "native-instruments-razor",
+        "count": "1"
+      }
+    ],
+    "native-instruments-rc-24": [
+      {
+        "cask": "native-instruments-rc-24",
+        "count": "1"
+      }
+    ],
+    "native-instruments-rc-48": [
+      {
+        "cask": "native-instruments-rc-48",
+        "count": "1"
+      }
+    ],
+    "native-instruments-reaktor-blocks": [
+      {
+        "cask": "native-instruments-reaktor-blocks",
+        "count": "1"
+      }
+    ],
+    "native-instruments-reaktor-factory-library": [
+      {
+        "cask": "native-instruments-reaktor-factory-library",
+        "count": "1"
+      }
+    ],
+    "native-instruments-reaktor-prism": [
+      {
+        "cask": "native-instruments-reaktor-prism",
+        "count": "1"
+      }
+    ],
+    "native-instruments-reaktor-spark-r2": [
+      {
+        "cask": "native-instruments-reaktor-spark-r2",
+        "count": "1"
+      }
+    ],
+    "native-instruments-reflektor": [
+      {
+        "cask": "native-instruments-reflektor",
+        "count": "1"
+      }
+    ],
+    "native-instruments-replika-xt": [
+      {
+        "cask": "native-instruments-replika-xt",
+        "count": "1"
+      }
+    ],
+    "native-instruments-rounds": [
+      {
+        "cask": "native-instruments-rounds",
+        "count": "1"
+      }
+    ],
+    "native-instruments-skanner-xt": [
+      {
+        "cask": "native-instruments-skanner-xt",
+        "count": "1"
+      }
+    ],
+    "native-instruments-solid-bus-comp-fx": [
+      {
+        "cask": "native-instruments-solid-bus-comp-fx",
+        "count": "1"
+      }
+    ],
+    "native-instruments-solid-dynamics-fx": [
+      {
+        "cask": "native-instruments-solid-dynamics-fx",
+        "count": "1"
+      }
+    ],
+    "native-instruments-solid-eq-fx": [
+      {
+        "cask": "native-instruments-solid-eq-fx",
+        "count": "1"
+      }
+    ],
+    "native-instruments-supercharger-gt": [
+      {
+        "cask": "native-instruments-supercharger-gt",
+        "count": "1"
+      }
+    ],
+    "native-instruments-the-finger-r2": [
+      {
+        "cask": "native-instruments-the-finger-r2",
+        "count": "1"
+      }
+    ],
+    "native-instruments-the-mouth": [
+      {
+        "cask": "native-instruments-the-mouth",
+        "count": "1"
+      }
+    ],
+    "native-instruments-traktors-12": [
+      {
+        "cask": "native-instruments-traktors-12",
+        "count": "1"
+      }
+    ],
+    "native-instruments-transient-master-fx": [
+      {
+        "cask": "native-instruments-transient-master-fx",
+        "count": "1"
+      }
+    ],
+    "native-instruments-vari-comp": [
+      {
+        "cask": "native-instruments-vari-comp",
+        "count": "1"
+      }
+    ],
+    "native-instruments-vc-160-fx": [
+      {
+        "cask": "native-instruments-vc-160-fx",
+        "count": "1"
+      }
+    ],
+    "native-instruments-vc-2a-fx": [
+      {
+        "cask": "native-instruments-vc-2a-fx",
+        "count": "1"
+      }
+    ],
+    "native-instruments-vc-76-fx": [
+      {
+        "cask": "native-instruments-vc-76-fx",
+        "count": "1"
+      }
+    ],
+    "nativedisplaybrightness": [
+      {
+        "cask": "nativedisplaybrightness",
+        "count": "147"
+      }
+    ],
+    "natron": [
+      {
+        "cask": "natron",
+        "count": "92"
+      }
+    ],
+    "nautilus": [
+      {
+        "cask": "nautilus",
+        "count": "18"
+      }
+    ],
+    "navi": [
+      {
+        "cask": "navi",
+        "count": "1"
+      }
+    ],
+    "navicat-data-modeler": [
+      {
+        "cask": "navicat-data-modeler",
+        "count": "57"
+      }
+    ],
+    "navicat-data-modeler-essentials": [
+      {
+        "cask": "navicat-data-modeler-essentials",
+        "count": "104"
+      }
+    ],
+    "navicat-for-mariadb": [
+      {
+        "cask": "navicat-for-mariadb",
+        "count": "86"
+      }
+    ],
+    "navicat-for-mysql": [
+      {
+        "cask": "navicat-for-mysql",
+        "count": "603"
+      }
+    ],
+    "navicat-for-oracle": [
+      {
+        "cask": "navicat-for-oracle",
+        "count": "79"
+      }
+    ],
+    "navicat-for-postgresql": [
+      {
+        "cask": "navicat-for-postgresql",
+        "count": "285"
+      }
+    ],
+    "navicat-for-sql-server": [
+      {
+        "cask": "navicat-for-sql-server",
+        "count": "56"
+      }
+    ],
+    "navicat-for-sqlite": [
+      {
+        "cask": "navicat-for-sqlite",
+        "count": "85"
+      }
+    ],
+    "navicat-premium": [
+      {
+        "cask": "navicat-premium",
+        "count": "729"
+      }
+    ],
+    "navicat-premium-cn": [
+      {
+        "cask": "navicat-premium-cn",
+        "count": "1"
+      }
+    ],
+    "navicat-premium-essentials": [
+      {
+        "cask": "navicat-premium-essentials",
+        "count": "63"
+      }
+    ],
+    "navicat-premium@12": [
+      {
+        "cask": "navicat-premium@12",
+        "count": "1"
+      }
+    ],
+    "nbtexplorer": [
+      {
+        "cask": "nbtexplorer",
+        "count": "63"
+      }
+    ],
+    "ncar-ncl": [
+      {
+        "cask": "ncar-ncl",
+        "count": "348"
+      }
+    ],
+    "ncurses-old": [
+      {
+        "cask": "ncurses-old",
+        "count": "1"
+      }
+    ],
+    "ndm": [
+      {
+        "cask": "ndm",
+        "count": "273"
+      }
+    ],
+    "near-lock": [
+      {
+        "cask": "near-lock",
+        "count": "344"
+      }
+    ],
+    "neat": [
+      {
+        "cask": "neat",
+        "count": "8"
+      }
+    ],
+    "neo4j": [
+      {
+        "cask": "neo4j",
+        "count": "600"
+      }
+    ],
+    "neofinder": [
+      {
+        "cask": "neofinder",
+        "count": "87"
+      }
+    ],
+    "neovide": [
+      {
+        "cask": "neovide",
+        "count": "1"
+      }
+    ],
+    "neovim-nightly": [
+      {
+        "cask": "neovim-nightly",
+        "count": "57"
+      }
+    ],
+    "nested-app": [
+      {
+        "cask": "nested-app",
+        "count": "1"
+      }
+    ],
+    "nestopia": [
+      {
+        "cask": "nestopia",
+        "count": "156"
+      }
+    ],
+    "netbeans": [
+      {
+        "cask": "netbeans",
+        "count": "2,745"
+      }
+    ],
+    "netbeans-cpp": [
+      {
+        "cask": "netbeans-cpp",
+        "count": "167"
+      }
+    ],
+    "netbeans-html": [
+      {
+        "cask": "netbeans-html",
+        "count": "20"
+      }
+    ],
+    "netbeans-java-ee": [
+      {
+        "cask": "netbeans-java-ee",
+        "count": "291"
+      }
+    ],
+    "netbeans-java-se": [
+      {
+        "cask": "netbeans-java-se",
+        "count": "236"
+      }
+    ],
+    "netbeans-php": [
+      {
+        "cask": "netbeans-php",
+        "count": "148"
+      }
+    ],
+    "netdownloadhelpercoapp": [
+      {
+        "cask": "netdownloadhelpercoapp",
+        "count": "19"
+      }
+    ],
+    "neteasemusic": [
+      {
+        "cask": "neteasemusic",
+        "count": "4,964"
+      }
+    ],
+    "netgear-switch-discovery-tool": [
+      {
+        "cask": "netgear-switch-discovery-tool",
+        "count": "28"
+      }
+    ],
+    "netgeargenie": [
+      {
+        "cask": "netgeargenie",
+        "count": "9"
+      }
+    ],
+    "nethackcocoa": [
+      {
+        "cask": "nethackcocoa",
+        "count": "104"
+      }
+    ],
+    "netiquette": [
+      {
+        "cask": "netiquette",
+        "count": "246"
+      }
+    ],
+    "netloc": [
+      {
+        "cask": "netloc",
+        "count": "2"
+      }
+    ],
+    "netlogo": [
+      {
+        "cask": "netlogo",
+        "count": "190"
+      }
+    ],
+    "netnewswire": [
+      {
+        "cask": "netnewswire",
+        "count": "1,634"
+      }
+    ],
+    "netron": [
+      {
+        "cask": "netron",
+        "count": "3,105"
+      }
+    ],
+    "netshade": [
+      {
+        "cask": "netshade",
+        "count": "5"
+      }
+    ],
+    "netspot": [
+      {
+        "cask": "netspot",
+        "count": "1,081"
+      }
+    ],
+    "netsurf": [
+      {
+        "cask": "netsurf",
+        "count": "121"
+      }
+    ],
+    "netxms-console": [
+      {
+        "cask": "netxms-console",
+        "count": "10"
+      }
+    ],
+    "neurongpu": [
+      {
+        "cask": "neurongpu",
+        "count": "20"
+      }
+    ],
+    "newshosting": [
+      {
+        "cask": "newshosting",
+        "count": "1"
+      }
+    ],
+    "next": [
+      {
+        "cask": "next",
+        "count": "527"
+      }
+    ],
+    "nextcloud": [
+      {
+        "cask": "nextcloud",
+        "count": "4,898"
+      }
+    ],
+    "nfov": [
+      {
+        "cask": "nfov",
+        "count": "71"
+      }
+    ],
+    "ngrok": [
+      {
+        "cask": "ngrok",
+        "count": "53,501"
+      }
+    ],
+    "nheko": [
+      {
+        "cask": "nheko",
+        "count": "94"
+      }
+    ],
+    "nheko-reborn": [
+      {
+        "cask": "nheko-reborn",
+        "count": "2"
+      }
+    ],
+    "ni-488-2": [
+      {
+        "cask": "ni-488-2",
+        "count": "6"
+      }
+    ],
+    "nicecast": [
+      {
+        "cask": "nicecast",
+        "count": "3"
+      }
+    ],
+    "night-owl": [
+      {
+        "cask": "night-owl",
+        "count": "371"
+      }
+    ],
+    "nightfall": [
+      {
+        "cask": "nightfall",
+        "count": "77"
+      }
+    ],
+    "nightingale": [
+      {
+        "cask": "nightingale",
+        "count": "43"
+      }
+    ],
+    "nightowl": [
+      {
+        "cask": "nightowl",
+        "count": "1,570"
+      }
+    ],
+    "nimble": [
+      {
+        "cask": "nimble",
+        "count": "81"
+      }
+    ],
+    "nimble-commander": [
+      {
+        "cask": "nimble-commander",
+        "count": "120"
+      }
+    ],
+    "nimbus": [
+      {
+        "cask": "nimbus",
+        "count": "75"
+      }
+    ],
+    "ninja-download-manager-ndm": [
+      {
+        "cask": "ninja-download-manager-ndm",
+        "count": "35"
+      }
+    ],
+    "nirvana": [
+      {
+        "cask": "nirvana",
+        "count": "5"
+      }
+    ],
+    "nisus-thesaurus": [
+      {
+        "cask": "nisus-thesaurus",
+        "count": "28"
+      }
+    ],
+    "nitrokey": [
+      {
+        "cask": "nitrokey",
+        "count": "199"
+      }
+    ],
+    "nitroshare": [
+      {
+        "cask": "nitroshare",
+        "count": "116"
+      }
+    ],
+    "nkts-keyboard": [
+      {
+        "cask": "nkts-keyboard",
+        "count": "2"
+      }
+    ],
+    "nmap": [
+      {
+        "cask": "nmap",
+        "count": "1"
+      }
+    ],
+    "nndd": [
+      {
+        "cask": "nndd",
+        "count": "6"
+      }
+    ],
+    "no-checksum": [
+      {
+        "cask": "no-checksum",
+        "count": "2"
+      }
+    ],
+    "no-github-hover-safari-extension": [
+      {
+        "cask": "no-github-hover-safari-extension",
+        "count": "1"
+      }
+    ],
+    "no-ip-duc": [
+      {
+        "cask": "no-ip-duc",
+        "count": "107"
+      }
+    ],
+    "nocturn": [
+      {
+        "cask": "nocturn",
+        "count": "17"
+      }
+    ],
+    "nocturnal": [
+      {
+        "cask": "nocturnal",
+        "count": "69"
+      }
+    ],
+    "nocturne": [
+      {
+        "cask": "nocturne",
+        "count": "46"
+      }
+    ],
+    "node10": [
+      {
+        "cask": "node10",
+        "count": "7"
+      }
+    ],
+    "node8": [
+      {
+        "cask": "node8",
+        "count": "1"
+      }
+    ],
+    "node@10": [
+      {
+        "cask": "node@10",
+        "count": "8"
+      }
+    ],
+    "node@12": [
+      {
+        "cask": "node@12",
+        "count": "5"
+      }
+    ],
+    "nodebox": [
+      {
+        "cask": "nodebox",
+        "count": "44"
+      }
+    ],
+    "nodeclipse": [
+      {
+        "cask": "nodeclipse",
+        "count": "37"
+      }
+    ],
+    "nodemcu-pyflasher": [
+      {
+        "cask": "nodemcu-pyflasher",
+        "count": "1"
+      }
+    ],
+    "noise-machine": [
+      {
+        "cask": "noise-machine",
+        "count": "3"
+      }
+    ],
+    "noisebuddy": [
+      {
+        "cask": "noisebuddy",
+        "count": "27"
+      }
+    ],
+    "noisy": [
+      {
+        "cask": "noisy",
+        "count": "41"
+      }
+    ],
+    "noisytyper": [
+      {
+        "cask": "noisytyper",
+        "count": "13"
+      }
+    ],
+    "nomachine": [
+      {
+        "cask": "nomachine",
+        "count": "1,509"
+      }
+    ],
+    "nomachine-enterprise-client": [
+      {
+        "cask": "nomachine-enterprise-client",
+        "count": "1"
+      }
+    ],
+    "nomad": [
+      {
+        "cask": "nomad",
+        "count": "354"
+      }
+    ],
+    "noobproof": [
+      {
+        "cask": "noobproof",
+        "count": "8"
+      }
+    ],
+    "nook": [
+      {
+        "cask": "nook",
+        "count": "32"
+      }
+    ],
+    "nord-sound-manager": [
+      {
+        "cask": "nord-sound-manager",
+        "count": "2"
+      }
+    ],
+    "nordic-nrf-command-line-tools": [
+      {
+        "cask": "nordic-nrf-command-line-tools",
+        "count": "307"
+      }
+    ],
+    "nordic-nrf-connect": [
+      {
+        "cask": "nordic-nrf-connect",
+        "count": "118"
+      }
+    ],
+    "nordic-nrf5x-command-line-tools": [
+      {
+        "cask": "nordic-nrf5x-command-line-tools",
+        "count": "41"
+      }
+    ],
+    "nordlocker": [
+      {
+        "cask": "nordlocker",
+        "count": "3"
+      }
+    ],
+    "nordvpn": [
+      {
+        "cask": "nordvpn",
+        "count": "5,392"
+      }
+    ],
+    "nosleep": [
+      {
+        "cask": "nosleep",
+        "count": "934"
+      }
+    ],
+    "nosql-workbench-for-amazon-dynamodb": [
+      {
+        "cask": "nosql-workbench-for-amazon-dynamodb",
+        "count": "425"
+      }
+    ],
+    "nosqlbooster-for-mongodb": [
+      {
+        "cask": "nosqlbooster-for-mongodb",
+        "count": "920"
+      }
+    ],
+    "nosqlclient": [
+      {
+        "cask": "nosqlclient",
+        "count": "71"
+      }
+    ],
+    "not-pacman": [
+      {
+        "cask": "not-pacman",
+        "count": "39"
+      }
+    ],
+    "not-tetris": [
+      {
+        "cask": "not-tetris",
+        "count": "84"
+      }
+    ],
+    "notable": [
+      {
+        "cask": "notable",
+        "count": "1,816"
+      }
+    ],
+    "notational-velocity": [
+      {
+        "cask": "notational-velocity",
+        "count": "183"
+      }
+    ],
+    "notebooks": [
+      {
+        "cask": "notebooks",
+        "count": "82"
+      }
+    ],
+    "notedup": [
+      {
+        "cask": "notedup",
+        "count": "24"
+      }
+    ],
+    "noteplan": [
+      {
+        "cask": "noteplan",
+        "count": "53"
+      }
+    ],
+    "noti": [
+      {
+        "cask": "noti",
+        "count": "390"
+      }
+    ],
+    "notifyr": [
+      {
+        "cask": "notifyr",
+        "count": "7"
+      }
+    ],
+    "notion": [
+      {
+        "cask": "notion",
+        "count": "12,961"
+      }
+    ],
+    "noto": [
+      {
+        "cask": "noto",
+        "count": "10"
+      }
+    ],
+    "noun-project": [
+      {
+        "cask": "noun-project",
+        "count": "165"
+      }
+    ],
+    "nova67p": [
+      {
+        "cask": "nova67p",
+        "count": "2"
+      }
+    ],
+    "novabench": [
+      {
+        "cask": "novabench",
+        "count": "109"
+      }
+    ],
+    "novation-remote-sl-template-editor": [
+      {
+        "cask": "novation-remote-sl-template-editor",
+        "count": "1"
+      }
+    ],
+    "now": [
+      {
+        "cask": "now",
+        "count": "2,668"
+      }
+    ],
+    "now-tv-player": [
+      {
+        "cask": "now-tv-player",
+        "count": "21"
+      }
+    ],
+    "nowplayingitunes": [
+      {
+        "cask": "nowplayingitunes",
+        "count": "2"
+      }
+    ],
+    "nowplayingtweet": [
+      {
+        "cask": "nowplayingtweet",
+        "count": "61"
+      }
+    ],
+    "nowtvplayer": [
+      {
+        "cask": "nowtvplayer",
+        "count": "1"
+      }
+    ],
+    "nox-app-player": [
+      {
+        "cask": "nox-app-player",
+        "count": "783"
+      }
+    ],
+    "noxappplayer": [
+      {
+        "cask": "noxappplayer",
+        "count": "299"
+      }
+    ],
+    "nozbe": [
+      {
+        "cask": "nozbe",
+        "count": "44"
+      }
+    ],
+    "nrlquaker-winbox": [
+      {
+        "cask": "nrlquaker-winbox",
+        "count": "9,434"
+      }
+    ],
+    "nrr1": [
+      {
+        "cask": "nrr1",
+        "count": "2"
+      }
+    ],
+    "nslogger": [
+      {
+        "cask": "nslogger",
+        "count": "41"
+      }
+    ],
+    "nsregextester": [
+      {
+        "cask": "nsregextester",
+        "count": "49"
+      }
+    ],
+    "nteract": [
+      {
+        "cask": "nteract",
+        "count": "762"
+      }
+    ],
+    "nucc": [
+      {
+        "cask": "nucc",
+        "count": "20"
+      }
+    ],
+    "nuccdev": [
+      {
+        "cask": "nuccdev",
+        "count": "4"
+      }
+    ],
+    "nuclear": [
+      {
+        "cask": "nuclear",
+        "count": "84"
+      }
+    ],
+    "nucleo": [
+      {
+        "cask": "nucleo",
+        "count": "150"
+      }
+    ],
+    "nuclino": [
+      {
+        "cask": "nuclino",
+        "count": "40"
+      }
+    ],
+    "nulloy": [
+      {
+        "cask": "nulloy",
+        "count": "17"
+      }
+    ],
+    "nullpomino": [
+      {
+        "cask": "nullpomino",
+        "count": "23"
+      }
+    ],
+    "numi": [
+      {
+        "cask": "numi",
+        "count": "2,710"
+      }
+    ],
+    "nutstore": [
+      {
+        "cask": "nutstore",
+        "count": "452"
+      }
+    ],
+    "nvalt": [
+      {
+        "cask": "nvalt",
+        "count": "1,211"
+      }
+    ],
+    "nvidia-cuda": [
+      {
+        "cask": "nvidia-cuda",
+        "count": "323"
+      }
+    ],
+    "nvidia-geforce-now": [
+      {
+        "cask": "nvidia-geforce-now",
+        "count": "1,624"
+      }
+    ],
+    "nvidia-web-driver": [
+      {
+        "cask": "nvidia-web-driver",
+        "count": "30"
+      }
+    ],
+    "nwjs": [
+      {
+        "cask": "nwjs",
+        "count": "286"
+      }
+    ],
+    "nzbget": [
+      {
+        "cask": "nzbget",
+        "count": "244"
+      }
+    ],
+    "nzbvortex": [
+      {
+        "cask": "nzbvortex",
+        "count": "77"
+      }
+    ],
+    "oak-store": [
+      {
+        "cask": "oak-store",
+        "count": "25"
+      }
+    ],
+    "ob-xd": [
+      {
+        "cask": "ob-xd",
+        "count": "9"
+      }
+    ],
+    "obinskit": [
+      {
+        "cask": "obinskit",
+        "count": "1"
+      }
+    ],
+    "obinslab-starter": [
+      {
+        "cask": "obinslab-starter",
+        "count": "155"
+      }
+    ],
+    "objectivesharpie": [
+      {
+        "cask": "objectivesharpie",
+        "count": "39"
+      }
+    ],
+    "obs": [
+      {
+        "cask": "obs",
+        "count": "8,238"
+      }
+    ],
+    "obs-ndi": [
+      {
+        "cask": "obs-ndi",
+        "count": "12"
+      }
+    ],
+    "obyte": [
+      {
+        "cask": "obyte",
+        "count": "6"
+      }
+    ],
+    "ocelot": [
+      {
+        "cask": "ocelot",
+        "count": "2"
+      }
+    ],
+    "ocenaudio": [
+      {
+        "cask": "ocenaudio",
+        "count": "685"
+      }
+    ],
+    "oclint": [
+      {
+        "cask": "oclint",
+        "count": "3,278"
+      }
+    ],
+    "octave-app": [
+      {
+        "cask": "octave-app",
+        "count": "947"
+      }
+    ],
+    "octomouse": [
+      {
+        "cask": "octomouse",
+        "count": "35"
+      }
+    ],
+    "octoscreen": [
+      {
+        "cask": "octoscreen",
+        "count": "7"
+      }
+    ],
+    "odio": [
+      {
+        "cask": "odio",
+        "count": "86"
+      }
+    ],
+    "odrive": [
+      {
+        "cask": "odrive",
+        "count": "245"
+      }
+    ],
+    "og-aws-okta": [
+      {
+        "cask": "og-aws-okta",
+        "count": "5"
+      }
+    ],
+    "ogdesign-eagle": [
+      {
+        "cask": "ogdesign-eagle",
+        "count": "142"
+      }
+    ],
+    "okadash": [
+      {
+        "cask": "okadash",
+        "count": "5"
+      }
+    ],
+    "okapi": [
+      {
+        "cask": "okapi",
+        "count": "12"
+      }
+    ],
+    "oki-hiper-c-driver": [
+      {
+        "cask": "oki-hiper-c-driver",
+        "count": "2"
+      }
+    ],
+    "oki_c332dnw": [
+      {
+        "cask": "oki_c332dnw",
+        "count": "1"
+      }
+    ],
+    "okuna-desktop": [
+      {
+        "cask": "okuna-desktop",
+        "count": "18"
+      }
+    ],
+    "old-keepassxc": [
+      {
+        "cask": "old-keepassxc",
+        "count": "1"
+      }
+    ],
+    "olive": [
+      {
+        "cask": "olive",
+        "count": "68"
+      }
+    ],
+    "omegat": [
+      {
+        "cask": "omegat",
+        "count": "83"
+      }
+    ],
+    "omnidazzle": [
+      {
+        "cask": "omnidazzle",
+        "count": "57"
+      }
+    ],
+    "omnidb": [
+      {
+        "cask": "omnidb",
+        "count": "170"
+      }
+    ],
+    "omnidisksweeper": [
+      {
+        "cask": "omnidisksweeper",
+        "count": "2,685"
+      }
+    ],
+    "omnifocus": [
+      {
+        "cask": "omnifocus",
+        "count": "2,119"
+      }
+    ],
+    "omnifocus2": [
+      {
+        "cask": "omnifocus2",
+        "count": "27"
+      }
+    ],
+    "omnigraffle": [
+      {
+        "cask": "omnigraffle",
+        "count": "2,874"
+      }
+    ],
+    "omnigraffle6": [
+      {
+        "cask": "omnigraffle6",
+        "count": "36"
+      }
+    ],
+    "omnioutliner": [
+      {
+        "cask": "omnioutliner",
+        "count": "767"
+      }
+    ],
+    "omniplan": [
+      {
+        "cask": "omniplan",
+        "count": "725"
+      }
+    ],
+    "omnipresence": [
+      {
+        "cask": "omnipresence",
+        "count": "127"
+      }
+    ],
+    "omniweb": [
+      {
+        "cask": "omniweb",
+        "count": "26"
+      }
+    ],
+    "oms-bundle-all": [
+      {
+        "cask": "oms-bundle-all",
+        "count": "1"
+      }
+    ],
+    "oms-bundle-intellij": [
+      {
+        "cask": "oms-bundle-intellij",
+        "count": "1"
+      }
+    ],
+    "oms-java": [
+      {
+        "cask": "oms-java",
+        "count": "3"
+      }
+    ],
+    "oms-rpm": [
+      {
+        "cask": "oms-rpm",
+        "count": "2"
+      }
+    ],
+    "oms-tools-bundle": [
+      {
+        "cask": "oms-tools-bundle",
+        "count": "1"
+      }
+    ],
+    "oms-zookeeper": [
+      {
+        "cask": "oms-zookeeper",
+        "count": "4"
+      }
+    ],
+    "oms-zulu": [
+      {
+        "cask": "oms-zulu",
+        "count": "2"
+      }
+    ],
+    "omx-ebooks": [
+      {
+        "cask": "omx-ebooks",
+        "count": "3"
+      }
+    ],
+    "ondesoft-audiobook-converter": [
+      {
+        "cask": "ondesoft-audiobook-converter",
+        "count": "87"
+      }
+    ],
+    "one-switch": [
+      {
+        "cask": "one-switch",
+        "count": "531"
+      }
+    ],
+    "onecast": [
+      {
+        "cask": "onecast",
+        "count": "57"
+      }
+    ],
+    "onedrive": [
+      {
+        "cask": "onedrive",
+        "count": "5,594"
+      }
+    ],
+    "onenote-importer-preview": [
+      {
+        "cask": "onenote-importer-preview",
+        "count": "63"
+      }
+    ],
+    "onepile": [
+      {
+        "cask": "onepile",
+        "count": "13"
+      }
+    ],
+    "oneswitch": [
+      {
+        "cask": "oneswitch",
+        "count": "2"
+      }
+    ],
+    "oni": [
+      {
+        "cask": "oni",
+        "count": "1,964"
+      }
+    ],
+    "onionshare": [
+      {
+        "cask": "onionshare",
+        "count": "306"
+      }
+    ],
+    "onivim2": [
+      {
+        "cask": "onivim2",
+        "count": "4"
+      }
+    ],
+    "onlyoffice": [
+      {
+        "cask": "onlyoffice",
+        "count": "355"
+      }
+    ],
+    "onyx": [
+      {
+        "cask": "onyx",
+        "count": "9,486"
+      }
+    ],
+    "oolite": [
+      {
+        "cask": "oolite",
+        "count": "22"
+      }
+    ],
+    "open-ecard": [
+      {
+        "cask": "open-ecard",
+        "count": "4"
+      }
+    ],
+    "open-in-code": [
+      {
+        "cask": "open-in-code",
+        "count": "949"
+      }
+    ],
+    "open-jdk11": [
+      {
+        "cask": "open-jdk11",
+        "count": "2"
+      }
+    ],
+    "open-jdk12": [
+      {
+        "cask": "open-jdk12",
+        "count": "1"
+      }
+    ],
+    "open-jdk13": [
+      {
+        "cask": "open-jdk13",
+        "count": "1"
+      }
+    ],
+    "open-jupyter": [
+      {
+        "cask": "open-jupyter",
+        "count": "2"
+      }
+    ],
+    "open-with-player": [
+      {
+        "cask": "open-with-player",
+        "count": "1"
+      }
+    ],
+    "openarena": [
+      {
+        "cask": "openarena",
+        "count": "402"
+      }
+    ],
+    "openaudible": [
+      {
+        "cask": "openaudible",
+        "count": "64"
+      }
+    ],
+    "openbazaar": [
+      {
+        "cask": "openbazaar",
+        "count": "83"
+      }
+    ],
+    "openbci-gui": [
+      {
+        "cask": "openbci-gui",
+        "count": "12"
+      }
+    ],
+    "openboard": [
+      {
+        "cask": "openboard",
+        "count": "108"
+      }
+    ],
+    "openboardview": [
+      {
+        "cask": "openboardview",
+        "count": "75"
+      }
+    ],
+    "openbookdesktop": [
+      {
+        "cask": "openbookdesktop",
+        "count": "11"
+      }
+    ],
+    "openconnect-gui": [
+      {
+        "cask": "openconnect-gui",
+        "count": "5,089"
+      }
+    ],
+    "opencore-configurator": [
+      {
+        "cask": "opencore-configurator",
+        "count": "96"
+      }
+    ],
+    "opencpn": [
+      {
+        "cask": "opencpn",
+        "count": "66"
+      }
+    ],
+    "opendns-updater": [
+      {
+        "cask": "opendns-updater",
+        "count": "23"
+      }
+    ],
+    "opendnsupdater": [
+      {
+        "cask": "opendnsupdater",
+        "count": "42"
+      }
+    ],
+    "openecard": [
+      {
+        "cask": "openecard",
+        "count": "4"
+      }
+    ],
+    "openemu": [
+      {
+        "cask": "openemu",
+        "count": "4,289"
+      }
+    ],
+    "openemu-experimental": [
+      {
+        "cask": "openemu-experimental",
+        "count": "371"
+      }
+    ],
+    "openemulator": [
+      {
+        "cask": "openemulator",
+        "count": "9"
+      }
+    ],
+    "openfile": [
+      {
+        "cask": "openfile",
+        "count": "3"
+      }
+    ],
+    "openfluid": [
+      {
+        "cask": "openfluid",
+        "count": "9"
+      }
+    ],
+    "openframeworks": [
+      {
+        "cask": "openframeworks",
+        "count": "159"
+      }
+    ],
+    "openineditor-lite": [
+      {
+        "cask": "openineditor-lite",
+        "count": "474"
+      }
+    ],
+    "openinterminal": [
+      {
+        "cask": "openinterminal",
+        "count": "4,525"
+      }
+    ],
+    "openinterminal-lite": [
+      {
+        "cask": "openinterminal-lite",
+        "count": "1,451"
+      }
+    ],
+    "openj9": [
+      {
+        "cask": "openj9",
+        "count": "8"
+      }
+    ],
+    "openjdk": [
+      {
+        "cask": "openjdk",
+        "count": "1"
+      }
+    ],
+    "openjdk8": [
+      {
+        "cask": "openjdk8",
+        "count": "1"
+      }
+    ],
+    "openkey": [
+      {
+        "cask": "openkey",
+        "count": "303"
+      }
+    ],
+    "openlp": [
+      {
+        "cask": "openlp",
+        "count": "34"
+      }
+    ],
+    "openmsx": [
+      {
+        "cask": "openmsx",
+        "count": "31"
+      }
+    ],
+    "openmtp": [
+      {
+        "cask": "openmtp",
+        "count": "496"
+      }
+    ],
+    "openmw": [
+      {
+        "cask": "openmw",
+        "count": "67"
+      }
+    ],
+    "openmw-nightlies": [
+      {
+        "cask": "openmw-nightlies",
+        "count": "2"
+      }
+    ],
+    "opennx": [
+      {
+        "cask": "opennx",
+        "count": "23"
+      }
+    ],
+    "openocd-0.10.0-12": [
+      {
+        "cask": "openocd-0.10.0-12",
+        "count": "2"
+      }
+    ],
+    "openoffice": [
+      {
+        "cask": "openoffice",
+        "count": "3,063"
+      }
+    ],
+    "openpht": [
+      {
+        "cask": "openpht",
+        "count": "42"
+      }
+    ],
+    "openra": [
+      {
+        "cask": "openra",
+        "count": "1,132"
+      }
+    ],
+    "openra-playtest": [
+      {
+        "cask": "openra-playtest",
+        "count": "1"
+      }
+    ],
+    "openrct2": [
+      {
+        "cask": "openrct2",
+        "count": "146"
+      }
+    ],
+    "openrefine": [
+      {
+        "cask": "openrefine",
+        "count": "977"
+      }
+    ],
+    "openrtp": [
+      {
+        "cask": "openrtp",
+        "count": "30"
+      }
+    ],
+    "openrtp112": [
+      {
+        "cask": "openrtp112",
+        "count": "1"
+      }
+    ],
+    "opensc": [
+      {
+        "cask": "opensc",
+        "count": "660"
+      }
+    ],
+    "openscad": [
+      {
+        "cask": "openscad",
+        "count": "1,975"
+      }
+    ],
+    "openscad-snapshot": [
+      {
+        "cask": "openscad-snapshot",
+        "count": "39"
+      }
+    ],
+    "opensesame": [
+      {
+        "cask": "opensesame",
+        "count": "43"
+      }
+    ],
+    "openshot-video-editor": [
+      {
+        "cask": "openshot-video-editor",
+        "count": "1,159"
+      }
+    ],
+    "opensim": [
+      {
+        "cask": "opensim",
+        "count": "936"
+      }
+    ],
+    "opensong": [
+      {
+        "cask": "opensong",
+        "count": "24"
+      }
+    ],
+    "openspacedesktop": [
+      {
+        "cask": "openspacedesktop",
+        "count": "7"
+      }
+    ],
+    "opentoonz": [
+      {
+        "cask": "opentoonz",
+        "count": "69"
+      }
+    ],
+    "openttd": [
+      {
+        "cask": "openttd",
+        "count": "587"
+      }
+    ],
+    "opentx-companion": [
+      {
+        "cask": "opentx-companion",
+        "count": "1"
+      }
+    ],
+    "openvanilla": [
+      {
+        "cask": "openvanilla",
+        "count": "110"
+      }
+    ],
+    "openvisualtraceroute": [
+      {
+        "cask": "openvisualtraceroute",
+        "count": "190"
+      }
+    ],
+    "openvpn-connect": [
+      {
+        "cask": "openvpn-connect",
+        "count": "1,190"
+      }
+    ],
+    "openvpn-connect-beta": [
+      {
+        "cask": "openvpn-connect-beta",
+        "count": "40"
+      }
+    ],
+    "openwebstart": [
+      {
+        "cask": "openwebstart",
+        "count": "183"
+      }
+    ],
+    "openxcom": [
+      {
+        "cask": "openxcom",
+        "count": "49"
+      }
+    ],
+    "openzfs": [
+      {
+        "cask": "openzfs",
+        "count": "614"
+      }
+    ],
+    "opera": [
+      {
+        "cask": "opera",
+        "count": "14,120"
+      }
+    ],
+    "opera-beta": [
+      {
+        "cask": "opera-beta",
+        "count": "125"
+      }
+    ],
+    "opera-developer": [
+      {
+        "cask": "opera-developer",
+        "count": "357"
+      }
+    ],
+    "opera-mail": [
+      {
+        "cask": "opera-mail",
+        "count": "52"
+      }
+    ],
+    "opera-mobile-emulator": [
+      {
+        "cask": "opera-mobile-emulator",
+        "count": "65"
+      }
+    ],
+    "opera-neon": [
+      {
+        "cask": "opera-neon",
+        "count": "243"
+      }
+    ],
+    "operadriver": [
+      {
+        "cask": "operadriver",
+        "count": "202"
+      }
+    ],
+    "optimage": [
+      {
+        "cask": "optimage",
+        "count": "208"
+      }
+    ],
+    "optimal-layout": [
+      {
+        "cask": "optimal-layout",
+        "count": "49"
+      }
+    ],
+    "optimus-player": [
+      {
+        "cask": "optimus-player",
+        "count": "3"
+      }
+    ],
+    "optionspace": [
+      {
+        "cask": "optionspace",
+        "count": "2"
+      }
+    ],
+    "oracle-jdk": [
+      {
+        "cask": "oracle-jdk",
+        "count": "12,514"
+      }
+    ],
+    "oracle-jdk-11.0.3": [
+      {
+        "cask": "oracle-jdk-11.0.3",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-7u80": [
+      {
+        "cask": "oracle-jdk-7u80",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u101": [
+      {
+        "cask": "oracle-jdk-8u101",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u40": [
+      {
+        "cask": "oracle-jdk-8u40",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u45": [
+      {
+        "cask": "oracle-jdk-8u45",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u51": [
+      {
+        "cask": "oracle-jdk-8u51",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u60": [
+      {
+        "cask": "oracle-jdk-8u60",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u74": [
+      {
+        "cask": "oracle-jdk-8u74",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-javadoc": [
+      {
+        "cask": "oracle-jdk-javadoc",
+        "count": "659"
+      }
+    ],
+    "oracle-jdk10": [
+      {
+        "cask": "oracle-jdk10",
+        "count": "3"
+      }
+    ],
+    "oracle-jdk11": [
+      {
+        "cask": "oracle-jdk11",
+        "count": "7"
+      }
+    ],
+    "oracle-jdk12": [
+      {
+        "cask": "oracle-jdk12",
+        "count": "2"
+      }
+    ],
+    "oracle-jdk13": [
+      {
+        "cask": "oracle-jdk13",
+        "count": "2"
+      }
+    ],
+    "oracle-jdk7": [
+      {
+        "cask": "oracle-jdk7",
+        "count": "3"
+      }
+    ],
+    "oracle-jdk8": [
+      {
+        "cask": "oracle-jdk8",
+        "count": "16"
+      }
+    ],
+    "oracle-jdk9": [
+      {
+        "cask": "oracle-jdk9",
+        "count": "3"
+      }
+    ],
+    "orange": [
+      {
+        "cask": "orange",
+        "count": "185"
+      }
+    ],
+    "orelord-mongodb": [
+      {
+        "cask": "orelord-mongodb",
+        "count": "3"
+      }
+    ],
+    "origami-studio": [
+      {
+        "cask": "origami-studio",
+        "count": "194"
+      }
+    ],
+    "origin": [
+      {
+        "cask": "origin",
+        "count": "1,233"
+      }
+    ],
+    "orka": [
+      {
+        "cask": "orka",
+        "count": "25"
+      }
+    ],
+    "orka-cli": [
+      {
+        "cask": "orka-cli",
+        "count": "3"
+      }
+    ],
+    "oryoki": [
+      {
+        "cask": "oryoki",
+        "count": "11"
+      }
+    ],
+    "osbuddy": [
+      {
+        "cask": "osbuddy",
+        "count": "25"
+      }
+    ],
+    "osc": [
+      {
+        "cask": "osc",
+        "count": "2"
+      }
+    ],
+    "oscar": [
+      {
+        "cask": "oscar",
+        "count": "31"
+      }
+    ],
+    "oscilloscope": [
+      {
+        "cask": "oscilloscope",
+        "count": "25"
+      }
+    ],
+    "osctester": [
+      {
+        "cask": "osctester",
+        "count": "82"
+      }
+    ],
+    "osctl": [
+      {
+        "cask": "osctl",
+        "count": "11"
+      }
+    ],
+    "osculator": [
+      {
+        "cask": "osculator",
+        "count": "2"
+      }
+    ],
+    "osirix-quicklook": [
+      {
+        "cask": "osirix-quicklook",
+        "count": "220"
+      }
+    ],
+    "osmc": [
+      {
+        "cask": "osmc",
+        "count": "89"
+      }
+    ],
+    "osquery": [
+      {
+        "cask": "osquery",
+        "count": "8"
+      }
+    ],
+    "oss-browser": [
+      {
+        "cask": "oss-browser",
+        "count": "2"
+      }
+    ],
+    "osu": [
+      {
+        "cask": "osu",
+        "count": "60"
+      }
+    ],
+    "osu-development": [
+      {
+        "cask": "osu-development",
+        "count": "77"
+      }
+    ],
+    "osxfuse": [
+      {
+        "cask": "osxfuse",
+        "count": "113,812"
+      }
+    ],
+    "osxfuse-dev": [
+      {
+        "cask": "osxfuse-dev",
+        "count": "134"
+      }
+    ],
+    "otp-auth": [
+      {
+        "cask": "otp-auth",
+        "count": "283"
+      }
+    ],
+    "otter-browser": [
+      {
+        "cask": "otter-browser",
+        "count": "65"
+      }
+    ],
+    "otx": [
+      {
+        "cask": "otx",
+        "count": "340"
+      }
+    ],
+    "outguess": [
+      {
+        "cask": "outguess",
+        "count": "340"
+      }
+    ],
+    "outline": [
+      {
+        "cask": "outline",
+        "count": "226"
+      }
+    ],
+    "outline-manager": [
+      {
+        "cask": "outline-manager",
+        "count": "386"
+      }
+    ],
+    "outset": [
+      {
+        "cask": "outset",
+        "count": "152"
+      }
+    ],
+    "outwit-hub": [
+      {
+        "cask": "outwit-hub",
+        "count": "11"
+      }
+    ],
+    "overdrive-media-console": [
+      {
+        "cask": "overdrive-media-console",
+        "count": "75"
+      }
+    ],
+    "overflow": [
+      {
+        "cask": "overflow",
+        "count": "55"
+      }
+    ],
+    "overkill": [
+      {
+        "cask": "overkill",
+        "count": "359"
+      }
+    ],
+    "oversight": [
+      {
+        "cask": "oversight",
+        "count": "492"
+      }
+    ],
+    "overture": [
+      {
+        "cask": "overture",
+        "count": "2"
+      }
+    ],
+    "ovito": [
+      {
+        "cask": "ovito",
+        "count": "14"
+      }
+    ],
+    "owasp-zap": [
+      {
+        "cask": "owasp-zap",
+        "count": "4,283"
+      }
+    ],
+    "owncloud": [
+      {
+        "cask": "owncloud",
+        "count": "1,026"
+      }
+    ],
+    "oxygen-xml-editor": [
+      {
+        "cask": "oxygen-xml-editor",
+        "count": "272"
+      }
+    ],
+    "p-208ii-driver": [
+      {
+        "cask": "p-208ii-driver",
+        "count": "2"
+      }
+    ],
+    "p4merge": [
+      {
+        "cask": "p4merge",
+        "count": "1"
+      }
+    ],
+    "p4v": [
+      {
+        "cask": "p4v",
+        "count": "2,262"
+      }
+    ],
+    "p6sync": [
+      {
+        "cask": "p6sync",
+        "count": "4"
+      }
+    ],
+    "pablodraw": [
+      {
+        "cask": "pablodraw",
+        "count": "38"
+      }
+    ],
+    "pacifist": [
+      {
+        "cask": "pacifist",
+        "count": "483"
+      }
+    ],
+    "packages": [
+      {
+        "cask": "packages",
+        "count": "580"
+      }
+    ],
+    "packet-cli": [
+      {
+        "cask": "packet-cli",
+        "count": "2"
+      }
+    ],
+    "packet-peeper": [
+      {
+        "cask": "packet-peeper",
+        "count": "63"
+      }
+    ],
+    "packetproxy": [
+      {
+        "cask": "packetproxy",
+        "count": "12"
+      }
+    ],
+    "packetsender": [
+      {
+        "cask": "packetsender",
+        "count": "2,345"
+      }
+    ],
+    "pages-data-merge": [
+      {
+        "cask": "pages-data-merge",
+        "count": "16"
+      }
+    ],
+    "pagico": [
+      {
+        "cask": "pagico",
+        "count": "55"
+      }
+    ],
+    "paintbrush": [
+      {
+        "cask": "paintbrush",
+        "count": "2,777"
+      }
+    ],
+    "paintcode": [
+      {
+        "cask": "paintcode",
+        "count": "112"
+      }
+    ],
+    "pallotron-yubiswitch": [
+      {
+        "cask": "pallotron-yubiswitch",
+        "count": "137"
+      }
+    ],
+    "panconvert": [
+      {
+        "cask": "panconvert",
+        "count": "2"
+      }
+    ],
+    "panda": [
+      {
+        "cask": "panda",
+        "count": "75"
+      }
+    ],
+    "pandora": [
+      {
+        "cask": "pandora",
+        "count": "154"
+      }
+    ],
+    "panic-unison": [
+      {
+        "cask": "panic-unison",
+        "count": "55"
+      }
+    ],
+    "panoply": [
+      {
+        "cask": "panoply",
+        "count": "190"
+      }
+    ],
+    "panoptes": [
+      {
+        "cask": "panoptes",
+        "count": "7"
+      }
+    ],
+    "pantheon-localdev": [
+      {
+        "cask": "pantheon-localdev",
+        "count": "1"
+      }
+    ],
+    "paparazzi": [
+      {
+        "cask": "paparazzi",
+        "count": "234"
+      }
+    ],
+    "paper": [
+      {
+        "cask": "paper",
+        "count": "381"
+      }
+    ],
+    "papers": [
+      {
+        "cask": "papers",
+        "count": "581"
+      }
+    ],
+    "paperspace": [
+      {
+        "cask": "paperspace",
+        "count": "48"
+      }
+    ],
+    "papyrus": [
+      {
+        "cask": "papyrus",
+        "count": "96"
+      }
+    ],
+    "paragon-extfs": [
+      {
+        "cask": "paragon-extfs",
+        "count": "473"
+      }
+    ],
+    "paragon-ntfs": [
+      {
+        "cask": "paragon-ntfs",
+        "count": "1,803"
+      }
+    ],
+    "paragon-vmdk-mounter": [
+      {
+        "cask": "paragon-vmdk-mounter",
+        "count": "307"
+      }
+    ],
+    "parallels": [
+      {
+        "cask": "parallels",
+        "count": "6,375"
+      }
+    ],
+    "parallels-access": [
+      {
+        "cask": "parallels-access",
+        "count": "129"
+      }
+    ],
+    "parallels-client": [
+      {
+        "cask": "parallels-client",
+        "count": "265"
+      }
+    ],
+    "parallels-desktop": [
+      {
+        "cask": "parallels-desktop",
+        "count": "4"
+      }
+    ],
+    "parallels-toolbox": [
+      {
+        "cask": "parallels-toolbox",
+        "count": "420"
+      }
+    ],
+    "parallels-toolbox2": [
+      {
+        "cask": "parallels-toolbox2",
+        "count": "1"
+      }
+    ],
+    "parallels-virtualization-sdk": [
+      {
+        "cask": "parallels-virtualization-sdk",
+        "count": "451"
+      }
+    ],
+    "parallels12": [
+      {
+        "cask": "parallels12",
+        "count": "22"
+      }
+    ],
+    "parallels13": [
+      {
+        "cask": "parallels13",
+        "count": "72"
+      }
+    ],
+    "parallels14": [
+      {
+        "cask": "parallels14",
+        "count": "3"
+      }
+    ],
+    "paraview": [
+      {
+        "cask": "paraview",
+        "count": "1,069"
+      }
+    ],
+    "parse": [
+      {
+        "cask": "parse",
+        "count": "54"
+      }
+    ],
+    "parsec": [
+      {
+        "cask": "parsec",
+        "count": "686"
+      }
+    ],
+    "parsehub": [
+      {
+        "cask": "parsehub",
+        "count": "46"
+      }
+    ],
+    "particle-dev": [
+      {
+        "cask": "particle-dev",
+        "count": "19"
+      }
+    ],
+    "pascom-client": [
+      {
+        "cask": "pascom-client",
+        "count": "1"
+      }
+    ],
+    "pashua": [
+      {
+        "cask": "pashua",
+        "count": "72"
+      }
+    ],
+    "passafari": [
+      {
+        "cask": "passafari",
+        "count": "15"
+      }
+    ],
+    "passformacos": [
+      {
+        "cask": "passformacos",
+        "count": "13"
+      }
+    ],
+    "password": [
+      {
+        "cask": "password",
+        "count": "1"
+      }
+    ],
+    "password-assistant": [
+      {
+        "cask": "password-assistant",
+        "count": "68"
+      }
+    ],
+    "password-gorilla": [
+      {
+        "cask": "password-gorilla",
+        "count": "280"
+      }
+    ],
+    "passwordsafeswt": [
+      {
+        "cask": "passwordsafeswt",
+        "count": "1"
+      }
+    ],
+    "paste": [
+      {
+        "cask": "paste",
+        "count": "811"
+      }
+    ],
+    "pastebot": [
+      {
+        "cask": "pastebot",
+        "count": "259"
+      }
+    ],
+    "pastor": [
+      {
+        "cask": "pastor",
+        "count": "3"
+      }
+    ],
+    "patchwork": [
+      {
+        "cask": "patchwork",
+        "count": "294"
+      }
+    ],
+    "path-finder": [
+      {
+        "cask": "path-finder",
+        "count": "1,117"
+      }
+    ],
+    "path-finder7": [
+      {
+        "cask": "path-finder7",
+        "count": "3"
+      }
+    ],
+    "paw": [
+      {
+        "cask": "paw",
+        "count": "3,011"
+      }
+    ],
+    "paw2": [
+      {
+        "cask": "paw2",
+        "count": "1"
+      }
+    ],
+    "pawnee": [
+      {
+        "cask": "pawnee",
+        "count": "2"
+      }
+    ],
+    "pazi": [
+      {
+        "cask": "pazi",
+        "count": "1"
+      }
+    ],
+    "pb-for-desktop": [
+      {
+        "cask": "pb-for-desktop",
+        "count": "1"
+      }
+    ],
+    "pcloud-drive": [
+      {
+        "cask": "pcloud-drive",
+        "count": "22"
+      }
+    ],
+    "pd": [
+      {
+        "cask": "pd",
+        "count": "288"
+      }
+    ],
+    "pd-extended": [
+      {
+        "cask": "pd-extended",
+        "count": "82"
+      }
+    ],
+    "pd-l2ork": [
+      {
+        "cask": "pd-l2ork",
+        "count": "53"
+      }
+    ],
+    "pdf-converter-master": [
+      {
+        "cask": "pdf-converter-master",
+        "count": "67"
+      }
+    ],
+    "pdf-expert": [
+      {
+        "cask": "pdf-expert",
+        "count": "3,468"
+      }
+    ],
+    "pdf-expert-beta": [
+      {
+        "cask": "pdf-expert-beta",
+        "count": "23"
+      }
+    ],
+    "pdf-images": [
+      {
+        "cask": "pdf-images",
+        "count": "278"
+      }
+    ],
+    "pdf-squeezer": [
+      {
+        "cask": "pdf-squeezer",
+        "count": "140"
+      }
+    ],
+    "pdf-toolbox": [
+      {
+        "cask": "pdf-toolbox",
+        "count": "156"
+      }
+    ],
+    "pdfelement": [
+      {
+        "cask": "pdfelement",
+        "count": "506"
+      }
+    ],
+    "pdfelement-cn": [
+      {
+        "cask": "pdfelement-cn",
+        "count": "1"
+      }
+    ],
+    "pdfelement-express": [
+      {
+        "cask": "pdfelement-express",
+        "count": "61"
+      }
+    ],
+    "pdfelementpro": [
+      {
+        "cask": "pdfelementpro",
+        "count": "16"
+      }
+    ],
+    "pdfexpert": [
+      {
+        "cask": "pdfexpert",
+        "count": "1"
+      }
+    ],
+    "pdfextractor": [
+      {
+        "cask": "pdfextractor",
+        "count": "62"
+      }
+    ],
+    "pdfinfo": [
+      {
+        "cask": "pdfinfo",
+        "count": "1,150"
+      }
+    ],
+    "pdfkey-pro": [
+      {
+        "cask": "pdfkey-pro",
+        "count": "14"
+      }
+    ],
+    "pdfmasher": [
+      {
+        "cask": "pdfmasher",
+        "count": "3"
+      }
+    ],
+    "pdfpen": [
+      {
+        "cask": "pdfpen",
+        "count": "159"
+      }
+    ],
+    "pdfpenpro": [
+      {
+        "cask": "pdfpenpro",
+        "count": "290"
+      }
+    ],
+    "pdfsam-basic": [
+      {
+        "cask": "pdfsam-basic",
+        "count": "612"
+      }
+    ],
+    "pdfshaver": [
+      {
+        "cask": "pdfshaver",
+        "count": "46"
+      }
+    ],
+    "pdftk": [
+      {
+        "cask": "pdftk",
+        "count": "9"
+      }
+    ],
+    "pdftk-server": [
+      {
+        "cask": "pdftk-server",
+        "count": "9"
+      }
+    ],
+    "pdftotext": [
+      {
+        "cask": "pdftotext",
+        "count": "3,940"
+      }
+    ],
+    "pdk": [
+      {
+        "cask": "pdk",
+        "count": "2,545"
+      }
+    ],
+    "pdnu": [
+      {
+        "cask": "pdnu",
+        "count": "1"
+      }
+    ],
+    "pe-client-tools": [
+      {
+        "cask": "pe-client-tools",
+        "count": "46"
+      }
+    ],
+    "pe-client-tools-2018.1": [
+      {
+        "cask": "pe-client-tools-2018.1",
+        "count": "4"
+      }
+    ],
+    "pe-client-tools-2019.3": [
+      {
+        "cask": "pe-client-tools-2019.3",
+        "count": "2"
+      }
+    ],
+    "peakhour": [
+      {
+        "cask": "peakhour",
+        "count": "43"
+      }
+    ],
+    "peepopen": [
+      {
+        "cask": "peepopen",
+        "count": "6"
+      }
+    ],
+    "penc": [
+      {
+        "cask": "penc",
+        "count": "134"
+      }
+    ],
+    "pencil": [
+      {
+        "cask": "pencil",
+        "count": "870"
+      }
+    ],
+    "pencil2d": [
+      {
+        "cask": "pencil2d",
+        "count": "156"
+      }
+    ],
+    "pennywise": [
+      {
+        "cask": "pennywise",
+        "count": "1,081"
+      }
+    ],
+    "people-plus-content-ip": [
+      {
+        "cask": "people-plus-content-ip",
+        "count": "40"
+      }
+    ],
+    "perforce": [
+      {
+        "cask": "perforce",
+        "count": "801"
+      }
+    ],
+    "periphery": [
+      {
+        "cask": "periphery",
+        "count": "3,568"
+      }
+    ],
+    "permissionscanner": [
+      {
+        "cask": "permissionscanner",
+        "count": "12"
+      }
+    ],
+    "permute": [
+      {
+        "cask": "permute",
+        "count": "367"
+      }
+    ],
+    "persepolis-download-manager": [
+      {
+        "cask": "persepolis-download-manager",
+        "count": "281"
+      }
+    ],
+    "perspec": [
+      {
+        "cask": "perspec",
+        "count": "5"
+      }
+    ],
+    "pester": [
+      {
+        "cask": "pester",
+        "count": "60"
+      }
+    ],
+    "pext": [
+      {
+        "cask": "pext",
+        "count": "13"
+      }
+    ],
+    "pext-nightly": [
+      {
+        "cask": "pext-nightly",
+        "count": "53"
+      }
+    ],
+    "peyton-xbox360-controller-driver-unofficial": [
+      {
+        "cask": "peyton-xbox360-controller-driver-unofficial",
+        "count": "1"
+      }
+    ],
+    "pflists": [
+      {
+        "cask": "pflists",
+        "count": "24"
+      }
+    ],
+    "pg-8x": [
+      {
+        "cask": "pg-8x",
+        "count": "4"
+      }
+    ],
+    "pg-commander": [
+      {
+        "cask": "pg-commander",
+        "count": "313"
+      }
+    ],
+    "pgadmin3": [
+      {
+        "cask": "pgadmin3",
+        "count": "1,079"
+      }
+    ],
+    "pgadmin4": [
+      {
+        "cask": "pgadmin4",
+        "count": "18,714"
+      }
+    ],
+    "pgmodeler": [
+      {
+        "cask": "pgmodeler",
+        "count": "9"
+      }
+    ],
+    "phantomjs": [
+      {
+        "cask": "phantomjs",
+        "count": "25,569"
+      }
+    ],
+    "phantomjs-sakura": [
+      {
+        "cask": "phantomjs-sakura",
+        "count": "2"
+      }
+    ],
+    "pharo-launcher": [
+      {
+        "cask": "pharo-launcher",
+        "count": "74"
+      }
+    ],
+    "phew": [
+      {
+        "cask": "phew",
+        "count": "72"
+      }
+    ],
+    "phiewer": [
+      {
+        "cask": "phiewer",
+        "count": "117"
+      }
+    ],
+    "philips-hue-sync": [
+      {
+        "cask": "philips-hue-sync",
+        "count": "233"
+      }
+    ],
+    "phocus": [
+      {
+        "cask": "phocus",
+        "count": "25"
+      }
+    ],
+    "phoenix": [
+      {
+        "cask": "phoenix",
+        "count": "610"
+      }
+    ],
+    "phoenix-slides": [
+      {
+        "cask": "phoenix-slides",
+        "count": "69"
+      }
+    ],
+    "phon": [
+      {
+        "cask": "phon",
+        "count": "3"
+      }
+    ],
+    "phonebrowse": [
+      {
+        "cask": "phonebrowse",
+        "count": "16"
+      }
+    ],
+    "phoneclean": [
+      {
+        "cask": "phoneclean",
+        "count": "33"
+      }
+    ],
+    "phonegap": [
+      {
+        "cask": "phonegap",
+        "count": "216"
+      }
+    ],
+    "phonerescue": [
+      {
+        "cask": "phonerescue",
+        "count": "20"
+      }
+    ],
+    "phonetrans": [
+      {
+        "cask": "phonetrans",
+        "count": "16"
+      }
+    ],
+    "phoneview": [
+      {
+        "cask": "phoneview",
+        "count": "3"
+      }
+    ],
+    "photo-supreme-single-user": [
+      {
+        "cask": "photo-supreme-single-user",
+        "count": "3"
+      }
+    ],
+    "photoninja": [
+      {
+        "cask": "photoninja",
+        "count": "21"
+      }
+    ],
+    "photoscan": [
+      {
+        "cask": "photoscan",
+        "count": "3"
+      }
+    ],
+    "photosweeper-x": [
+      {
+        "cask": "photosweeper-x",
+        "count": "27"
+      }
+    ],
+    "photosync": [
+      {
+        "cask": "photosync",
+        "count": "105"
+      }
+    ],
+    "photozoom-pro": [
+      {
+        "cask": "photozoom-pro",
+        "count": "8"
+      }
+    ],
+    "phpstorm": [
+      {
+        "cask": "phpstorm",
+        "count": "7,584"
+      }
+    ],
+    "phpstorm-perpetual": [
+      {
+        "cask": "phpstorm-perpetual",
+        "count": "11"
+      }
+    ],
+    "phpstorm2016": [
+      {
+        "cask": "phpstorm2016",
+        "count": "6"
+      }
+    ],
+    "physicseditor": [
+      {
+        "cask": "physicseditor",
+        "count": "22"
+      }
+    ],
+    "pianoone": [
+      {
+        "cask": "pianoone",
+        "count": "3"
+      }
+    ],
+    "pibakery": [
+      {
+        "cask": "pibakery",
+        "count": "175"
+      }
+    ],
+    "picgo": [
+      {
+        "cask": "picgo",
+        "count": "987"
+      }
+    ],
+    "picotech-picoscope": [
+      {
+        "cask": "picotech-picoscope",
+        "count": "1"
+      }
+    ],
+    "picty": [
+      {
+        "cask": "picty",
+        "count": "1"
+      }
+    ],
+    "piezo": [
+      {
+        "cask": "piezo",
+        "count": "152"
+      }
+    ],
+    "pikopixel": [
+      {
+        "cask": "pikopixel",
+        "count": "52"
+      }
+    ],
+    "pine": [
+      {
+        "cask": "pine",
+        "count": "682"
+      }
+    ],
+    "pineapple": [
+      {
+        "cask": "pineapple",
+        "count": "48"
+      }
+    ],
+    "pinegrow": [
+      {
+        "cask": "pinegrow",
+        "count": "53"
+      }
+    ],
+    "pingid": [
+      {
+        "cask": "pingid",
+        "count": "56"
+      }
+    ],
+    "pingmenu": [
+      {
+        "cask": "pingmenu",
+        "count": "18"
+      }
+    ],
+    "pingplotter": [
+      {
+        "cask": "pingplotter",
+        "count": "262"
+      }
+    ],
+    "pins": [
+      {
+        "cask": "pins",
+        "count": "7"
+      }
+    ],
+    "pinta": [
+      {
+        "cask": "pinta",
+        "count": "515"
+      }
+    ],
+    "pitchperfect": [
+      {
+        "cask": "pitchperfect",
+        "count": "11"
+      }
+    ],
+    "pivy": [
+      {
+        "cask": "pivy",
+        "count": "14"
+      }
+    ],
+    "pixel-check": [
+      {
+        "cask": "pixel-check",
+        "count": "48"
+      }
+    ],
+    "pixel-picker": [
+      {
+        "cask": "pixel-picker",
+        "count": "194"
+      }
+    ],
+    "pixelmator": [
+      {
+        "cask": "pixelmator",
+        "count": "11"
+      }
+    ],
+    "pixelpeeper": [
+      {
+        "cask": "pixelpeeper",
+        "count": "13"
+      }
+    ],
+    "pixelsnap": [
+      {
+        "cask": "pixelsnap",
+        "count": "100"
+      }
+    ],
+    "pixelsnap2": [
+      {
+        "cask": "pixelsnap2",
+        "count": "6"
+      }
+    ],
+    "pixelstick": [
+      {
+        "cask": "pixelstick",
+        "count": "42"
+      }
+    ],
+    "pixi-paint": [
+      {
+        "cask": "pixi-paint",
+        "count": "17"
+      }
+    ],
+    "pjslint": [
+      {
+        "cask": "pjslint",
+        "count": "19"
+      }
+    ],
+    "plain-clip": [
+      {
+        "cask": "plain-clip",
+        "count": "41"
+      }
+    ],
+    "plan": [
+      {
+        "cask": "plan",
+        "count": "32"
+      }
+    ],
+    "plant": [
+      {
+        "cask": "plant",
+        "count": "5"
+      }
+    ],
+    "plantronics-hub": [
+      {
+        "cask": "plantronics-hub",
+        "count": "227"
+      }
+    ],
+    "platelet": [
+      {
+        "cask": "platelet",
+        "count": "23"
+      }
+    ],
+    "platypus": [
+      {
+        "cask": "platypus",
+        "count": "1,007"
+      }
+    ],
+    "play": [
+      {
+        "cask": "play",
+        "count": "484"
+      }
+    ],
+    "playback": [
+      {
+        "cask": "playback",
+        "count": "17"
+      }
+    ],
+    "playmemories-home": [
+      {
+        "cask": "playmemories-home",
+        "count": "70"
+      }
+    ],
+    "playnow": [
+      {
+        "cask": "playnow",
+        "count": "222"
+      }
+    ],
+    "playonmac": [
+      {
+        "cask": "playonmac",
+        "count": "3,025"
+      }
+    ],
+    "plecs-standalone": [
+      {
+        "cask": "plecs-standalone",
+        "count": "3"
+      }
+    ],
+    "plex": [
+      {
+        "cask": "plex",
+        "count": "2,984"
+      }
+    ],
+    "plex-media-player": [
+      {
+        "cask": "plex-media-player",
+        "count": "4,375"
+      }
+    ],
+    "plex-media-server": [
+      {
+        "cask": "plex-media-server",
+        "count": "4,258"
+      }
+    ],
+    "plex-music": [
+      {
+        "cask": "plex-music",
+        "count": "1"
+      }
+    ],
+    "plexamp": [
+      {
+        "cask": "plexamp",
+        "count": "408"
+      }
+    ],
+    "pliim": [
+      {
+        "cask": "pliim",
+        "count": "47"
+      }
+    ],
+    "plistedit-pro": [
+      {
+        "cask": "plistedit-pro",
+        "count": "670"
+      }
+    ],
+    "plotdigitizer": [
+      {
+        "cask": "plotdigitizer",
+        "count": "51"
+      }
+    ],
+    "plover": [
+      {
+        "cask": "plover",
+        "count": "198"
+      }
+    ],
+    "plug": [
+      {
+        "cask": "plug",
+        "count": "306"
+      }
+    ],
+    "pluralsight": [
+      {
+        "cask": "pluralsight",
+        "count": "301"
+      }
+    ],
+    "plyr": [
+      {
+        "cask": "plyr",
+        "count": "9"
+      }
+    ],
+    "pngyu": [
+      {
+        "cask": "pngyu",
+        "count": "42"
+      }
+    ],
+    "pock": [
+      {
+        "cask": "pock",
+        "count": "3,924"
+      }
+    ],
+    "pocket-casts": [
+      {
+        "cask": "pocket-casts",
+        "count": "1,077"
+      }
+    ],
+    "pocket-tanks": [
+      {
+        "cask": "pocket-tanks",
+        "count": "1"
+      }
+    ],
+    "podcastmenu": [
+      {
+        "cask": "podcastmenu",
+        "count": "122"
+      }
+    ],
+    "podman": [
+      {
+        "cask": "podman",
+        "count": "6,530"
+      }
+    ],
+    "podmand": [
+      {
+        "cask": "podmand",
+        "count": "111"
+      }
+    ],
+    "podofyllin": [
+      {
+        "cask": "podofyllin",
+        "count": "7"
+      }
+    ],
+    "podolski": [
+      {
+        "cask": "podolski",
+        "count": "13"
+      }
+    ],
+    "podtrans": [
+      {
+        "cask": "podtrans",
+        "count": "14"
+      }
+    ],
+    "podworks": [
+      {
+        "cask": "podworks",
+        "count": "2"
+      }
+    ],
+    "poedit": [
+      {
+        "cask": "poedit",
+        "count": "1,172"
+      }
+    ],
+    "poi": [
+      {
+        "cask": "poi",
+        "count": "60"
+      }
+    ],
+    "pokemon-showdown": [
+      {
+        "cask": "pokemon-showdown",
+        "count": "78"
+      }
+    ],
+    "pokemon-trading-card-game-online": [
+      {
+        "cask": "pokemon-trading-card-game-online",
+        "count": "26"
+      }
+    ],
+    "pokerstars": [
+      {
+        "cask": "pokerstars",
+        "count": "235"
+      }
+    ],
+    "pokerth": [
+      {
+        "cask": "pokerth",
+        "count": "83"
+      }
+    ],
+    "polar-bookshelf": [
+      {
+        "cask": "polar-bookshelf",
+        "count": "547"
+      }
+    ],
+    "polar-clock": [
+      {
+        "cask": "polar-clock",
+        "count": "4"
+      }
+    ],
+    "polar-websync": [
+      {
+        "cask": "polar-websync",
+        "count": "1"
+      }
+    ],
+    "polycode": [
+      {
+        "cask": "polycode",
+        "count": "7"
+      }
+    ],
+    "polycom-content": [
+      {
+        "cask": "polycom-content",
+        "count": "27"
+      }
+    ],
+    "polycom-realpresence": [
+      {
+        "cask": "polycom-realpresence",
+        "count": "73"
+      }
+    ],
+    "polymail": [
+      {
+        "cask": "polymail",
+        "count": "151"
+      }
+    ],
+    "polyphone": [
+      {
+        "cask": "polyphone",
+        "count": "37"
+      }
+    ],
+    "pomello": [
+      {
+        "cask": "pomello",
+        "count": "79"
+      }
+    ],
+    "pomodone": [
+      {
+        "cask": "pomodone",
+        "count": "209"
+      }
+    ],
+    "pomolectron": [
+      {
+        "cask": "pomolectron",
+        "count": "95"
+      }
+    ],
+    "pomotodo": [
+      {
+        "cask": "pomotodo",
+        "count": "272"
+      }
+    ],
+    "pomotroid": [
+      {
+        "cask": "pomotroid",
+        "count": "334"
+      }
+    ],
+    "pongsaver": [
+      {
+        "cask": "pongsaver",
+        "count": "58"
+      }
+    ],
+    "popchar": [
+      {
+        "cask": "popchar",
+        "count": "43"
+      }
+    ],
+    "popclip": [
+      {
+        "cask": "popclip",
+        "count": "568"
+      }
+    ],
+    "popclip-beta": [
+      {
+        "cask": "popclip-beta",
+        "count": "2"
+      }
+    ],
+    "popclip-latest": [
+      {
+        "cask": "popclip-latest",
+        "count": "1"
+      }
+    ],
+    "popcorn-time": [
+      {
+        "cask": "popcorn-time",
+        "count": "967"
+      }
+    ],
+    "popcorn-time-beta": [
+      {
+        "cask": "popcorn-time-beta",
+        "count": "269"
+      }
+    ],
+    "popmaker": [
+      {
+        "cask": "popmaker",
+        "count": "10"
+      }
+    ],
+    "popo": [
+      {
+        "cask": "popo",
+        "count": "36"
+      }
+    ],
+    "popsql": [
+      {
+        "cask": "popsql",
+        "count": "189"
+      }
+    ],
+    "port-map": [
+      {
+        "cask": "port-map",
+        "count": "3"
+      }
+    ],
+    "portfolioperformance": [
+      {
+        "cask": "portfolioperformance",
+        "count": "246"
+      }
+    ],
+    "porting-kit": [
+      {
+        "cask": "porting-kit",
+        "count": "401"
+      }
+    ],
+    "portingkit": [
+      {
+        "cask": "portingkit",
+        "count": "4"
+      }
+    ],
+    "post-haste": [
+      {
+        "cask": "post-haste",
+        "count": "65"
+      }
+    ],
+    "postbird": [
+      {
+        "cask": "postbird",
+        "count": "413"
+      }
+    ],
+    "postbox": [
+      {
+        "cask": "postbox",
+        "count": "604"
+      }
+    ],
+    "posterazor": [
+      {
+        "cask": "posterazor",
+        "count": "64"
+      }
+    ],
+    "postgres": [
+      {
+        "cask": "postgres",
+        "count": "5,316"
+      }
+    ],
+    "postgres-beta": [
+      {
+        "cask": "postgres-beta",
+        "count": "13"
+      }
+    ],
+    "postgrespreferencepane": [
+      {
+        "cask": "postgrespreferencepane",
+        "count": "117"
+      }
+    ],
+    "postico": [
+      {
+        "cask": "postico",
+        "count": "5,879"
+      }
+    ],
+    "postman": [
+      {
+        "cask": "postman",
+        "count": "89,779"
+      }
+    ],
+    "postman-custom": [
+      {
+        "cask": "postman-custom",
+        "count": "3"
+      }
+    ],
+    "postman6": [
+      {
+        "cask": "postman6",
+        "count": "3"
+      }
+    ],
+    "powder": [
+      {
+        "cask": "powder",
+        "count": "76"
+      }
+    ],
+    "powder-player": [
+      {
+        "cask": "powder-player",
+        "count": "19"
+      }
+    ],
+    "power-manager": [
+      {
+        "cask": "power-manager",
+        "count": "106"
+      }
+    ],
+    "powerline-go": [
+      {
+        "cask": "powerline-go",
+        "count": "1"
+      }
+    ],
+    "powerpanel": [
+      {
+        "cask": "powerpanel",
+        "count": "25"
+      }
+    ],
+    "powerphotos": [
+      {
+        "cask": "powerphotos",
+        "count": "179"
+      }
+    ],
+    "powerselect": [
+      {
+        "cask": "powerselect",
+        "count": "1"
+      }
+    ],
+    "powershell": [
+      {
+        "cask": "powershell",
+        "count": "69,490"
+      }
+    ],
+    "powershell-preview": [
+      {
+        "cask": "powershell-preview",
+        "count": "3,444"
+      }
+    ],
+    "powershell6": [
+      {
+        "cask": "powershell6",
+        "count": "14"
+      }
+    ],
+    "powershell60": [
+      {
+        "cask": "powershell60",
+        "count": "22"
+      }
+    ],
+    "powerword": [
+      {
+        "cask": "powerword",
+        "count": "41"
+      }
+    ],
+    "ppamorim-fruit": [
+      {
+        "cask": "ppamorim-fruit",
+        "count": "1"
+      }
+    ],
+    "ppduck": [
+      {
+        "cask": "ppduck",
+        "count": "46"
+      }
+    ],
+    "pphelper": [
+      {
+        "cask": "pphelper",
+        "count": "49"
+      }
+    ],
+    "pprng": [
+      {
+        "cask": "pprng",
+        "count": "3"
+      }
+    ],
+    "praat": [
+      {
+        "cask": "praat",
+        "count": "258"
+      }
+    ],
+    "pragmatapro": [
+      {
+        "cask": "pragmatapro",
+        "count": "12"
+      }
+    ],
+    "pratique": [
+      {
+        "cask": "pratique",
+        "count": "5"
+      }
+    ],
+    "precize": [
+      {
+        "cask": "precize",
+        "count": "8"
+      }
+    ],
+    "pref-setter": [
+      {
+        "cask": "pref-setter",
+        "count": "1,016"
+      }
+    ],
+    "preference-manager": [
+      {
+        "cask": "preference-manager",
+        "count": "27"
+      }
+    ],
+    "preferencecleaner": [
+      {
+        "cask": "preferencecleaner",
+        "count": "28"
+      }
+    ],
+    "preflight": [
+      {
+        "cask": "preflight",
+        "count": "10"
+      }
+    ],
+    "preform": [
+      {
+        "cask": "preform",
+        "count": "70"
+      }
+    ],
+    "prefs-editor": [
+      {
+        "cask": "prefs-editor",
+        "count": "179"
+      }
+    ],
+    "prepros": [
+      {
+        "cask": "prepros",
+        "count": "128"
+      }
+    ],
+    "presentation": [
+      {
+        "cask": "presentation",
+        "count": "575"
+      }
+    ],
+    "pretzel": [
+      {
+        "cask": "pretzel",
+        "count": "48"
+      }
+    ],
+    "prey": [
+      {
+        "cask": "prey",
+        "count": "170"
+      }
+    ],
+    "prezi-classic": [
+      {
+        "cask": "prezi-classic",
+        "count": "50"
+      }
+    ],
+    "prezi-next": [
+      {
+        "cask": "prezi-next",
+        "count": "19"
+      }
+    ],
+    "prince": [
+      {
+        "cask": "prince",
+        "count": "785"
+      }
+    ],
+    "prince-latest": [
+      {
+        "cask": "prince-latest",
+        "count": "5"
+      }
+    ],
+    "principle": [
+      {
+        "cask": "principle",
+        "count": "179"
+      }
+    ],
+    "printdriver-lexmark-xc2235": [
+      {
+        "cask": "printdriver-lexmark-xc2235",
+        "count": "1"
+      }
+    ],
+    "printopia": [
+      {
+        "cask": "printopia",
+        "count": "63"
+      }
+    ],
+    "printrun": [
+      {
+        "cask": "printrun",
+        "count": "180"
+      }
+    ],
+    "prismatik": [
+      {
+        "cask": "prismatik",
+        "count": "45"
+      }
+    ],
+    "pritunl": [
+      {
+        "cask": "pritunl",
+        "count": "2,253"
+      }
+    ],
+    "privacy-services-manager": [
+      {
+        "cask": "privacy-services-manager",
+        "count": "11"
+      }
+    ],
+    "private-eye": [
+      {
+        "cask": "private-eye",
+        "count": "235"
+      }
+    ],
+    "private-internet-access": [
+      {
+        "cask": "private-internet-access",
+        "count": "2,693"
+      }
+    ],
+    "privatetunnel": [
+      {
+        "cask": "privatetunnel",
+        "count": "90"
+      }
+    ],
+    "privatevpn": [
+      {
+        "cask": "privatevpn",
+        "count": "1"
+      }
+    ],
+    "prizmo": [
+      {
+        "cask": "prizmo",
+        "count": "247"
+      }
+    ],
+    "pro-motion-ng": [
+      {
+        "cask": "pro-motion-ng",
+        "count": "3"
+      }
+    ],
+    "processing": [
+      {
+        "cask": "processing",
+        "count": "1,714"
+      }
+    ],
+    "processing2": [
+      {
+        "cask": "processing2",
+        "count": "123"
+      }
+    ],
+    "procexp": [
+      {
+        "cask": "procexp",
+        "count": "48"
+      }
+    ],
+    "proclaim": [
+      {
+        "cask": "proclaim",
+        "count": "8"
+      }
+    ],
+    "product-hunt": [
+      {
+        "cask": "product-hunt",
+        "count": "41"
+      }
+    ],
+    "profet": [
+      {
+        "cask": "profet",
+        "count": "6"
+      }
+    ],
+    "profilecreator": [
+      {
+        "cask": "profilecreator",
+        "count": "224"
+      }
+    ],
+    "profilemanager": [
+      {
+        "cask": "profilemanager",
+        "count": "20"
+      }
+    ],
+    "profilesmanager": [
+      {
+        "cask": "profilesmanager",
+        "count": "2"
+      }
+    ],
+    "profind": [
+      {
+        "cask": "profind",
+        "count": "7"
+      }
+    ],
+    "programmer-dvorak": [
+      {
+        "cask": "programmer-dvorak",
+        "count": "75"
+      }
+    ],
+    "progressive-downloader": [
+      {
+        "cask": "progressive-downloader",
+        "count": "294"
+      }
+    ],
+    "projectlibre": [
+      {
+        "cask": "projectlibre",
+        "count": "474"
+      }
+    ],
+    "prolific-pl2303": [
+      {
+        "cask": "prolific-pl2303",
+        "count": "336"
+      }
+    ],
+    "propresenter": [
+      {
+        "cask": "propresenter",
+        "count": "119"
+      }
+    ],
+    "pros-editor": [
+      {
+        "cask": "pros-editor",
+        "count": "910"
+      }
+    ],
+    "prosys-opc-ua-browser": [
+      {
+        "cask": "prosys-opc-ua-browser",
+        "count": "3"
+      }
+    ],
+    "prosys-opc-ua-client": [
+      {
+        "cask": "prosys-opc-ua-client",
+        "count": "25"
+      }
+    ],
+    "protege": [
+      {
+        "cask": "protege",
+        "count": "279"
+      }
+    ],
+    "protonmail-bridge": [
+      {
+        "cask": "protonmail-bridge",
+        "count": "860"
+      }
+    ],
+    "protonmail-unofficial": [
+      {
+        "cask": "protonmail-unofficial",
+        "count": "154"
+      }
+    ],
+    "protonvpn": [
+      {
+        "cask": "protonvpn",
+        "count": "2,250"
+      }
+    ],
+    "protopie": [
+      {
+        "cask": "protopie",
+        "count": "96"
+      }
+    ],
+    "protoverb": [
+      {
+        "cask": "protoverb",
+        "count": "6"
+      }
+    ],
+    "provisioning": [
+      {
+        "cask": "provisioning",
+        "count": "92"
+      }
+    ],
+    "provisionql": [
+      {
+        "cask": "provisionql",
+        "count": "7,054"
+      }
+    ],
+    "prowritingaid": [
+      {
+        "cask": "prowritingaid",
+        "count": "5"
+      }
+    ],
+    "prowritingaid-for-safari": [
+      {
+        "cask": "prowritingaid-for-safari",
+        "count": "1"
+      }
+    ],
+    "proxifier": [
+      {
+        "cask": "proxifier",
+        "count": "1,063"
+      }
+    ],
+    "proximity": [
+      {
+        "cask": "proximity",
+        "count": "129"
+      }
+    ],
+    "proxpn": [
+      {
+        "cask": "proxpn",
+        "count": "17"
+      }
+    ],
+    "proxyman": [
+      {
+        "cask": "proxyman",
+        "count": "1,751"
+      }
+    ],
+    "prudent": [
+      {
+        "cask": "prudent",
+        "count": "27"
+      }
+    ],
+    "prusa-slic3r": [
+      {
+        "cask": "prusa-slic3r",
+        "count": "10"
+      }
+    ],
+    "prusaslicer": [
+      {
+        "cask": "prusaslicer",
+        "count": "583"
+      }
+    ],
+    "psequel": [
+      {
+        "cask": "psequel",
+        "count": "2,524"
+      }
+    ],
+    "psi": [
+      {
+        "cask": "psi",
+        "count": "59"
+      }
+    ],
+    "psi-plus": [
+      {
+        "cask": "psi-plus",
+        "count": "77"
+      }
+    ],
+    "pspp": [
+      {
+        "cask": "pspp",
+        "count": "1"
+      }
+    ],
+    "psychopy": [
+      {
+        "cask": "psychopy",
+        "count": "211"
+      }
+    ],
+    "pteq-x": [
+      {
+        "cask": "pteq-x",
+        "count": "2"
+      }
+    ],
+    "publii": [
+      {
+        "cask": "publii",
+        "count": "8"
+      }
+    ],
+    "publish-or-perish": [
+      {
+        "cask": "publish-or-perish",
+        "count": "27"
+      }
+    ],
+    "pullover": [
+      {
+        "cask": "pullover",
+        "count": "31"
+      }
+    ],
+    "pulse-sms": [
+      {
+        "cask": "pulse-sms",
+        "count": "59"
+      }
+    ],
+    "punto-switcher": [
+      {
+        "cask": "punto-switcher",
+        "count": "589"
+      }
+    ],
+    "puppet-agent": [
+      {
+        "cask": "puppet-agent",
+        "count": "916"
+      }
+    ],
+    "puppet-agent-5": [
+      {
+        "cask": "puppet-agent-5",
+        "count": "182"
+      }
+    ],
+    "puppet-agent-6": [
+      {
+        "cask": "puppet-agent-6",
+        "count": "201"
+      }
+    ],
+    "puppet-bolt": [
+      {
+        "cask": "puppet-bolt",
+        "count": "1,850"
+      }
+    ],
+    "puppetry": [
+      {
+        "cask": "puppetry",
+        "count": "70"
+      }
+    ],
+    "purevpn": [
+      {
+        "cask": "purevpn",
+        "count": "396"
+      }
+    ],
+    "pusher": [
+      {
+        "cask": "pusher",
+        "count": "5,418"
+      }
+    ],
+    "pushtotalk": [
+      {
+        "cask": "pushtotalk",
+        "count": "1"
+      }
+    ],
+    "putio-adder": [
+      {
+        "cask": "putio-adder",
+        "count": "37"
+      }
+    ],
+    "puush": [
+      {
+        "cask": "puush",
+        "count": "44"
+      }
+    ],
+    "puzzles": [
+      {
+        "cask": "puzzles",
+        "count": "82"
+      }
+    ],
+    "pwnagetool": [
+      {
+        "cask": "pwnagetool",
+        "count": "22"
+      }
+    ],
+    "pxplus-ibm-vga8": [
+      {
+        "cask": "pxplus-ibm-vga8",
+        "count": "8"
+      }
+    ],
+    "pycharm": [
+      {
+        "cask": "pycharm",
+        "count": "18,052"
+      }
+    ],
+    "pycharm-ce": [
+      {
+        "cask": "pycharm-ce",
+        "count": "11,909"
+      }
+    ],
+    "pycharm-ce-with-anaconda-plugin": [
+      {
+        "cask": "pycharm-ce-with-anaconda-plugin",
+        "count": "40"
+      }
+    ],
+    "pycharm-custom": [
+      {
+        "cask": "pycharm-custom",
+        "count": "7"
+      }
+    ],
+    "pycharm-edu": [
+      {
+        "cask": "pycharm-edu",
+        "count": "472"
+      }
+    ],
+    "pycharm-with-anaconda-plugin": [
+      {
+        "cask": "pycharm-with-anaconda-plugin",
+        "count": "13"
+      }
+    ],
+    "pydiosync": [
+      {
+        "cask": "pydiosync",
+        "count": "1"
+      }
+    ],
+    "pyfa": [
+      {
+        "cask": "pyfa",
+        "count": "266"
+      }
+    ],
+    "pym-player": [
+      {
+        "cask": "pym-player",
+        "count": "29"
+      }
+    ],
+    "pym-player-beta": [
+      {
+        "cask": "pym-player-beta",
+        "count": "2"
+      }
+    ],
+    "pynsource": [
+      {
+        "cask": "pynsource",
+        "count": "22"
+      }
+    ],
+    "python-3.7": [
+      {
+        "cask": "python-3.7",
+        "count": "3"
+      }
+    ],
+    "python-3.8": [
+      {
+        "cask": "python-3.8",
+        "count": "5"
+      }
+    ],
+    "python-framework-27": [
+      {
+        "cask": "python-framework-27",
+        "count": "1"
+      }
+    ],
+    "python-framework-36": [
+      {
+        "cask": "python-framework-36",
+        "count": "8"
+      }
+    ],
+    "python-framework-37": [
+      {
+        "cask": "python-framework-37",
+        "count": "3"
+      }
+    ],
+    "python-framework-38": [
+      {
+        "cask": "python-framework-38",
+        "count": "5"
+      }
+    ],
+    "pyzo": [
+      {
+        "cask": "pyzo",
+        "count": "57"
+      }
+    ],
+    "qbittorrent": [
+      {
+        "cask": "qbittorrent",
+        "count": "11,477"
+      }
+    ],
+    "qbittorrent-cli": [
+      {
+        "cask": "qbittorrent-cli",
+        "count": "2"
+      }
+    ],
+    "qbittorrent-ee": [
+      {
+        "cask": "qbittorrent-ee",
+        "count": "4"
+      }
+    ],
+    "qbittorrent-enhanced-edition": [
+      {
+        "cask": "qbittorrent-enhanced-edition",
+        "count": "1"
+      }
+    ],
+    "qblocker": [
+      {
+        "cask": "qblocker",
+        "count": "85"
+      }
+    ],
+    "qbserve": [
+      {
+        "cask": "qbserve",
+        "count": "102"
+      }
+    ],
+    "qcad": [
+      {
+        "cask": "qcad",
+        "count": "323"
+      }
+    ],
+    "qcma": [
+      {
+        "cask": "qcma",
+        "count": "66"
+      }
+    ],
+    "qctools": [
+      {
+        "cask": "qctools",
+        "count": "95"
+      }
+    ],
+    "qdesktop": [
+      {
+        "cask": "qdesktop",
+        "count": "136"
+      }
+    ],
+    "qdslrdashboard": [
+      {
+        "cask": "qdslrdashboard",
+        "count": "48"
+      }
+    ],
+    "qfinder-pro": [
+      {
+        "cask": "qfinder-pro",
+        "count": "271"
+      }
+    ],
+    "qgis": [
+      {
+        "cask": "qgis",
+        "count": "1,524"
+      }
+    ],
+    "qgroundcontrol": [
+      {
+        "cask": "qgroundcontrol",
+        "count": "51"
+      }
+    ],
+    "qianqianmusic": [
+      {
+        "cask": "qianqianmusic",
+        "count": "13"
+      }
+    ],
+    "qif-master": [
+      {
+        "cask": "qif-master",
+        "count": "1"
+      }
+    ],
+    "qingg": [
+      {
+        "cask": "qingg",
+        "count": "154"
+      }
+    ],
+    "qiyimedia": [
+      {
+        "cask": "qiyimedia",
+        "count": "799"
+      }
+    ],
+    "ql-ansilove": [
+      {
+        "cask": "ql-ansilove",
+        "count": "154"
+      }
+    ],
+    "ql-procreate-viewer": [
+      {
+        "cask": "ql-procreate-viewer",
+        "count": "5"
+      }
+    ],
+    "qlab": [
+      {
+        "cask": "qlab",
+        "count": "155"
+      }
+    ],
+    "qladdict": [
+      {
+        "cask": "qladdict",
+        "count": "670"
+      }
+    ],
+    "qlc-plus": [
+      {
+        "cask": "qlc-plus",
+        "count": "56"
+      }
+    ],
+    "qlcolorcode": [
+      {
+        "cask": "qlcolorcode",
+        "count": "25,364"
+      }
+    ],
+    "qlcommonmark": [
+      {
+        "cask": "qlcommonmark",
+        "count": "523"
+      }
+    ],
+    "qldds": [
+      {
+        "cask": "qldds",
+        "count": "93"
+      }
+    ],
+    "qlfits": [
+      {
+        "cask": "qlfits",
+        "count": "176"
+      }
+    ],
+    "qlgradle": [
+      {
+        "cask": "qlgradle",
+        "count": "503"
+      }
+    ],
+    "qlimagesize": [
+      {
+        "cask": "qlimagesize",
+        "count": "18,587"
+      }
+    ],
+    "qlmarkdown": [
+      {
+        "cask": "qlmarkdown",
+        "count": "29,780"
+      }
+    ],
+    "qlmarkdown-gfm": [
+      {
+        "cask": "qlmarkdown-gfm",
+        "count": "92"
+      }
+    ],
+    "qlmobi": [
+      {
+        "cask": "qlmobi",
+        "count": "517"
+      }
+    ],
+    "qlnetcdf": [
+      {
+        "cask": "qlnetcdf",
+        "count": "97"
+      }
+    ],
+    "qlplayground": [
+      {
+        "cask": "qlplayground",
+        "count": "415"
+      }
+    ],
+    "qlprettypatch": [
+      {
+        "cask": "qlprettypatch",
+        "count": "5,785"
+      }
+    ],
+    "qlrest": [
+      {
+        "cask": "qlrest",
+        "count": "197"
+      }
+    ],
+    "qlscpt": [
+      {
+        "cask": "qlscpt",
+        "count": "25"
+      }
+    ],
+    "qlstephen": [
+      {
+        "cask": "qlstephen",
+        "count": "29,133"
+      }
+    ],
+    "qlswift": [
+      {
+        "cask": "qlswift",
+        "count": "230"
+      }
+    ],
+    "qltorrent": [
+      {
+        "cask": "qltorrent",
+        "count": "4"
+      }
+    ],
+    "qlvega": [
+      {
+        "cask": "qlvega",
+        "count": "2"
+      }
+    ],
+    "qlvideo": [
+      {
+        "cask": "qlvideo",
+        "count": "15,863"
+      }
+    ],
+    "qlwaveform": [
+      {
+        "cask": "qlwaveform",
+        "count": "1"
+      }
+    ],
+    "qmapshack": [
+      {
+        "cask": "qmapshack",
+        "count": "28"
+      }
+    ],
+    "qmc2": [
+      {
+        "cask": "qmc2",
+        "count": "3"
+      }
+    ],
+    "qmk-toolbox": [
+      {
+        "cask": "qmk-toolbox",
+        "count": "2,292"
+      }
+    ],
+    "qmoji": [
+      {
+        "cask": "qmoji",
+        "count": "42"
+      }
+    ],
+    "qnap-external-raid-manager": [
+      {
+        "cask": "qnap-external-raid-manager",
+        "count": "7"
+      }
+    ],
+    "qnapi": [
+      {
+        "cask": "qnapi",
+        "count": "734"
+      }
+    ],
+    "qobuz": [
+      {
+        "cask": "qobuz",
+        "count": "84"
+      }
+    ],
+    "qownnotes": [
+      {
+        "cask": "qownnotes",
+        "count": "643"
+      }
+    ],
+    "qp": [
+      {
+        "cask": "qp",
+        "count": "5"
+      }
+    ],
+    "qq": [
+      {
+        "cask": "qq",
+        "count": "5,905"
+      }
+    ],
+    "qqbrowser": [
+      {
+        "cask": "qqbrowser",
+        "count": "192"
+      }
+    ],
+    "qqlive": [
+      {
+        "cask": "qqlive",
+        "count": "1,380"
+      }
+    ],
+    "qqmacmgr": [
+      {
+        "cask": "qqmacmgr",
+        "count": "108"
+      }
+    ],
+    "qqmusic": [
+      {
+        "cask": "qqmusic",
+        "count": "2,623"
+      }
+    ],
+    "qqplayer": [
+      {
+        "cask": "qqplayer",
+        "count": "104"
+      }
+    ],
+    "qqwebdevtools": [
+      {
+        "cask": "qqwebdevtools",
+        "count": "1"
+      }
+    ],
+    "qr-factory": [
+      {
+        "cask": "qr-factory",
+        "count": "1"
+      }
+    ],
+    "qr-journal": [
+      {
+        "cask": "qr-journal",
+        "count": "102"
+      }
+    ],
+    "qrange": [
+      {
+        "cask": "qrange",
+        "count": "5"
+      }
+    ],
+    "qrfcview": [
+      {
+        "cask": "qrfcview",
+        "count": "13"
+      }
+    ],
+    "qrq": [
+      {
+        "cask": "qrq",
+        "count": "1"
+      }
+    ],
+    "qsync-client": [
+      {
+        "cask": "qsync-client",
+        "count": "190"
+      }
+    ],
+    "qsyncthingtray": [
+      {
+        "cask": "qsyncthingtray",
+        "count": "186"
+      }
+    ],
+    "qt-brynhildr": [
+      {
+        "cask": "qt-brynhildr",
+        "count": "1"
+      }
+    ],
+    "qt-creator": [
+      {
+        "cask": "qt-creator",
+        "count": "7,461"
+      }
+    ],
+    "qt-creator-dev": [
+      {
+        "cask": "qt-creator-dev",
+        "count": "120"
+      }
+    ],
+    "qt-design-studio": [
+      {
+        "cask": "qt-design-studio",
+        "count": "364"
+      }
+    ],
+    "qt3dstudio": [
+      {
+        "cask": "qt3dstudio",
+        "count": "63"
+      }
+    ],
+    "qtmips": [
+      {
+        "cask": "qtmips",
+        "count": "1"
+      }
+    ],
+    "qtmips_gui": [
+      {
+        "cask": "qtmips_gui",
+        "count": "1"
+      }
+    ],
+    "qtox": [
+      {
+        "cask": "qtox",
+        "count": "218"
+      }
+    ],
+    "qtpass": [
+      {
+        "cask": "qtpass",
+        "count": "1,296"
+      }
+    ],
+    "qtspim": [
+      {
+        "cask": "qtspim",
+        "count": "391"
+      }
+    ],
+    "qtum-qt": [
+      {
+        "cask": "qtum-qt",
+        "count": "14"
+      }
+    ],
+    "quail": [
+      {
+        "cask": "quail",
+        "count": "41"
+      }
+    ],
+    "quakespasm": [
+      {
+        "cask": "quakespasm",
+        "count": "72"
+      }
+    ],
+    "quassel": [
+      {
+        "cask": "quassel",
+        "count": "80"
+      }
+    ],
+    "quassel-client": [
+      {
+        "cask": "quassel-client",
+        "count": "110"
+      }
+    ],
+    "quaternion": [
+      {
+        "cask": "quaternion",
+        "count": "79"
+      }
+    ],
+    "quay-cli": [
+      {
+        "cask": "quay-cli",
+        "count": "1"
+      }
+    ],
+    "querious": [
+      {
+        "cask": "querious",
+        "count": "273"
+      }
+    ],
+    "questrade-iq-edge": [
+      {
+        "cask": "questrade-iq-edge",
+        "count": "12"
+      }
+    ],
+    "quickbooks": [
+      {
+        "cask": "quickbooks",
+        "count": "68"
+      }
+    ],
+    "quickbooks-online": [
+      {
+        "cask": "quickbooks-online",
+        "count": "144"
+      }
+    ],
+    "quickboot": [
+      {
+        "cask": "quickboot",
+        "count": "16"
+      }
+    ],
+    "quicken": [
+      {
+        "cask": "quicken",
+        "count": "150"
+      }
+    ],
+    "quickeys": [
+      {
+        "cask": "quickeys",
+        "count": "1"
+      }
+    ],
+    "quickgeojson": [
+      {
+        "cask": "quickgeojson",
+        "count": "87"
+      }
+    ],
+    "quickhash": [
+      {
+        "cask": "quickhash",
+        "count": "93"
+      }
+    ],
+    "quickhue": [
+      {
+        "cask": "quickhue",
+        "count": "45"
+      }
+    ],
+    "quickjson": [
+      {
+        "cask": "quickjson",
+        "count": "179"
+      }
+    ],
+    "quicklock": [
+      {
+        "cask": "quicklock",
+        "count": "3"
+      }
+    ],
+    "quicklook-csv": [
+      {
+        "cask": "quicklook-csv",
+        "count": "8,211"
+      }
+    ],
+    "quicklook-gltf": [
+      {
+        "cask": "quicklook-gltf",
+        "count": "3"
+      }
+    ],
+    "quicklook-json": [
+      {
+        "cask": "quicklook-json",
+        "count": "27,485"
+      }
+    ],
+    "quicklook-pat": [
+      {
+        "cask": "quicklook-pat",
+        "count": "647"
+      }
+    ],
+    "quicklook-pfm": [
+      {
+        "cask": "quicklook-pfm",
+        "count": "90"
+      }
+    ],
+    "quicklookapk": [
+      {
+        "cask": "quicklookapk",
+        "count": "2,634"
+      }
+    ],
+    "quicklookase": [
+      {
+        "cask": "quicklookase",
+        "count": "9,286"
+      }
+    ],
+    "quicknfo": [
+      {
+        "cask": "quicknfo",
+        "count": "288"
+      }
+    ],
+    "quicksilver": [
+      {
+        "cask": "quicksilver",
+        "count": "891"
+      }
+    ],
+    "quicksync": [
+      {
+        "cask": "quicksync",
+        "count": "7"
+      }
+    ],
+    "quicktime-player7": [
+      {
+        "cask": "quicktime-player7",
+        "count": "56"
+      }
+    ],
+    "quickwords": [
+      {
+        "cask": "quickwords",
+        "count": "4"
+      }
+    ],
+    "quik": [
+      {
+        "cask": "quik",
+        "count": "395"
+      }
+    ],
+    "quip": [
+      {
+        "cask": "quip",
+        "count": "871"
+      }
+    ],
+    "quiterss": [
+      {
+        "cask": "quiterss",
+        "count": "92"
+      }
+    ],
+    "quitter": [
+      {
+        "cask": "quitter",
+        "count": "337"
+      }
+    ],
+    "quiver": [
+      {
+        "cask": "quiver",
+        "count": "1"
+      }
+    ],
+    "quneo-editor": [
+      {
+        "cask": "quneo-editor",
+        "count": "1"
+      }
+    ],
+    "quodlibet": [
+      {
+        "cask": "quodlibet",
+        "count": "288"
+      }
+    ],
+    "qutebrowser": [
+      {
+        "cask": "qutebrowser",
+        "count": "2,785"
+      }
+    ],
+    "quupa-bridge": [
+      {
+        "cask": "quupa-bridge",
+        "count": "1"
+      }
+    ],
+    "quuppa-bridge": [
+      {
+        "cask": "quuppa-bridge",
+        "count": "1"
+      }
+    ],
+    "quuppa-data-player": [
+      {
+        "cask": "quuppa-data-player",
+        "count": "12"
+      }
+    ],
+    "quuppa-site-planner": [
+      {
+        "cask": "quuppa-site-planner",
+        "count": "20"
+      }
+    ],
+    "qv2ray": [
+      {
+        "cask": "qv2ray",
+        "count": "71"
+      }
+    ],
+    "qview": [
+      {
+        "cask": "qview",
+        "count": "409"
+      }
+    ],
+    "qxmledit": [
+      {
+        "cask": "qxmledit",
+        "count": "124"
+      }
+    ],
+    "qyooo": [
+      {
+        "cask": "qyooo",
+        "count": "4"
+      }
+    ],
+    "r": [
+      {
+        "cask": "r",
+        "count": "9,538"
+      }
+    ],
+    "r-app": [
+      {
+        "cask": "r-app",
+        "count": "22"
+      }
+    ],
+    "r-dictionary": [
+      {
+        "cask": "r-dictionary",
+        "count": "3"
+      }
+    ],
+    "r-name": [
+      {
+        "cask": "r-name",
+        "count": "37"
+      }
+    ],
+    "rabbitmq": [
+      {
+        "cask": "rabbitmq",
+        "count": "424"
+      }
+    ],
+    "race-for-the-galaxy": [
+      {
+        "cask": "race-for-the-galaxy",
+        "count": "2"
+      }
+    ],
+    "race-into-space": [
+      {
+        "cask": "race-into-space",
+        "count": "11"
+      }
+    ],
+    "racket": [
+      {
+        "cask": "racket",
+        "count": "2,965"
+      }
+    ],
+    "racket-cs": [
+      {
+        "cask": "racket-cs",
+        "count": "116"
+      }
+    ],
+    "radar": [
+      {
+        "cask": "radar",
+        "count": "559"
+      }
+    ],
+    "radare2": [
+      {
+        "cask": "radare2",
+        "count": "1"
+      }
+    ],
+    "radarr": [
+      {
+        "cask": "radarr",
+        "count": "833"
+      }
+    ],
+    "radi": [
+      {
+        "cask": "radi",
+        "count": "2"
+      }
+    ],
+    "radiant-player": [
+      {
+        "cask": "radiant-player",
+        "count": "117"
+      }
+    ],
+    "radio-silence": [
+      {
+        "cask": "radio-silence",
+        "count": "266"
+      }
+    ],
+    "radioshark": [
+      {
+        "cask": "radioshark",
+        "count": "4"
+      }
+    ],
+    "ragnarok": [
+      {
+        "cask": "ragnarok",
+        "count": "5"
+      }
+    ],
+    "raindropio": [
+      {
+        "cask": "raindropio",
+        "count": "578"
+      }
+    ],
+    "rainlendar-pro": [
+      {
+        "cask": "rainlendar-pro",
+        "count": "1"
+      }
+    ],
+    "rambox": [
+      {
+        "cask": "rambox",
+        "count": "2,128"
+      }
+    ],
+    "rambox-pro": [
+      {
+        "cask": "rambox-pro",
+        "count": "1"
+      }
+    ],
+    "ramme": [
+      {
+        "cask": "ramme",
+        "count": "52"
+      }
+    ],
+    "ransomwhere": [
+      {
+        "cask": "ransomwhere",
+        "count": "321"
+      }
+    ],
+    "rapidminer-studio": [
+      {
+        "cask": "rapidminer-studio",
+        "count": "105"
+      }
+    ],
+    "rapidweaver": [
+      {
+        "cask": "rapidweaver",
+        "count": "59"
+      }
+    ],
+    "raptor": [
+      {
+        "cask": "raptor",
+        "count": "17"
+      }
+    ],
+    "rar": [
+      {
+        "cask": "rar",
+        "count": "5,099"
+      }
+    ],
+    "raspberry-pi-imager": [
+      {
+        "cask": "raspberry-pi-imager",
+        "count": "325"
+      }
+    ],
+    "rationalacoustics-smaartv8": [
+      {
+        "cask": "rationalacoustics-smaartv8",
+        "count": "1"
+      }
+    ],
+    "raven": [
+      {
+        "cask": "raven",
+        "count": "45"
+      }
+    ],
+    "raven-reader": [
+      {
+        "cask": "raven-reader",
+        "count": "13"
+      }
+    ],
+    "raw-photo-processor": [
+      {
+        "cask": "raw-photo-processor",
+        "count": "35"
+      }
+    ],
+    "rawdigger": [
+      {
+        "cask": "rawdigger",
+        "count": "1"
+      }
+    ],
+    "rawtherapee": [
+      {
+        "cask": "rawtherapee",
+        "count": "982"
+      }
+    ],
+    "razer-synapse": [
+      {
+        "cask": "razer-synapse",
+        "count": "597"
+      }
+    ],
+    "razorsql": [
+      {
+        "cask": "razorsql",
+        "count": "359"
+      }
+    ],
+    "rcdefaultapp": [
+      {
+        "cask": "rcdefaultapp",
+        "count": "595"
+      }
+    ],
+    "rclone-browser": [
+      {
+        "cask": "rclone-browser",
+        "count": "247"
+      }
+    ],
+    "rclone-browser-2": [
+      {
+        "cask": "rclone-browser-2",
+        "count": "2"
+      }
+    ],
+    "rcloneosx": [
+      {
+        "cask": "rcloneosx",
+        "count": "441"
+      }
+    ],
+    "rcse": [
+      {
+        "cask": "rcse",
+        "count": "1"
+      }
+    ],
+    "react-native-debugger": [
+      {
+        "cask": "react-native-debugger",
+        "count": "51,882"
+      }
+    ],
+    "react-proto": [
+      {
+        "cask": "react-proto",
+        "count": "46"
+      }
+    ],
+    "react-studio": [
+      {
+        "cask": "react-studio",
+        "count": "318"
+      }
+    ],
+    "reactide": [
+      {
+        "cask": "reactide",
+        "count": "1"
+      }
+    ],
+    "reactotron": [
+      {
+        "cask": "reactotron",
+        "count": "2,232"
+      }
+    ],
+    "readandwrite": [
+      {
+        "cask": "readandwrite",
+        "count": "1"
+      }
+    ],
+    "readcube": [
+      {
+        "cask": "readcube",
+        "count": "100"
+      }
+    ],
+    "real-vnc": [
+      {
+        "cask": "real-vnc",
+        "count": "3"
+      }
+    ],
+    "realforce": [
+      {
+        "cask": "realforce",
+        "count": "15"
+      }
+    ],
+    "realm-browser": [
+      {
+        "cask": "realm-browser",
+        "count": "61"
+      }
+    ],
+    "realm-studio": [
+      {
+        "cask": "realm-studio",
+        "count": "463"
+      }
+    ],
+    "reaper": [
+      {
+        "cask": "reaper",
+        "count": "1,389"
+      }
+    ],
+    "reborn": [
+      {
+        "cask": "reborn",
+        "count": "1"
+      }
+    ],
+    "receiptquicklook": [
+      {
+        "cask": "receiptquicklook",
+        "count": "92"
+      }
+    ],
+    "receipts": [
+      {
+        "cask": "receipts",
+        "count": "38"
+      }
+    ],
+    "receivemidi": [
+      {
+        "cask": "receivemidi",
+        "count": "2"
+      }
+    ],
+    "recents": [
+      {
+        "cask": "recents",
+        "count": "80"
+      }
+    ],
+    "recordit": [
+      {
+        "cask": "recordit",
+        "count": "590"
+      }
+    ],
+    "recovery-disk-assistant": [
+      {
+        "cask": "recovery-disk-assistant",
+        "count": "59"
+      }
+    ],
+    "rectangle": [
+      {
+        "cask": "rectangle",
+        "count": "12,886"
+      }
+    ],
+    "red": [
+      {
+        "cask": "red",
+        "count": "76"
+      }
+    ],
+    "red-eye": [
+      {
+        "cask": "red-eye",
+        "count": "16"
+      }
+    ],
+    "red-latest": [
+      {
+        "cask": "red-latest",
+        "count": "18"
+      }
+    ],
+    "redcine-x-pro": [
+      {
+        "cask": "redcine-x-pro",
+        "count": "74"
+      }
+    ],
+    "redeclipse": [
+      {
+        "cask": "redeclipse",
+        "count": "3"
+      }
+    ],
+    "redis": [
+      {
+        "cask": "redis",
+        "count": "1,308"
+      }
+    ],
+    "redis-app": [
+      {
+        "cask": "redis-app",
+        "count": "2"
+      }
+    ],
+    "reeddit": [
+      {
+        "cask": "reeddit",
+        "count": "15"
+      }
+    ],
+    "refined-github-safari": [
+      {
+        "cask": "refined-github-safari",
+        "count": "141"
+      }
+    ],
+    "reflector": [
+      {
+        "cask": "reflector",
+        "count": "413"
+      }
+    ],
+    "reflector2": [
+      {
+        "cask": "reflector2",
+        "count": "10"
+      }
+    ],
+    "regexhibit": [
+      {
+        "cask": "regexhibit",
+        "count": "40"
+      }
+    ],
+    "reggy": [
+      {
+        "cask": "reggy",
+        "count": "112"
+      }
+    ],
+    "regrader": [
+      {
+        "cask": "regrader",
+        "count": "3"
+      }
+    ],
+    "reikey": [
+      {
+        "cask": "reikey",
+        "count": "402"
+      }
+    ],
+    "rekordbox": [
+      {
+        "cask": "rekordbox",
+        "count": "289"
+      }
+    ],
+    "relab-development-lx480-complete": [
+      {
+        "cask": "relab-development-lx480-complete",
+        "count": "1"
+      }
+    ],
+    "relativewave-form": [
+      {
+        "cask": "relativewave-form",
+        "count": "3"
+      }
+    ],
+    "relaunch64": [
+      {
+        "cask": "relaunch64",
+        "count": "3"
+      }
+    ],
+    "relay": [
+      {
+        "cask": "relay",
+        "count": "1"
+      }
+    ],
+    "reload-scorm-player": [
+      {
+        "cask": "reload-scorm-player",
+        "count": "8"
+      }
+    ],
+    "rember": [
+      {
+        "cask": "rember",
+        "count": "86"
+      }
+    ],
+    "remembear": [
+      {
+        "cask": "remembear",
+        "count": "51"
+      }
+    ],
+    "remember-the-milk": [
+      {
+        "cask": "remember-the-milk",
+        "count": "225"
+      }
+    ],
+    "remix": [
+      {
+        "cask": "remix",
+        "count": "1"
+      }
+    ],
+    "remote-buddy": [
+      {
+        "cask": "remote-buddy",
+        "count": "23"
+      }
+    ],
+    "remote-desktop-manager": [
+      {
+        "cask": "remote-desktop-manager",
+        "count": "845"
+      }
+    ],
+    "remote-desktop-manager-free": [
+      {
+        "cask": "remote-desktop-manager-free",
+        "count": "760"
+      }
+    ],
+    "remoteviewer": [
+      {
+        "cask": "remoteviewer",
+        "count": "296"
+      }
+    ],
+    "remotix-agent": [
+      {
+        "cask": "remotix-agent",
+        "count": "30"
+      }
+    ],
+    "renamer": [
+      {
+        "cask": "renamer",
+        "count": "311"
+      }
+    ],
+    "renault-r-link-2-toolbox": [
+      {
+        "cask": "renault-r-link-2-toolbox",
+        "count": "1"
+      }
+    ],
+    "renpy": [
+      {
+        "cask": "renpy",
+        "count": "146"
+      }
+    ],
+    "reolink-client": [
+      {
+        "cask": "reolink-client",
+        "count": "29"
+      }
+    ],
+    "repairhomepermissions": [
+      {
+        "cask": "repairhomepermissions",
+        "count": "9"
+      }
+    ],
+    "repetier-host": [
+      {
+        "cask": "repetier-host",
+        "count": "119"
+      }
+    ],
+    "request-rocket": [
+      {
+        "cask": "request-rocket",
+        "count": "5"
+      }
+    ],
+    "rescuetime": [
+      {
+        "cask": "rescuetime",
+        "count": "1,536"
+      }
+    ],
+    "resilio-sync": [
+      {
+        "cask": "resilio-sync",
+        "count": "1,183"
+      }
+    ],
+    "resolume-arena": [
+      {
+        "cask": "resolume-arena",
+        "count": "19"
+      }
+    ],
+    "resolutionator": [
+      {
+        "cask": "resolutionator",
+        "count": "177"
+      }
+    ],
+    "respresso": [
+      {
+        "cask": "respresso",
+        "count": "3"
+      }
+    ],
+    "rest": [
+      {
+        "cask": "rest",
+        "count": "8"
+      }
+    ],
+    "restart": [
+      {
+        "cask": "restart",
+        "count": "2"
+      }
+    ],
+    "restclient": [
+      {
+        "cask": "restclient",
+        "count": "158"
+      }
+    ],
+    "resxtreme": [
+      {
+        "cask": "resxtreme",
+        "count": "56"
+      }
+    ],
+    "retini": [
+      {
+        "cask": "retini",
+        "count": "1"
+      }
+    ],
+    "retinizer": [
+      {
+        "cask": "retinizer",
+        "count": "158"
+      }
+    ],
+    "retro-virtual-machine": [
+      {
+        "cask": "retro-virtual-machine",
+        "count": "45"
+      }
+    ],
+    "retroactive": [
+      {
+        "cask": "retroactive",
+        "count": "15"
+      }
+    ],
+    "retroarch": [
+      {
+        "cask": "retroarch",
+        "count": "1,055"
+      }
+    ],
+    "retroarch-metal": [
+      {
+        "cask": "retroarch-metal",
+        "count": "273"
+      }
+    ],
+    "retrobatch": [
+      {
+        "cask": "retrobatch",
+        "count": "41"
+      }
+    ],
+    "retroshare": [
+      {
+        "cask": "retroshare",
+        "count": "84"
+      }
+    ],
+    "reunion": [
+      {
+        "cask": "reunion",
+        "count": "11"
+      }
+    ],
+    "reveal": [
+      {
+        "cask": "reveal",
+        "count": "299"
+      }
+    ],
+    "review-sherlock": [
+      {
+        "cask": "review-sherlock",
+        "count": "1"
+      }
+    ],
+    "revisionist": [
+      {
+        "cask": "revisionist",
+        "count": "7"
+      }
+    ],
+    "revisions": [
+      {
+        "cask": "revisions",
+        "count": "12"
+      }
+    ],
+    "rftg": [
+      {
+        "cask": "rftg",
+        "count": "2"
+      }
+    ],
+    "rhinoceros": [
+      {
+        "cask": "rhinoceros",
+        "count": "85"
+      }
+    ],
+    "ricochet": [
+      {
+        "cask": "ricochet",
+        "count": "40"
+      }
+    ],
+    "ricoh-ps-printers-vol3-exp-driver": [
+      {
+        "cask": "ricoh-ps-printers-vol3-exp-driver",
+        "count": "12"
+      }
+    ],
+    "ricoh-ps-printers-vol4-exp-driver": [
+      {
+        "cask": "ricoh-ps-printers-vol4-exp-driver",
+        "count": "86"
+      }
+    ],
+    "ricoh-theta": [
+      {
+        "cask": "ricoh-theta",
+        "count": "46"
+      }
+    ],
+    "ricoh-theta-file-transfer": [
+      {
+        "cask": "ricoh-theta-file-transfer",
+        "count": "2"
+      }
+    ],
+    "ricoh-theta-movie-converter": [
+      {
+        "cask": "ricoh-theta-movie-converter",
+        "count": "2"
+      }
+    ],
+    "ricoh_driver": [
+      {
+        "cask": "ricoh_driver",
+        "count": "28"
+      }
+    ],
+    "rider": [
+      {
+        "cask": "rider",
+        "count": "1,972"
+      }
+    ],
+    "rider-custom": [
+      {
+        "cask": "rider-custom",
+        "count": "6"
+      }
+    ],
+    "ridibooks": [
+      {
+        "cask": "ridibooks",
+        "count": "199"
+      }
+    ],
+    "rightfont": [
+      {
+        "cask": "rightfont",
+        "count": "280"
+      }
+    ],
+    "rightzoom": [
+      {
+        "cask": "rightzoom",
+        "count": "116"
+      }
+    ],
+    "ring": [
+      {
+        "cask": "ring",
+        "count": "182"
+      }
+    ],
+    "ringcentral": [
+      {
+        "cask": "ringcentral",
+        "count": "477"
+      }
+    ],
+    "ringcentral-meetings": [
+      {
+        "cask": "ringcentral-meetings",
+        "count": "335"
+      }
+    ],
+    "ringtones": [
+      {
+        "cask": "ringtones",
+        "count": "15"
+      }
+    ],
+    "riot": [
+      {
+        "cask": "riot",
+        "count": "2,320"
+      }
+    ],
+    "ripcord": [
+      {
+        "cask": "ripcord",
+        "count": "443"
+      }
+    ],
+    "ripit": [
+      {
+        "cask": "ripit",
+        "count": "129"
+      }
+    ],
+    "riverflow": [
+      {
+        "cask": "riverflow",
+        "count": "5"
+      }
+    ],
+    "roaringapps": [
+      {
+        "cask": "roaringapps",
+        "count": "11"
+      }
+    ],
+    "roblox": [
+      {
+        "cask": "roblox",
+        "count": "369"
+      }
+    ],
+    "robo-3t": [
+      {
+        "cask": "robo-3t",
+        "count": "8,997"
+      }
+    ],
+    "robofont": [
+      {
+        "cask": "robofont",
+        "count": "42"
+      }
+    ],
+    "roboform": [
+      {
+        "cask": "roboform",
+        "count": "74"
+      }
+    ],
+    "rocket": [
+      {
+        "cask": "rocket",
+        "count": "2,390"
+      }
+    ],
+    "rocket-chat": [
+      {
+        "cask": "rocket-chat",
+        "count": "2,479"
+      }
+    ],
+    "rocket-chat-custom": [
+      {
+        "cask": "rocket-chat-custom",
+        "count": "11"
+      }
+    ],
+    "rocket-typist": [
+      {
+        "cask": "rocket-typist",
+        "count": "43"
+      }
+    ],
+    "rocketcake": [
+      {
+        "cask": "rocketcake",
+        "count": "10"
+      }
+    ],
+    "rocks-n-diamonds": [
+      {
+        "cask": "rocks-n-diamonds",
+        "count": "16"
+      }
+    ],
+    "rodeo": [
+      {
+        "cask": "rodeo",
+        "count": "146"
+      }
+    ],
+    "roku-remote-tool": [
+      {
+        "cask": "roku-remote-tool",
+        "count": "39"
+      }
+    ],
+    "roland-quad-capture-usb-driver": [
+      {
+        "cask": "roland-quad-capture-usb-driver",
+        "count": "10"
+      }
+    ],
+    "rolisteam": [
+      {
+        "cask": "rolisteam",
+        "count": "2"
+      }
+    ],
+    "roon": [
+      {
+        "cask": "roon",
+        "count": "128"
+      }
+    ],
+    "rosaimagewriter": [
+      {
+        "cask": "rosaimagewriter",
+        "count": "51"
+      }
+    ],
+    "rotato": [
+      {
+        "cask": "rotato",
+        "count": "74"
+      }
+    ],
+    "routebuddy": [
+      {
+        "cask": "routebuddy",
+        "count": "5"
+      }
+    ],
+    "routeconverter": [
+      {
+        "cask": "routeconverter",
+        "count": "24"
+      }
+    ],
+    "routemap": [
+      {
+        "cask": "routemap",
+        "count": "5"
+      }
+    ],
+    "rowanj-gitx": [
+      {
+        "cask": "rowanj-gitx",
+        "count": "3,106"
+      }
+    ],
+    "rowmote-helper": [
+      {
+        "cask": "rowmote-helper",
+        "count": "36"
+      }
+    ],
+    "royal-tsx": [
+      {
+        "cask": "royal-tsx",
+        "count": "1,391"
+      }
+    ],
+    "royal-tsx@3": [
+      {
+        "cask": "royal-tsx@3",
+        "count": "18"
+      }
+    ],
+    "rpn-scientific": [
+      {
+        "cask": "rpn-scientific",
+        "count": "20"
+      }
+    ],
+    "rpvoip": [
+      {
+        "cask": "rpvoip",
+        "count": "62"
+      }
+    ],
+    "rq": [
+      {
+        "cask": "rq",
+        "count": "201"
+      }
+    ],
+    "rrcc": [
+      {
+        "cask": "rrcc",
+        "count": "12"
+      }
+    ],
+    "rrootage": [
+      {
+        "cask": "rrootage",
+        "count": "1"
+      }
+    ],
+    "rss": [
+      {
+        "cask": "rss",
+        "count": "113"
+      }
+    ],
+    "rssowl": [
+      {
+        "cask": "rssowl",
+        "count": "116"
+      }
+    ],
+    "rstudio": [
+      {
+        "cask": "rstudio",
+        "count": "15,317"
+      }
+    ],
+    "rstudio-custom": [
+      {
+        "cask": "rstudio-custom",
+        "count": "3"
+      }
+    ],
+    "rstudio-daily": [
+      {
+        "cask": "rstudio-daily",
+        "count": "152"
+      }
+    ],
+    "rstudio-preview": [
+      {
+        "cask": "rstudio-preview",
+        "count": "354"
+      }
+    ],
+    "rsyncosx": [
+      {
+        "cask": "rsyncosx",
+        "count": "756"
+      }
+    ],
+    "rtunic": [
+      {
+        "cask": "rtunic",
+        "count": "4"
+      }
+    ],
+    "rtx": [
+      {
+        "cask": "rtx",
+        "count": "6"
+      }
+    ],
+    "rubitrack-pro": [
+      {
+        "cask": "rubitrack-pro",
+        "count": "16"
+      }
+    ],
+    "rubymine": [
+      {
+        "cask": "rubymine",
+        "count": "3,674"
+      }
+    ],
+    "rubymotion": [
+      {
+        "cask": "rubymotion",
+        "count": "83"
+      }
+    ],
+    "rumpus": [
+      {
+        "cask": "rumpus",
+        "count": "8"
+      }
+    ],
+    "runatlantis": [
+      {
+        "cask": "runatlantis",
+        "count": "3"
+      }
+    ],
+    "runelite": [
+      {
+        "cask": "runelite",
+        "count": "1"
+      }
+    ],
+    "runescape": [
+      {
+        "cask": "runescape",
+        "count": "172"
+      }
+    ],
+    "runjs": [
+      {
+        "cask": "runjs",
+        "count": "467"
+      }
+    ],
+    "runlet": [
+      {
+        "cask": "runlet",
+        "count": "23"
+      }
+    ],
+    "runway": [
+      {
+        "cask": "runway",
+        "count": "46"
+      }
+    ],
+    "ryver": [
+      {
+        "cask": "ryver",
+        "count": "43"
+      }
+    ],
+    "s-identity": [
+      {
+        "cask": "s-identity",
+        "count": "5"
+      }
+    ],
+    "sabaki": [
+      {
+        "cask": "sabaki",
+        "count": "121"
+      }
+    ],
+    "sabnzbd": [
+      {
+        "cask": "sabnzbd",
+        "count": "484"
+      }
+    ],
+    "safari-technology-preview": [
+      {
+        "cask": "safari-technology-preview",
+        "count": "1,079"
+      }
+    ],
+    "safaricookiecutter": [
+      {
+        "cask": "safaricookiecutter",
+        "count": "77"
+      }
+    ],
+    "safarisort": [
+      {
+        "cask": "safarisort",
+        "count": "43"
+      }
+    ],
+    "safe": [
+      {
+        "cask": "safe",
+        "count": "6"
+      }
+    ],
+    "safe-exam-browser": [
+      {
+        "cask": "safe-exam-browser",
+        "count": "16"
+      }
+    ],
+    "safe-network": [
+      {
+        "cask": "safe-network",
+        "count": "1"
+      }
+    ],
+    "safeincloud-password-manager": [
+      {
+        "cask": "safeincloud-password-manager",
+        "count": "150"
+      }
+    ],
+    "sage": [
+      {
+        "cask": "sage",
+        "count": "1,429"
+      }
+    ],
+    "saleae-logic": [
+      {
+        "cask": "saleae-logic",
+        "count": "57"
+      }
+    ],
+    "sameboy": [
+      {
+        "cask": "sameboy",
+        "count": "42"
+      }
+    ],
+    "sampler": [
+      {
+        "cask": "sampler",
+        "count": "2,706"
+      }
+    ],
+    "samsung-dex": [
+      {
+        "cask": "samsung-dex",
+        "count": "2"
+      }
+    ],
+    "samsung-portable-ssd-software": [
+      {
+        "cask": "samsung-portable-ssd-software",
+        "count": "4"
+      }
+    ],
+    "sandego": [
+      {
+        "cask": "sandego",
+        "count": "1"
+      }
+    ],
+    "sands": [
+      {
+        "cask": "sands",
+        "count": "1"
+      }
+    ],
+    "sandstrip": [
+      {
+        "cask": "sandstrip",
+        "count": "5"
+      }
+    ],
+    "santa": [
+      {
+        "cask": "santa",
+        "count": "599"
+      }
+    ],
+    "saoimageds9": [
+      {
+        "cask": "saoimageds9",
+        "count": "211"
+      }
+    ],
+    "sapmachine-jdk": [
+      {
+        "cask": "sapmachine-jdk",
+        "count": "1,173"
+      }
+    ],
+    "sapmachine-jdk-lts": [
+      {
+        "cask": "sapmachine-jdk-lts",
+        "count": "2"
+      }
+    ],
+    "sapmachine11-ea-jdk": [
+      {
+        "cask": "sapmachine11-ea-jdk",
+        "count": "12"
+      }
+    ],
+    "sapmachine11-ea-jre": [
+      {
+        "cask": "sapmachine11-ea-jre",
+        "count": "4"
+      }
+    ],
+    "sapmachine11-jdk": [
+      {
+        "cask": "sapmachine11-jdk",
+        "count": "800"
+      }
+    ],
+    "sapmachine11-jre": [
+      {
+        "cask": "sapmachine11-jre",
+        "count": "34"
+      }
+    ],
+    "sapmachine12-ea-jdk": [
+      {
+        "cask": "sapmachine12-ea-jdk",
+        "count": "8"
+      }
+    ],
+    "sapmachine12-ea-jre": [
+      {
+        "cask": "sapmachine12-ea-jre",
+        "count": "4"
+      }
+    ],
+    "sapmachine12-jdk": [
+      {
+        "cask": "sapmachine12-jdk",
+        "count": "32"
+      }
+    ],
+    "sapmachine12-jre": [
+      {
+        "cask": "sapmachine12-jre",
+        "count": "6"
+      }
+    ],
+    "sapmachine13-ea-jdk": [
+      {
+        "cask": "sapmachine13-ea-jdk",
+        "count": "30"
+      }
+    ],
+    "sapmachine13-ea-jre": [
+      {
+        "cask": "sapmachine13-ea-jre",
+        "count": "6"
+      }
+    ],
+    "sapmachine13-jdk": [
+      {
+        "cask": "sapmachine13-jdk",
+        "count": "30"
+      }
+    ],
+    "sapmachine13-jre": [
+      {
+        "cask": "sapmachine13-jre",
+        "count": "3"
+      }
+    ],
+    "sapmachine14-ea-jdk": [
+      {
+        "cask": "sapmachine14-ea-jdk",
+        "count": "14"
+      }
+    ],
+    "sapmachine14-ea-jre": [
+      {
+        "cask": "sapmachine14-ea-jre",
+        "count": "5"
+      }
+    ],
+    "sapmachine14-jdk": [
+      {
+        "cask": "sapmachine14-jdk",
+        "count": "4"
+      }
+    ],
+    "sapmachine14-jre": [
+      {
+        "cask": "sapmachine14-jre",
+        "count": "3"
+      }
+    ],
+    "sapmachine15-ea-jdk": [
+      {
+        "cask": "sapmachine15-ea-jdk",
+        "count": "1"
+      }
+    ],
+    "sara": [
+      {
+        "cask": "sara",
+        "count": "2"
+      }
+    ],
+    "satellite-eyes": [
+      {
+        "cask": "satellite-eyes",
+        "count": "85"
+      }
+    ],
+    "sauce-connect": [
+      {
+        "cask": "sauce-connect",
+        "count": "284"
+      }
+    ],
+    "saucer": [
+      {
+        "cask": "saucer",
+        "count": "1"
+      }
+    ],
+    "sauerbraten": [
+      {
+        "cask": "sauerbraten",
+        "count": "59"
+      }
+    ],
+    "save-hollywood": [
+      {
+        "cask": "save-hollywood",
+        "count": "222"
+      }
+    ],
+    "saxotraderpro": [
+      {
+        "cask": "saxotraderpro",
+        "count": "2"
+      }
+    ],
+    "sblack": [
+      {
+        "cask": "sblack",
+        "count": "18"
+      }
+    ],
+    "sbrowserq": [
+      {
+        "cask": "sbrowserq",
+        "count": "2"
+      }
+    ],
+    "scala-ide": [
+      {
+        "cask": "scala-ide",
+        "count": "665"
+      }
+    ],
+    "scala-intellij": [
+      {
+        "cask": "scala-intellij",
+        "count": "10"
+      }
+    ],
+    "scalafmt-151": [
+      {
+        "cask": "scalafmt-151",
+        "count": "4"
+      }
+    ],
+    "scaleft": [
+      {
+        "cask": "scaleft",
+        "count": "93"
+      }
+    ],
+    "scalingo": [
+      {
+        "cask": "scalingo",
+        "count": "6"
+      }
+    ],
+    "scansion": [
+      {
+        "cask": "scansion",
+        "count": "74"
+      }
+    ],
+    "scap-workbench": [
+      {
+        "cask": "scap-workbench",
+        "count": "120"
+      }
+    ],
+    "scapple": [
+      {
+        "cask": "scapple",
+        "count": "250"
+      }
+    ],
+    "scenebuilder": [
+      {
+        "cask": "scenebuilder",
+        "count": "367"
+      }
+    ],
+    "scenery": [
+      {
+        "cask": "scenery",
+        "count": "2"
+      }
+    ],
+    "schism-tracker": [
+      {
+        "cask": "schism-tracker",
+        "count": "30"
+      }
+    ],
+    "schismtracker": [
+      {
+        "cask": "schismtracker",
+        "count": "1"
+      }
+    ],
+    "scidavis": [
+      {
+        "cask": "scidavis",
+        "count": "87"
+      }
+    ],
+    "scidvsmac": [
+      {
+        "cask": "scidvsmac",
+        "count": "65"
+      }
+    ],
+    "sciebo": [
+      {
+        "cask": "sciebo",
+        "count": "1"
+      }
+    ],
+    "scihubeva": [
+      {
+        "cask": "scihubeva",
+        "count": "108"
+      }
+    ],
+    "scilab": [
+      {
+        "cask": "scilab",
+        "count": "420"
+      }
+    ],
+    "scope": [
+      {
+        "cask": "scope",
+        "count": "23"
+      }
+    ],
+    "scopebox": [
+      {
+        "cask": "scopebox",
+        "count": "3"
+      }
+    ],
+    "scout": [
+      {
+        "cask": "scout",
+        "count": "56"
+      }
+    ],
+    "scrapspace": [
+      {
+        "cask": "scrapspace",
+        "count": "2"
+      }
+    ],
+    "scratch": [
+      {
+        "cask": "scratch",
+        "count": "612"
+      }
+    ],
+    "screaming-frog-seo-spider": [
+      {
+        "cask": "screaming-frog-seo-spider",
+        "count": "407"
+      }
+    ],
+    "screen": [
+      {
+        "cask": "screen",
+        "count": "194"
+      }
+    ],
+    "screen_ruler": [
+      {
+        "cask": "screen_ruler",
+        "count": "2"
+      }
+    ],
+    "screencast": [
+      {
+        "cask": "screencast",
+        "count": "49"
+      }
+    ],
+    "screencat": [
+      {
+        "cask": "screencat",
+        "count": "3"
+      }
+    ],
+    "screenflick": [
+      {
+        "cask": "screenflick",
+        "count": "291"
+      }
+    ],
+    "screenflow": [
+      {
+        "cask": "screenflow",
+        "count": "1,178"
+      }
+    ],
+    "screenflow5": [
+      {
+        "cask": "screenflow5",
+        "count": "9"
+      }
+    ],
+    "screenflow6": [
+      {
+        "cask": "screenflow6",
+        "count": "3"
+      }
+    ],
+    "screenfocus": [
+      {
+        "cask": "screenfocus",
+        "count": "1"
+      }
+    ],
+    "screenotate": [
+      {
+        "cask": "screenotate",
+        "count": "4"
+      }
+    ],
+    "screens": [
+      {
+        "cask": "screens",
+        "count": "417"
+      }
+    ],
+    "screens-connect": [
+      {
+        "cask": "screens-connect",
+        "count": "328"
+      }
+    ],
+    "screensleeves-standalone": [
+      {
+        "cask": "screensleeves-standalone",
+        "count": "2"
+      }
+    ],
+    "screenstagram": [
+      {
+        "cask": "screenstagram",
+        "count": "1"
+      }
+    ],
+    "screensteps": [
+      {
+        "cask": "screensteps",
+        "count": "1"
+      }
+    ],
+    "screentray": [
+      {
+        "cask": "screentray",
+        "count": "15"
+      }
+    ],
+    "scribus": [
+      {
+        "cask": "scribus",
+        "count": "2,247"
+      }
+    ],
+    "scribus-dev": [
+      {
+        "cask": "scribus-dev",
+        "count": "50"
+      }
+    ],
+    "script-debugger": [
+      {
+        "cask": "script-debugger",
+        "count": "158"
+      }
+    ],
+    "scriptql": [
+      {
+        "cask": "scriptql",
+        "count": "204"
+      }
+    ],
+    "scrivener": [
+      {
+        "cask": "scrivener",
+        "count": "552"
+      }
+    ],
+    "scroll-reverser": [
+      {
+        "cask": "scroll-reverser",
+        "count": "3,037"
+      }
+    ],
+    "scrooo": [
+      {
+        "cask": "scrooo",
+        "count": "3"
+      }
+    ],
+    "scrub": [
+      {
+        "cask": "scrub",
+        "count": "8"
+      }
+    ],
+    "scrutiny": [
+      {
+        "cask": "scrutiny",
+        "count": "127"
+      }
+    ],
+    "scummvm": [
+      {
+        "cask": "scummvm",
+        "count": "383"
+      }
+    ],
+    "sdcc": [
+      {
+        "cask": "sdcc",
+        "count": "2"
+      }
+    ],
+    "sde": [
+      {
+        "cask": "sde",
+        "count": "20"
+      }
+    ],
+    "sdformatter": [
+      {
+        "cask": "sdformatter",
+        "count": "985"
+      }
+    ],
+    "sdm": [
+      {
+        "cask": "sdm",
+        "count": "2"
+      }
+    ],
+    "sdrdx": [
+      {
+        "cask": "sdrdx",
+        "count": "124"
+      }
+    ],
+    "seadrive": [
+      {
+        "cask": "seadrive",
+        "count": "105"
+      }
+    ],
+    "seafile-client": [
+      {
+        "cask": "seafile-client",
+        "count": "747"
+      }
+    ],
+    "seagate-dashboard": [
+      {
+        "cask": "seagate-dashboard",
+        "count": "12"
+      }
+    ],
+    "seaglass": [
+      {
+        "cask": "seaglass",
+        "count": "527"
+      }
+    ],
+    "seal": [
+      {
+        "cask": "seal",
+        "count": "1"
+      }
+    ],
+    "seamonkey": [
+      {
+        "cask": "seamonkey",
+        "count": "380"
+      }
+    ],
+    "searchkey": [
+      {
+        "cask": "searchkey",
+        "count": "6"
+      }
+    ],
+    "searchkeylite": [
+      {
+        "cask": "searchkeylite",
+        "count": "3"
+      }
+    ],
+    "seashore": [
+      {
+        "cask": "seashore",
+        "count": "392"
+      }
+    ],
+    "second-life-viewer": [
+      {
+        "cask": "second-life-viewer",
+        "count": "118"
+      }
+    ],
+    "secure-pipes": [
+      {
+        "cask": "secure-pipes",
+        "count": "287"
+      }
+    ],
+    "securedownloadmanager": [
+      {
+        "cask": "securedownloadmanager",
+        "count": "2"
+      }
+    ],
+    "securesafe": [
+      {
+        "cask": "securesafe",
+        "count": "21"
+      }
+    ],
+    "securid": [
+      {
+        "cask": "securid",
+        "count": "102"
+      }
+    ],
+    "security-growler": [
+      {
+        "cask": "security-growler",
+        "count": "49"
+      }
+    ],
+    "securityspy": [
+      {
+        "cask": "securityspy",
+        "count": "76"
+      }
+    ],
+    "segger-embedded-studio-for-arm": [
+      {
+        "cask": "segger-embedded-studio-for-arm",
+        "count": "113"
+      }
+    ],
+    "segger-embedded-studio-for-risc-v": [
+      {
+        "cask": "segger-embedded-studio-for-risc-v",
+        "count": "1"
+      }
+    ],
+    "segger-jlink": [
+      {
+        "cask": "segger-jlink",
+        "count": "626"
+      }
+    ],
+    "segger-ozone": [
+      {
+        "cask": "segger-ozone",
+        "count": "25"
+      }
+    ],
+    "segger-systemview": [
+      {
+        "cask": "segger-systemview",
+        "count": "5"
+      }
+    ],
+    "sejda-pdf": [
+      {
+        "cask": "sejda-pdf",
+        "count": "157"
+      }
+    ],
+    "sekey": [
+      {
+        "cask": "sekey",
+        "count": "448"
+      }
+    ],
+    "selfcontrol": [
+      {
+        "cask": "selfcontrol",
+        "count": "815"
+      }
+    ],
+    "selflanguage-self-control": [
+      {
+        "cask": "selflanguage-self-control",
+        "count": "8"
+      }
+    ],
+    "semaphor": [
+      {
+        "cask": "semaphor",
+        "count": "15"
+      }
+    ],
+    "semulov": [
+      {
+        "cask": "semulov",
+        "count": "92"
+      }
+    ],
+    "sencha": [
+      {
+        "cask": "sencha",
+        "count": "379"
+      }
+    ],
+    "send-anywhere": [
+      {
+        "cask": "send-anywhere",
+        "count": "267"
+      }
+    ],
+    "send-to-kindle": [
+      {
+        "cask": "send-to-kindle",
+        "count": "831"
+      }
+    ],
+    "sendmidi": [
+      {
+        "cask": "sendmidi",
+        "count": "1"
+      }
+    ],
+    "sensei": [
+      {
+        "cask": "sensei",
+        "count": "203"
+      }
+    ],
+    "sensiblesidebuttons": [
+      {
+        "cask": "sensiblesidebuttons",
+        "count": "1,025"
+      }
+    ],
+    "sentinel": [
+      {
+        "cask": "sentinel",
+        "count": "86"
+      }
+    ],
+    "senuti": [
+      {
+        "cask": "senuti",
+        "count": "22"
+      }
+    ],
+    "sequel-pro": [
+      {
+        "cask": "sequel-pro",
+        "count": "22,035"
+      }
+    ],
+    "sequel-pro-nightly": [
+      {
+        "cask": "sequel-pro-nightly",
+        "count": "5,792"
+      }
+    ],
+    "sequel-pro-nightly-cask": [
+      {
+        "cask": "sequel-pro-nightly-cask",
+        "count": "3"
+      }
+    ],
+    "sequencair": [
+      {
+        "cask": "sequencair",
+        "count": "5"
+      }
+    ],
+    "sequential": [
+      {
+        "cask": "sequential",
+        "count": "183"
+      }
+    ],
+    "serial": [
+      {
+        "cask": "serial",
+        "count": "330"
+      }
+    ],
+    "serial-tools": [
+      {
+        "cask": "serial-tools",
+        "count": "197"
+      }
+    ],
+    "serialcloner": [
+      {
+        "cask": "serialcloner",
+        "count": "11"
+      }
+    ],
+    "serviio": [
+      {
+        "cask": "serviio",
+        "count": "260"
+      }
+    ],
+    "servo": [
+      {
+        "cask": "servo",
+        "count": "122"
+      }
+    ],
+    "servpane": [
+      {
+        "cask": "servpane",
+        "count": "94"
+      }
+    ],
+    "session": [
+      {
+        "cask": "session",
+        "count": "65"
+      }
+    ],
+    "session-manager-plugin": [
+      {
+        "cask": "session-manager-plugin",
+        "count": "1,307"
+      }
+    ],
+    "sessionrestore": [
+      {
+        "cask": "sessionrestore",
+        "count": "2"
+      }
+    ],
+    "setapp": [
+      {
+        "cask": "setapp",
+        "count": "2,200"
+      }
+    ],
+    "sf-symbols": [
+      {
+        "cask": "sf-symbols",
+        "count": "562"
+      }
+    ],
+    "sfdx": [
+      {
+        "cask": "sfdx",
+        "count": "613"
+      }
+    ],
+    "sforzando": [
+      {
+        "cask": "sforzando",
+        "count": "3"
+      }
+    ],
+    "shades": [
+      {
+        "cask": "shades",
+        "count": "160"
+      }
+    ],
+    "shadow": [
+      {
+        "cask": "shadow",
+        "count": "353"
+      }
+    ],
+    "shadow-beta": [
+      {
+        "cask": "shadow-beta",
+        "count": "40"
+      }
+    ],
+    "shadowsocksx": [
+      {
+        "cask": "shadowsocksx",
+        "count": "953"
+      }
+    ],
+    "shadowsocksx-ng": [
+      {
+        "cask": "shadowsocksx-ng",
+        "count": "4,771"
+      }
+    ],
+    "shadowsocksx-ng-r": [
+      {
+        "cask": "shadowsocksx-ng-r",
+        "count": "2,240"
+      }
+    ],
+    "shadowsocksx-ng-r8": [
+      {
+        "cask": "shadowsocksx-ng-r8",
+        "count": "4"
+      }
+    ],
+    "shapes": [
+      {
+        "cask": "shapes",
+        "count": "30"
+      }
+    ],
+    "sharemouse": [
+      {
+        "cask": "sharemouse",
+        "count": "623"
+      }
+    ],
+    "sharepod": [
+      {
+        "cask": "sharepod",
+        "count": "7"
+      }
+    ],
+    "sharpshooter": [
+      {
+        "cask": "sharpshooter",
+        "count": "2"
+      }
+    ],
+    "shb1": [
+      {
+        "cask": "shb1",
+        "count": "2"
+      }
+    ],
+    "shearwater": [
+      {
+        "cask": "shearwater",
+        "count": "3"
+      }
+    ],
+    "sheepshaver": [
+      {
+        "cask": "sheepshaver",
+        "count": "3"
+      }
+    ],
+    "shellhere": [
+      {
+        "cask": "shellhere",
+        "count": "34"
+      }
+    ],
+    "sherlock": [
+      {
+        "cask": "sherlock",
+        "count": "150"
+      }
+    ],
+    "shiba": [
+      {
+        "cask": "shiba",
+        "count": "41"
+      }
+    ],
+    "shift": [
+      {
+        "cask": "shift",
+        "count": "347"
+      }
+    ],
+    "shiftit": [
+      {
+        "cask": "shiftit",
+        "count": "8,500"
+      }
+    ],
+    "shifty": [
+      {
+        "cask": "shifty",
+        "count": "508"
+      }
+    ],
+    "shimeike-formulatepro": [
+      {
+        "cask": "shimeike-formulatepro",
+        "count": "95"
+      }
+    ],
+    "shimo": [
+      {
+        "cask": "shimo",
+        "count": "563"
+      }
+    ],
+    "shiori": [
+      {
+        "cask": "shiori",
+        "count": "120"
+      }
+    ],
+    "shoes": [
+      {
+        "cask": "shoes",
+        "count": "29"
+      }
+    ],
+    "shootersubx": [
+      {
+        "cask": "shootersubx",
+        "count": "2"
+      }
+    ],
+    "shoretel-connect": [
+      {
+        "cask": "shoretel-connect",
+        "count": "7"
+      }
+    ],
+    "shortcat": [
+      {
+        "cask": "shortcat",
+        "count": "229"
+      }
+    ],
+    "shortcutdetective": [
+      {
+        "cask": "shortcutdetective",
+        "count": "78"
+      }
+    ],
+    "shortcuts": [
+      {
+        "cask": "shortcuts",
+        "count": "60"
+      }
+    ],
+    "shotcut": [
+      {
+        "cask": "shotcut",
+        "count": "1,135"
+      }
+    ],
+    "showhiddenfiles": [
+      {
+        "cask": "showhiddenfiles",
+        "count": "22"
+      }
+    ],
+    "showyedge": [
+      {
+        "cask": "showyedge",
+        "count": "166"
+      }
+    ],
+    "shrinkit": [
+      {
+        "cask": "shrinkit",
+        "count": "36"
+      }
+    ],
+    "shupapan": [
+      {
+        "cask": "shupapan",
+        "count": "43"
+      }
+    ],
+    "shutdown": [
+      {
+        "cask": "shutdown",
+        "count": "2"
+      }
+    ],
+    "shuttle": [
+      {
+        "cask": "shuttle",
+        "count": "823"
+      }
+    ],
+    "sia-host-manager": [
+      {
+        "cask": "sia-host-manager",
+        "count": "1"
+      }
+    ],
+    "sia-ui": [
+      {
+        "cask": "sia-ui",
+        "count": "89"
+      }
+    ],
+    "sickbeard-anime": [
+      {
+        "cask": "sickbeard-anime",
+        "count": "26"
+      }
+    ],
+    "sidekick": [
+      {
+        "cask": "sidekick",
+        "count": "71"
+      }
+    ],
+    "sidenotes": [
+      {
+        "cask": "sidenotes",
+        "count": "66"
+      }
+    ],
+    "sidequest": [
+      {
+        "cask": "sidequest",
+        "count": "235"
+      }
+    ],
+    "sidestep": [
+      {
+        "cask": "sidestep",
+        "count": "31"
+      }
+    ],
+    "sidneys-pb": [
+      {
+        "cask": "sidneys-pb",
+        "count": "4"
+      }
+    ],
+    "sigil": [
+      {
+        "cask": "sigil",
+        "count": "982"
+      }
+    ],
+    "sigilium": [
+      {
+        "cask": "sigilium",
+        "count": "3"
+      }
+    ],
+    "sigilium-email-signatures": [
+      {
+        "cask": "sigilium-email-signatures",
+        "count": "5"
+      }
+    ],
+    "signal": [
+      {
+        "cask": "signal",
+        "count": "11,019"
+      }
+    ],
+    "signal-beta": [
+      {
+        "cask": "signal-beta",
+        "count": "180"
+      }
+    ],
+    "signet": [
+      {
+        "cask": "signet",
+        "count": "16"
+      }
+    ],
+    "sigviewer": [
+      {
+        "cask": "sigviewer",
+        "count": "4"
+      }
+    ],
+    "silentknight": [
+      {
+        "cask": "silentknight",
+        "count": "46"
+      }
+    ],
+    "silhouette-saver": [
+      {
+        "cask": "silhouette-saver",
+        "count": "12"
+      }
+    ],
+    "silicon-labs-vcp-driver": [
+      {
+        "cask": "silicon-labs-vcp-driver",
+        "count": "1,229"
+      }
+    ],
+    "silnite": [
+      {
+        "cask": "silnite",
+        "count": "6"
+      }
+    ],
+    "silo": [
+      {
+        "cask": "silo",
+        "count": "33"
+      }
+    ],
+    "silverback": [
+      {
+        "cask": "silverback",
+        "count": "16"
+      }
+    ],
+    "silverlight": [
+      {
+        "cask": "silverlight",
+        "count": "1,692"
+      }
+    ],
+    "sim-daltonism": [
+      {
+        "cask": "sim-daltonism",
+        "count": "175"
+      }
+    ],
+    "simpholders": [
+      {
+        "cask": "simpholders",
+        "count": "93"
+      }
+    ],
+    "simple-comic": [
+      {
+        "cask": "simple-comic",
+        "count": "781"
+      }
+    ],
+    "simple-css": [
+      {
+        "cask": "simple-css",
+        "count": "8"
+      }
+    ],
+    "simple-dmx": [
+      {
+        "cask": "simple-dmx",
+        "count": "27"
+      }
+    ],
+    "simple-snake": [
+      {
+        "cask": "simple-snake",
+        "count": "1"
+      }
+    ],
+    "simplecap": [
+      {
+        "cask": "simplecap",
+        "count": "29"
+      }
+    ],
+    "simplediagrams": [
+      {
+        "cask": "simplediagrams",
+        "count": "40"
+      }
+    ],
+    "simplefloatingclock": [
+      {
+        "cask": "simplefloatingclock",
+        "count": "40"
+      }
+    ],
+    "simplemoviex": [
+      {
+        "cask": "simplemoviex",
+        "count": "4"
+      }
+    ],
+    "simplenote": [
+      {
+        "cask": "simplenote",
+        "count": "1,864"
+      }
+    ],
+    "simpless": [
+      {
+        "cask": "simpless",
+        "count": "16"
+      }
+    ],
+    "simplesynth": [
+      {
+        "cask": "simplesynth",
+        "count": "71"
+      }
+    ],
+    "simpletag": [
+      {
+        "cask": "simpletag",
+        "count": "3"
+      }
+    ],
+    "simplistic": [
+      {
+        "cask": "simplistic",
+        "count": "54"
+      }
+    ],
+    "simply-fortran": [
+      {
+        "cask": "simply-fortran",
+        "count": "43"
+      }
+    ],
+    "simsim": [
+      {
+        "cask": "simsim",
+        "count": "125"
+      }
+    ],
+    "singularity": [
+      {
+        "cask": "singularity",
+        "count": "264"
+      }
+    ],
+    "singularity-desktop-beta": [
+      {
+        "cask": "singularity-desktop-beta",
+        "count": "2"
+      }
+    ],
+    "sip": [
+      {
+        "cask": "sip",
+        "count": "1,041"
+      }
+    ],
+    "sip2sip": [
+      {
+        "cask": "sip2sip",
+        "count": "1"
+      }
+    ],
+    "sirimote": [
+      {
+        "cask": "sirimote",
+        "count": "48"
+      }
+    ],
+    "sitala": [
+      {
+        "cask": "sitala",
+        "count": "4"
+      }
+    ],
+    "sitebulb": [
+      {
+        "cask": "sitebulb",
+        "count": "3"
+      }
+    ],
+    "sixtyforce": [
+      {
+        "cask": "sixtyforce",
+        "count": "47"
+      }
+    ],
+    "sizeup": [
+      {
+        "cask": "sizeup",
+        "count": "1,546"
+      }
+    ],
+    "sizzlingkeys": [
+      {
+        "cask": "sizzlingkeys",
+        "count": "1"
+      }
+    ],
+    "sizzy": [
+      {
+        "cask": "sizzy",
+        "count": "103"
+      }
+    ],
+    "skala-preview": [
+      {
+        "cask": "skala-preview",
+        "count": "48"
+      }
+    ],
+    "skbd": [
+      {
+        "cask": "skbd",
+        "count": "1"
+      }
+    ],
+    "sketch": [
+      {
+        "cask": "sketch",
+        "count": "12,177"
+      }
+    ],
+    "sketch-43": [
+      {
+        "cask": "sketch-43",
+        "count": "2"
+      }
+    ],
+    "sketch-toolbox": [
+      {
+        "cask": "sketch-toolbox",
+        "count": "322"
+      }
+    ],
+    "sketch@43.2": [
+      {
+        "cask": "sketch@43.2",
+        "count": "2"
+      }
+    ],
+    "sketchbook": [
+      {
+        "cask": "sketchbook",
+        "count": "364"
+      }
+    ],
+    "sketchpacks": [
+      {
+        "cask": "sketchpacks",
+        "count": "445"
+      }
+    ],
+    "sketchup": [
+      {
+        "cask": "sketchup",
+        "count": "1,546"
+      }
+    ],
+    "sketchup-pro": [
+      {
+        "cask": "sketchup-pro",
+        "count": "182"
+      }
+    ],
+    "skeycalc": [
+      {
+        "cask": "skeycalc",
+        "count": "3"
+      }
+    ],
+    "skim": [
+      {
+        "cask": "skim",
+        "count": "8,674"
+      }
+    ],
+    "skitch": [
+      {
+        "cask": "skitch",
+        "count": "4,696"
+      }
+    ],
+    "skookumlogger": [
+      {
+        "cask": "skookumlogger",
+        "count": "1"
+      }
+    ],
+    "skreenics": [
+      {
+        "cask": "skreenics",
+        "count": "15"
+      }
+    ],
+    "skybox": [
+      {
+        "cask": "skybox",
+        "count": "34"
+      }
+    ],
+    "skyfonts": [
+      {
+        "cask": "skyfonts",
+        "count": "817"
+      }
+    ],
+    "skype": [
+      {
+        "cask": "skype",
+        "count": "47,836"
+      }
+    ],
+    "skype-cn": [
+      {
+        "cask": "skype-cn",
+        "count": "1"
+      }
+    ],
+    "skype-custom": [
+      {
+        "cask": "skype-custom",
+        "count": "1"
+      }
+    ],
+    "skype-for-business": [
+      {
+        "cask": "skype-for-business",
+        "count": "6,780"
+      }
+    ],
+    "skype-preview": [
+      {
+        "cask": "skype-preview",
+        "count": "127"
+      }
+    ],
+    "skype7": [
+      {
+        "cask": "skype7",
+        "count": "42"
+      }
+    ],
+    "skypewebplugin": [
+      {
+        "cask": "skypewebplugin",
+        "count": "106"
+      }
+    ],
+    "slack": [
+      {
+        "cask": "slack",
+        "count": "84,283"
+      }
+    ],
+    "slack-beta": [
+      {
+        "cask": "slack-beta",
+        "count": "925"
+      }
+    ],
+    "slash": [
+      {
+        "cask": "slash",
+        "count": "1"
+      }
+    ],
+    "slate": [
+      {
+        "cask": "slate",
+        "count": "853"
+      }
+    ],
+    "sleep": [
+      {
+        "cask": "sleep",
+        "count": "2"
+      }
+    ],
+    "sleep-monitor": [
+      {
+        "cask": "sleep-monitor",
+        "count": "3"
+      }
+    ],
+    "sleepyhead": [
+      {
+        "cask": "sleepyhead",
+        "count": "27"
+      }
+    ],
+    "sleipnir": [
+      {
+        "cask": "sleipnir",
+        "count": "44"
+      }
+    ],
+    "slic3r": [
+      {
+        "cask": "slic3r",
+        "count": "285"
+      }
+    ],
+    "slicer": [
+      {
+        "cask": "slicer",
+        "count": "70"
+      }
+    ],
+    "slicer-nightly": [
+      {
+        "cask": "slicer-nightly",
+        "count": "10"
+      }
+    ],
+    "slik": [
+      {
+        "cask": "slik",
+        "count": "23"
+      }
+    ],
+    "slimbatterymonitor": [
+      {
+        "cask": "slimbatterymonitor",
+        "count": "63"
+      }
+    ],
+    "sling": [
+      {
+        "cask": "sling",
+        "count": "6"
+      }
+    ],
+    "slingplayer": [
+      {
+        "cask": "slingplayer",
+        "count": "24"
+      }
+    ],
+    "slite": [
+      {
+        "cask": "slite",
+        "count": "136"
+      }
+    ],
+    "sloth": [
+      {
+        "cask": "sloth",
+        "count": "1,091"
+      }
+    ],
+    "slowquitapps": [
+      {
+        "cask": "slowquitapps",
+        "count": "1,326"
+      }
+    ],
+    "smallpdf": [
+      {
+        "cask": "smallpdf",
+        "count": "152"
+      }
+    ],
+    "sman": [
+      {
+        "cask": "sman",
+        "count": "1"
+      }
+    ],
+    "smaolab-tarabia": [
+      {
+        "cask": "smaolab-tarabia",
+        "count": "2"
+      }
+    ],
+    "smart-converter-pro": [
+      {
+        "cask": "smart-converter-pro",
+        "count": "23"
+      }
+    ],
+    "smart-scroll": [
+      {
+        "cask": "smart-scroll",
+        "count": "15"
+      }
+    ],
+    "smartconverter": [
+      {
+        "cask": "smartconverter",
+        "count": "15"
+      }
+    ],
+    "smartgit": [
+      {
+        "cask": "smartgit",
+        "count": "1,504"
+      }
+    ],
+    "smartgit-rc": [
+      {
+        "cask": "smartgit-rc",
+        "count": "1"
+      }
+    ],
+    "smartscope": [
+      {
+        "cask": "smartscope",
+        "count": "7"
+      }
+    ],
+    "smartsvn": [
+      {
+        "cask": "smartsvn",
+        "count": "649"
+      }
+    ],
+    "smartsynchronize": [
+      {
+        "cask": "smartsynchronize",
+        "count": "103"
+      }
+    ],
+    "smcfancontrol": [
+      {
+        "cask": "smcfancontrol",
+        "count": "5,957"
+      }
+    ],
+    "sml": [
+      {
+        "cask": "sml",
+        "count": "1"
+      }
+    ],
+    "sml-nj": [
+      {
+        "cask": "sml-nj",
+        "count": "3"
+      }
+    ],
+    "smlnj": [
+      {
+        "cask": "smlnj",
+        "count": "1,992"
+      }
+    ],
+    "smoothscroll": [
+      {
+        "cask": "smoothscroll",
+        "count": "227"
+      }
+    ],
+    "smooze": [
+      {
+        "cask": "smooze",
+        "count": "140"
+      }
+    ],
+    "snagit": [
+      {
+        "cask": "snagit",
+        "count": "856"
+      }
+    ],
+    "snagit4": [
+      {
+        "cask": "snagit4",
+        "count": "19"
+      }
+    ],
+    "snapndrag": [
+      {
+        "cask": "snapndrag",
+        "count": "42"
+      }
+    ],
+    "snappy": [
+      {
+        "cask": "snappy",
+        "count": "294"
+      }
+    ],
+    "sneek": [
+      {
+        "cask": "sneek",
+        "count": "28"
+      }
+    ],
+    "snes9x": [
+      {
+        "cask": "snes9x",
+        "count": "361"
+      }
+    ],
+    "snip": [
+      {
+        "cask": "snip",
+        "count": "606"
+      }
+    ],
+    "snipaste": [
+      {
+        "cask": "snipaste",
+        "count": "1,670"
+      }
+    ],
+    "sno": [
+      {
+        "cask": "sno",
+        "count": "10"
+      }
+    ],
+    "snowflake-odbc": [
+      {
+        "cask": "snowflake-odbc",
+        "count": "2"
+      }
+    ],
+    "snowflake-snowsql": [
+      {
+        "cask": "snowflake-snowsql",
+        "count": "2,343"
+      }
+    ],
+    "snwe": [
+      {
+        "cask": "snwe",
+        "count": "19"
+      }
+    ],
+    "soapui": [
+      {
+        "cask": "soapui",
+        "count": "3,390"
+      }
+    ],
+    "socket-io-tester": [
+      {
+        "cask": "socket-io-tester",
+        "count": "50"
+      }
+    ],
+    "sococo": [
+      {
+        "cask": "sococo",
+        "count": "145"
+      }
+    ],
+    "soda-player": [
+      {
+        "cask": "soda-player",
+        "count": "679"
+      }
+    ],
+    "soduto": [
+      {
+        "cask": "soduto",
+        "count": "102"
+      }
+    ],
+    "sofa-server": [
+      {
+        "cask": "sofa-server",
+        "count": "2"
+      }
+    ],
+    "softether-vpnserver-manager": [
+      {
+        "cask": "softether-vpnserver-manager",
+        "count": "1"
+      }
+    ],
+    "softmaker-freeoffice": [
+      {
+        "cask": "softmaker-freeoffice",
+        "count": "130"
+      }
+    ],
+    "softorino-youtube-converter": [
+      {
+        "cask": "softorino-youtube-converter",
+        "count": "119"
+      }
+    ],
+    "softraid": [
+      {
+        "cask": "softraid",
+        "count": "63"
+      }
+    ],
+    "softu2f": [
+      {
+        "cask": "softu2f",
+        "count": "91"
+      }
+    ],
+    "softube-amp-room-essentials": [
+      {
+        "cask": "softube-amp-room-essentials",
+        "count": "1"
+      }
+    ],
+    "softube-central": [
+      {
+        "cask": "softube-central",
+        "count": "7"
+      }
+    ],
+    "sogouinput": [
+      {
+        "cask": "sogouinput",
+        "count": "3,060"
+      }
+    ],
+    "soleol": [
+      {
+        "cask": "soleol",
+        "count": "5"
+      }
+    ],
+    "soluble": [
+      {
+        "cask": "soluble",
+        "count": "7"
+      }
+    ],
+    "solvespace": [
+      {
+        "cask": "solvespace",
+        "count": "94"
+      }
+    ],
+    "somafm": [
+      {
+        "cask": "somafm",
+        "count": "7"
+      }
+    ],
+    "sonalksis-creative-elements": [
+      {
+        "cask": "sonalksis-creative-elements",
+        "count": "1"
+      }
+    ],
+    "sonalksis-essentials": [
+      {
+        "cask": "sonalksis-essentials",
+        "count": "1"
+      }
+    ],
+    "sonalksis-freeg": [
+      {
+        "cask": "sonalksis-freeg",
+        "count": "1"
+      }
+    ],
+    "sonalksis-mastering-suite": [
+      {
+        "cask": "sonalksis-mastering-suite",
+        "count": "1"
+      }
+    ],
+    "sonalksis-multiband-dynamics": [
+      {
+        "cask": "sonalksis-multiband-dynamics",
+        "count": "1"
+      }
+    ],
+    "sonalksis-plugin-manager": [
+      {
+        "cask": "sonalksis-plugin-manager",
+        "count": "1"
+      }
+    ],
+    "sonarr": [
+      {
+        "cask": "sonarr",
+        "count": "4,295"
+      }
+    ],
+    "sonarr-menu": [
+      {
+        "cask": "sonarr-menu",
+        "count": "43"
+      }
+    ],
+    "sonic-pi": [
+      {
+        "cask": "sonic-pi",
+        "count": "629"
+      }
+    ],
+    "sonic-visualiser": [
+      {
+        "cask": "sonic-visualiser",
+        "count": "222"
+      }
+    ],
+    "sonoair": [
+      {
+        "cask": "sonoair",
+        "count": "34"
+      }
+    ],
+    "sonos": [
+      {
+        "cask": "sonos",
+        "count": "1,649"
+      }
+    ],
+    "sonos-controller": [
+      {
+        "cask": "sonos-controller",
+        "count": "5"
+      }
+    ],
+    "sony-ps4-remote-play": [
+      {
+        "cask": "sony-ps4-remote-play",
+        "count": "641"
+      }
+    ],
+    "sony-xperia-companion": [
+      {
+        "cask": "sony-xperia-companion",
+        "count": "35"
+      }
+    ],
+    "sopcast": [
+      {
+        "cask": "sopcast",
+        "count": "215"
+      }
+    ],
+    "soqlxplorer": [
+      {
+        "cask": "soqlxplorer",
+        "count": "231"
+      }
+    ],
+    "sorbet": [
+      {
+        "cask": "sorbet",
+        "count": "1"
+      }
+    ],
+    "soulseek": [
+      {
+        "cask": "soulseek",
+        "count": "533"
+      }
+    ],
+    "soulver": [
+      {
+        "cask": "soulver",
+        "count": "786"
+      }
+    ],
+    "soulver2": [
+      {
+        "cask": "soulver2",
+        "count": "29"
+      }
+    ],
+    "sound-blaster-play3": [
+      {
+        "cask": "sound-blaster-play3",
+        "count": "9"
+      }
+    ],
+    "sound-control": [
+      {
+        "cask": "sound-control",
+        "count": "302"
+      }
+    ],
+    "sound-siphon": [
+      {
+        "cask": "sound-siphon",
+        "count": "35"
+      }
+    ],
+    "soundboosterlite": [
+      {
+        "cask": "soundboosterlite",
+        "count": "32"
+      }
+    ],
+    "soundcleod": [
+      {
+        "cask": "soundcleod",
+        "count": "408"
+      }
+    ],
+    "soundcloud-downloader": [
+      {
+        "cask": "soundcloud-downloader",
+        "count": "275"
+      }
+    ],
+    "soundflower": [
+      {
+        "cask": "soundflower",
+        "count": "4,808"
+      }
+    ],
+    "soundflower-1.6.6b-karen_internal": [
+      {
+        "cask": "soundflower-1.6.6b-karen_internal",
+        "count": "1"
+      }
+    ],
+    "soundflowerbed": [
+      {
+        "cask": "soundflowerbed",
+        "count": "1,092"
+      }
+    ],
+    "soundfly-latest-karen_internal": [
+      {
+        "cask": "soundfly-latest-karen_internal",
+        "count": "1"
+      }
+    ],
+    "soundly": [
+      {
+        "cask": "soundly",
+        "count": "1"
+      }
+    ],
+    "soundnode": [
+      {
+        "cask": "soundnode",
+        "count": "101"
+      }
+    ],
+    "soundsource": [
+      {
+        "cask": "soundsource",
+        "count": "677"
+      }
+    ],
+    "soundtoys-echoboy-jr": [
+      {
+        "cask": "soundtoys-echoboy-jr",
+        "count": "1"
+      }
+    ],
+    "soundtoys-little-plate": [
+      {
+        "cask": "soundtoys-little-plate",
+        "count": "1"
+      }
+    ],
+    "soundtoys-sie-q": [
+      {
+        "cask": "soundtoys-sie-q",
+        "count": "1"
+      }
+    ],
+    "sourcenote": [
+      {
+        "cask": "sourcenote",
+        "count": "7"
+      }
+    ],
+    "sourcetrail": [
+      {
+        "cask": "sourcetrail",
+        "count": "754"
+      }
+    ],
+    "sourcetree": [
+      {
+        "cask": "sourcetree",
+        "count": "32,995"
+      }
+    ],
+    "sourcetree-alpha": [
+      {
+        "cask": "sourcetree-alpha",
+        "count": "19"
+      }
+    ],
+    "sourcetree-beta": [
+      {
+        "cask": "sourcetree-beta",
+        "count": "79"
+      }
+    ],
+    "sourcetree-custom": [
+      {
+        "cask": "sourcetree-custom",
+        "count": "2"
+      }
+    ],
+    "sozi": [
+      {
+        "cask": "sozi",
+        "count": "1"
+      }
+    ],
+    "spaceid": [
+      {
+        "cask": "spaceid",
+        "count": "8"
+      }
+    ],
+    "spacelauncher": [
+      {
+        "cask": "spacelauncher",
+        "count": "71"
+      }
+    ],
+    "spacemonkey": [
+      {
+        "cask": "spacemonkey",
+        "count": "6"
+      }
+    ],
+    "spaceradar": [
+      {
+        "cask": "spaceradar",
+        "count": "69"
+      }
+    ],
+    "spamsieve": [
+      {
+        "cask": "spamsieve",
+        "count": "188"
+      }
+    ],
+    "spark": [
+      {
+        "cask": "spark",
+        "count": "2,693"
+      }
+    ],
+    "sparkle": [
+      {
+        "cask": "sparkle",
+        "count": "317"
+      }
+    ],
+    "sparkleshare": [
+      {
+        "cask": "sparkleshare",
+        "count": "79"
+      }
+    ],
+    "spatial": [
+      {
+        "cask": "spatial",
+        "count": "39"
+      }
+    ],
+    "spatial-media-metadata-injector": [
+      {
+        "cask": "spatial-media-metadata-injector",
+        "count": "1"
+      }
+    ],
+    "spatterlight": [
+      {
+        "cask": "spatterlight",
+        "count": "22"
+      }
+    ],
+    "spechtlite": [
+      {
+        "cask": "spechtlite",
+        "count": "59"
+      }
+    ],
+    "spectacle": [
+      {
+        "cask": "spectacle",
+        "count": "31,426"
+      }
+    ],
+    "spectacle-editor": [
+      {
+        "cask": "spectacle-editor",
+        "count": "38"
+      }
+    ],
+    "spectacularity": [
+      {
+        "cask": "spectacularity",
+        "count": "12"
+      }
+    ],
+    "spectrum": [
+      {
+        "cask": "spectrum",
+        "count": "198"
+      }
+    ],
+    "spectx": [
+      {
+        "cask": "spectx",
+        "count": "5"
+      }
+    ],
+    "speculid": [
+      {
+        "cask": "speculid",
+        "count": "65"
+      }
+    ],
+    "speedcrunch": [
+      {
+        "cask": "speedcrunch",
+        "count": "355"
+      }
+    ],
+    "speedify": [
+      {
+        "cask": "speedify",
+        "count": "103"
+      }
+    ],
+    "spek": [
+      {
+        "cask": "spek",
+        "count": "7"
+      }
+    ],
+    "spek-alternative": [
+      {
+        "cask": "spek-alternative",
+        "count": "2"
+      }
+    ],
+    "spideroak-share": [
+      {
+        "cask": "spideroak-share",
+        "count": "3"
+      }
+    ],
+    "spideroakone": [
+      {
+        "cask": "spideroakone",
+        "count": "142"
+      }
+    ],
+    "spike": [
+      {
+        "cask": "spike",
+        "count": "390"
+      }
+    ],
+    "spillo": [
+      {
+        "cask": "spillo",
+        "count": "47"
+      }
+    ],
+    "spires": [
+      {
+        "cask": "spires",
+        "count": "3"
+      }
+    ],
+    "spitfire-audio": [
+      {
+        "cask": "spitfire-audio",
+        "count": "1"
+      }
+    ],
+    "splashtop-business": [
+      {
+        "cask": "splashtop-business",
+        "count": "83"
+      }
+    ],
+    "splashtop-personal": [
+      {
+        "cask": "splashtop-personal",
+        "count": "161"
+      }
+    ],
+    "splashtop-streamer": [
+      {
+        "cask": "splashtop-streamer",
+        "count": "166"
+      }
+    ],
+    "splashtop-wired-xdisplay-agent": [
+      {
+        "cask": "splashtop-wired-xdisplay-agent",
+        "count": "1"
+      }
+    ],
+    "splashtop-xdisplay": [
+      {
+        "cask": "splashtop-xdisplay",
+        "count": "1"
+      }
+    ],
+    "splayer": [
+      {
+        "cask": "splayer",
+        "count": "4"
+      }
+    ],
+    "splice": [
+      {
+        "cask": "splice",
+        "count": "177"
+      }
+    ],
+    "splitshow": [
+      {
+        "cask": "splitshow",
+        "count": "31"
+      }
+    ],
+    "spotifree": [
+      {
+        "cask": "spotifree",
+        "count": "288"
+      }
+    ],
+    "spotify": [
+      {
+        "cask": "spotify",
+        "count": "57,944"
+      }
+    ],
+    "spotify-notifications": [
+      {
+        "cask": "spotify-notifications",
+        "count": "877"
+      }
+    ],
+    "spotify-now-playing": [
+      {
+        "cask": "spotify-now-playing",
+        "count": "543"
+      }
+    ],
+    "spotlight-apps": [
+      {
+        "cask": "spotlight-apps",
+        "count": "1"
+      }
+    ],
+    "spotmenu": [
+      {
+        "cask": "spotmenu",
+        "count": "3,906"
+      }
+    ],
+    "spotspot": [
+      {
+        "cask": "spotspot",
+        "count": "27"
+      }
+    ],
+    "spotstatus": [
+      {
+        "cask": "spotstatus",
+        "count": "3"
+      }
+    ],
+    "springtoolsuite": [
+      {
+        "cask": "springtoolsuite",
+        "count": "1,554"
+      }
+    ],
+    "spriteilluminator": [
+      {
+        "cask": "spriteilluminator",
+        "count": "2"
+      }
+    ],
+    "spyder-py2": [
+      {
+        "cask": "spyder-py2",
+        "count": "94"
+      }
+    ],
+    "sql-power-architect-jdbc": [
+      {
+        "cask": "sql-power-architect-jdbc",
+        "count": "60"
+      }
+    ],
+    "sql-tabs": [
+      {
+        "cask": "sql-tabs",
+        "count": "46"
+      }
+    ],
+    "sqlcheck": [
+      {
+        "cask": "sqlcheck",
+        "count": "31"
+      }
+    ],
+    "sqlectron": [
+      {
+        "cask": "sqlectron",
+        "count": "328"
+      }
+    ],
+    "sqleditor": [
+      {
+        "cask": "sqleditor",
+        "count": "67"
+      }
+    ],
+    "sqlexplorer": [
+      {
+        "cask": "sqlexplorer",
+        "count": "106"
+      }
+    ],
+    "sqlitemanager": [
+      {
+        "cask": "sqlitemanager",
+        "count": "222"
+      }
+    ],
+    "sqlitestudio": [
+      {
+        "cask": "sqlitestudio",
+        "count": "934"
+      }
+    ],
+    "sqlpro-for-mssql": [
+      {
+        "cask": "sqlpro-for-mssql",
+        "count": "229"
+      }
+    ],
+    "sqlpro-for-mysql": [
+      {
+        "cask": "sqlpro-for-mysql",
+        "count": "365"
+      }
+    ],
+    "sqlpro-for-postgres": [
+      {
+        "cask": "sqlpro-for-postgres",
+        "count": "299"
+      }
+    ],
+    "sqlpro-for-sqlite": [
+      {
+        "cask": "sqlpro-for-sqlite",
+        "count": "250"
+      }
+    ],
+    "sqlpro-studio": [
+      {
+        "cask": "sqlpro-studio",
+        "count": "315"
+      }
+    ],
+    "sqlworkbenchj": [
+      {
+        "cask": "sqlworkbenchj",
+        "count": "3,699"
+      }
+    ],
+    "squadanimator-rugby": [
+      {
+        "cask": "squadanimator-rugby",
+        "count": "1"
+      }
+    ],
+    "squadanimatorgaa": [
+      {
+        "cask": "squadanimatorgaa",
+        "count": "1"
+      }
+    ],
+    "squadanimatorrugby": [
+      {
+        "cask": "squadanimatorrugby",
+        "count": "1"
+      }
+    ],
+    "squadanimatorsoccer": [
+      {
+        "cask": "squadanimatorsoccer",
+        "count": "1"
+      }
+    ],
+    "squeak": [
+      {
+        "cask": "squeak",
+        "count": "106"
+      }
+    ],
+    "squeed": [
+      {
+        "cask": "squeed",
+        "count": "1"
+      }
+    ],
+    "squidman": [
+      {
+        "cask": "squidman",
+        "count": "698"
+      }
+    ],
+    "squirrel": [
+      {
+        "cask": "squirrel",
+        "count": "4,076"
+      }
+    ],
+    "squirrelsql": [
+      {
+        "cask": "squirrelsql",
+        "count": "829"
+      }
+    ],
+    "sr": [
+      {
+        "cask": "sr",
+        "count": "1"
+      }
+    ],
+    "srware-iron": [
+      {
+        "cask": "srware-iron",
+        "count": "153"
+      }
+    ],
+    "ssd-fan-control": [
+      {
+        "cask": "ssd-fan-control",
+        "count": "1"
+      }
+    ],
+    "ssh-tunnel-manager": [
+      {
+        "cask": "ssh-tunnel-manager",
+        "count": "626"
+      }
+    ],
+    "sshcode": [
+      {
+        "cask": "sshcode",
+        "count": "3"
+      }
+    ],
+    "ssokit": [
+      {
+        "cask": "ssokit",
+        "count": "38"
+      }
+    ],
+    "stack": [
+      {
+        "cask": "stack",
+        "count": "356"
+      }
+    ],
+    "stack-exchange-notifier": [
+      {
+        "cask": "stack-exchange-notifier",
+        "count": "37"
+      }
+    ],
+    "stack-stack": [
+      {
+        "cask": "stack-stack",
+        "count": "16"
+      }
+    ],
+    "stamp": [
+      {
+        "cask": "stamp",
+        "count": "83"
+      }
+    ],
+    "stand": [
+      {
+        "cask": "stand",
+        "count": "42"
+      }
+    ],
+    "standard-ml-of-new-jersey": [
+      {
+        "cask": "standard-ml-of-new-jersey",
+        "count": "2"
+      }
+    ],
+    "standard-notes": [
+      {
+        "cask": "standard-notes",
+        "count": "1,056"
+      }
+    ],
+    "standing-desk": [
+      {
+        "cask": "standing-desk",
+        "count": "2"
+      }
+    ],
+    "starcraft": [
+      {
+        "cask": "starcraft",
+        "count": "148"
+      }
+    ],
+    "stargazer": [
+      {
+        "cask": "stargazer",
+        "count": "1"
+      }
+    ],
+    "stark": [
+      {
+        "cask": "stark",
+        "count": "12"
+      }
+    ],
+    "starleaf": [
+      {
+        "cask": "starleaf",
+        "count": "105"
+      }
+    ],
+    "starlogo-tng": [
+      {
+        "cask": "starlogo-tng",
+        "count": "1"
+      }
+    ],
+    "starsector": [
+      {
+        "cask": "starsector",
+        "count": "1"
+      }
+    ],
+    "startninja": [
+      {
+        "cask": "startninja",
+        "count": "55"
+      }
+    ],
+    "startninja-mycask": [
+      {
+        "cask": "startninja-mycask",
+        "count": "3"
+      }
+    ],
+    "startupizer": [
+      {
+        "cask": "startupizer",
+        "count": "42"
+      }
+    ],
+    "staruml": [
+      {
+        "cask": "staruml",
+        "count": "1,428"
+      }
+    ],
+    "station": [
+      {
+        "cask": "station",
+        "count": "3,296"
+      }
+    ],
+    "stationtv-link": [
+      {
+        "cask": "stationtv-link",
+        "count": "11"
+      }
+    ],
+    "statusfy": [
+      {
+        "cask": "statusfy",
+        "count": "81"
+      }
+    ],
+    "stay": [
+      {
+        "cask": "stay",
+        "count": "300"
+      }
+    ],
+    "steam": [
+      {
+        "cask": "steam",
+        "count": "27,022"
+      }
+    ],
+    "steam-installer": [
+      {
+        "cask": "steam-installer",
+        "count": "2"
+      }
+    ],
+    "steamcmd": [
+      {
+        "cask": "steamcmd",
+        "count": "274"
+      }
+    ],
+    "steamed-hams": [
+      {
+        "cask": "steamed-hams",
+        "count": "1"
+      }
+    ],
+    "steelseries-engine": [
+      {
+        "cask": "steelseries-engine",
+        "count": "284"
+      }
+    ],
+    "steelseries-exactmouse-tool": [
+      {
+        "cask": "steelseries-exactmouse-tool",
+        "count": "263"
+      }
+    ],
+    "steermouse": [
+      {
+        "cask": "steermouse",
+        "count": "1,442"
+      }
+    ],
+    "steinberg-cubase-pro-9v5": [
+      {
+        "cask": "steinberg-cubase-pro-9v5",
+        "count": "1"
+      }
+    ],
+    "steinberg-cubase-pro-9v5-update": [
+      {
+        "cask": "steinberg-cubase-pro-9v5-update",
+        "count": "1"
+      }
+    ],
+    "steinberg-elicenser-control-center": [
+      {
+        "cask": "steinberg-elicenser-control-center",
+        "count": "1"
+      }
+    ],
+    "steinberg-padshop": [
+      {
+        "cask": "steinberg-padshop",
+        "count": "1"
+      }
+    ],
+    "steinberg-retrologue": [
+      {
+        "cask": "steinberg-retrologue",
+        "count": "1"
+      }
+    ],
+    "steinberg-vst-classics-vol1": [
+      {
+        "cask": "steinberg-vst-classics-vol1",
+        "count": "4"
+      }
+    ],
+    "stella": [
+      {
+        "cask": "stella",
+        "count": "55"
+      }
+    ],
+    "stellarium": [
+      {
+        "cask": "stellarium",
+        "count": "895"
+      }
+    ],
+    "stepmania": [
+      {
+        "cask": "stepmania",
+        "count": "64"
+      }
+    ],
+    "stereo-tool": [
+      {
+        "cask": "stereo-tool",
+        "count": "3"
+      }
+    ],
+    "steveschow-gfxcardstatus": [
+      {
+        "cask": "steveschow-gfxcardstatus",
+        "count": "386"
+      }
+    ],
+    "stigma": [
+      {
+        "cask": "stigma",
+        "count": "5"
+      }
+    ],
+    "stm32cubeide": [
+      {
+        "cask": "stm32cubeide",
+        "count": "2"
+      }
+    ],
+    "stm32cubemx": [
+      {
+        "cask": "stm32cubemx",
+        "count": "7"
+      }
+    ],
+    "stoplight-next": [
+      {
+        "cask": "stoplight-next",
+        "count": "2"
+      }
+    ],
+    "stoplight-studio": [
+      {
+        "cask": "stoplight-studio",
+        "count": "507"
+      }
+    ],
+    "stopwatch": [
+      {
+        "cask": "stopwatch",
+        "count": "4"
+      }
+    ],
+    "storyboarder": [
+      {
+        "cask": "storyboarder",
+        "count": "90"
+      }
+    ],
+    "strange-flesh": [
+      {
+        "cask": "strange-flesh",
+        "count": "2"
+      }
+    ],
+    "strawberry": [
+      {
+        "cask": "strawberry",
+        "count": "13"
+      }
+    ],
+    "streamlabs-obs": [
+      {
+        "cask": "streamlabs-obs",
+        "count": "164"
+      }
+    ],
+    "streamlink-twitch-gui": [
+      {
+        "cask": "streamlink-twitch-gui",
+        "count": "702"
+      }
+    ],
+    "streamtools": [
+      {
+        "cask": "streamtools",
+        "count": "4"
+      }
+    ],
+    "stremio": [
+      {
+        "cask": "stremio",
+        "count": "724"
+      }
+    ],
+    "stretchly": [
+      {
+        "cask": "stretchly",
+        "count": "2,580"
+      }
+    ],
+    "stringsfile": [
+      {
+        "cask": "stringsfile",
+        "count": "67"
+      }
+    ],
+    "strongdm": [
+      {
+        "cask": "strongdm",
+        "count": "9"
+      }
+    ],
+    "strongvpn": [
+      {
+        "cask": "strongvpn",
+        "count": "2"
+      }
+    ],
+    "strongvpn-client": [
+      {
+        "cask": "strongvpn-client",
+        "count": "53"
+      }
+    ],
+    "stubbymanager": [
+      {
+        "cask": "stubbymanager",
+        "count": "80"
+      }
+    ],
+    "studio-3t": [
+      {
+        "cask": "studio-3t",
+        "count": "1,546"
+      }
+    ],
+    "studio-link": [
+      {
+        "cask": "studio-link",
+        "count": "1"
+      }
+    ],
+    "studiolinkstandalone": [
+      {
+        "cask": "studiolinkstandalone",
+        "count": "6"
+      }
+    ],
+    "suas-monitor": [
+      {
+        "cask": "suas-monitor",
+        "count": "3"
+      }
+    ],
+    "subcleaner": [
+      {
+        "cask": "subcleaner",
+        "count": "2"
+      }
+    ],
+    "subethaedit": [
+      {
+        "cask": "subethaedit",
+        "count": "165"
+      }
+    ],
+    "subgit": [
+      {
+        "cask": "subgit",
+        "count": "55"
+      }
+    ],
+    "subler": [
+      {
+        "cask": "subler",
+        "count": "1,431"
+      }
+    ],
+    "sublercli": [
+      {
+        "cask": "sublercli",
+        "count": "137"
+      }
+    ],
+    "sublime": [
+      {
+        "cask": "sublime",
+        "count": "4,097"
+      }
+    ],
+    "sublime-merge": [
+      {
+        "cask": "sublime-merge",
+        "count": "4,273"
+      }
+    ],
+    "sublime-merge-dev": [
+      {
+        "cask": "sublime-merge-dev",
+        "count": "111"
+      }
+    ],
+    "sublime-text": [
+      {
+        "cask": "sublime-text",
+        "count": "63,707"
+      }
+    ],
+    "sublime-text-3176": [
+      {
+        "cask": "sublime-text-3176",
+        "count": "1"
+      }
+    ],
+    "sublime-text-3200": [
+      {
+        "cask": "sublime-text-3200",
+        "count": "1"
+      }
+    ],
+    "sublime-text-dev": [
+      {
+        "cask": "sublime-text-dev",
+        "count": "530"
+      }
+    ],
+    "sublime-text2": [
+      {
+        "cask": "sublime-text2",
+        "count": "833"
+      }
+    ],
+    "subnetcalc": [
+      {
+        "cask": "subnetcalc",
+        "count": "100"
+      }
+    ],
+    "subsmarine": [
+      {
+        "cask": "subsmarine",
+        "count": "29"
+      }
+    ],
+    "subsurface": [
+      {
+        "cask": "subsurface",
+        "count": "77"
+      }
+    ],
+    "subtitle-master": [
+      {
+        "cask": "subtitle-master",
+        "count": "76"
+      }
+    ],
+    "subtitles": [
+      {
+        "cask": "subtitles",
+        "count": "158"
+      }
+    ],
+    "subtools": [
+      {
+        "cask": "subtools",
+        "count": "49"
+      }
+    ],
+    "suitcase-fusion": [
+      {
+        "cask": "suitcase-fusion",
+        "count": "42"
+      }
+    ],
+    "sunlogincontrol": [
+      {
+        "cask": "sunlogincontrol",
+        "count": "212"
+      }
+    ],
+    "sunsama": [
+      {
+        "cask": "sunsama",
+        "count": "19"
+      }
+    ],
+    "sunvox": [
+      {
+        "cask": "sunvox",
+        "count": "80"
+      }
+    ],
+    "superbeam": [
+      {
+        "cask": "superbeam",
+        "count": "54"
+      }
+    ],
+    "supercollider": [
+      {
+        "cask": "supercollider",
+        "count": "933"
+      }
+    ],
+    "superduper": [
+      {
+        "cask": "superduper",
+        "count": "2,136"
+      }
+    ],
+    "superhuman": [
+      {
+        "cask": "superhuman",
+        "count": "242"
+      }
+    ],
+    "supermjograph": [
+      {
+        "cask": "supermjograph",
+        "count": "6"
+      }
+    ],
+    "superproductivity": [
+      {
+        "cask": "superproductivity",
+        "count": "382"
+      }
+    ],
+    "supersync": [
+      {
+        "cask": "supersync",
+        "count": "13"
+      }
+    ],
+    "supertuxkart": [
+      {
+        "cask": "supertuxkart",
+        "count": "293"
+      }
+    ],
+    "supraudit": [
+      {
+        "cask": "supraudit",
+        "count": "3"
+      }
+    ],
+    "surfeasy-vpn": [
+      {
+        "cask": "surfeasy-vpn",
+        "count": "22"
+      }
+    ],
+    "surge": [
+      {
+        "cask": "surge",
+        "count": "899"
+      }
+    ],
+    "surge-synthesizer": [
+      {
+        "cask": "surge-synthesizer",
+        "count": "619"
+      }
+    ],
+    "surge2": [
+      {
+        "cask": "surge2",
+        "count": "14"
+      }
+    ],
+    "sus-inspector": [
+      {
+        "cask": "sus-inspector",
+        "count": "12"
+      }
+    ],
+    "suspicious-package": [
+      {
+        "cask": "suspicious-package",
+        "count": "15,927"
+      }
+    ],
+    "suunto-moveslink": [
+      {
+        "cask": "suunto-moveslink",
+        "count": "9"
+      }
+    ],
+    "suunto-moveslink2": [
+      {
+        "cask": "suunto-moveslink2",
+        "count": "34"
+      }
+    ],
+    "svgcleaner": [
+      {
+        "cask": "svgcleaner",
+        "count": "263"
+      }
+    ],
+    "svnx": [
+      {
+        "cask": "svnx",
+        "count": "841"
+      }
+    ],
+    "swannview-link": [
+      {
+        "cask": "swannview-link",
+        "count": "1"
+      }
+    ],
+    "sweet-home3d": [
+      {
+        "cask": "sweet-home3d",
+        "count": "662"
+      }
+    ],
+    "sweet16": [
+      {
+        "cask": "sweet16",
+        "count": "1"
+      }
+    ],
+    "swift": [
+      {
+        "cask": "swift",
+        "count": "115"
+      }
+    ],
+    "swift-explorer": [
+      {
+        "cask": "swift-explorer",
+        "count": "22"
+      }
+    ],
+    "swift-publisher": [
+      {
+        "cask": "swift-publisher",
+        "count": "55"
+      }
+    ],
+    "swift-runtime": [
+      {
+        "cask": "swift-runtime",
+        "count": "2"
+      }
+    ],
+    "swift-runtime-support-for-command-line-tools": [
+      {
+        "cask": "swift-runtime-support-for-command-line-tools",
+        "count": "2"
+      }
+    ],
+    "swift-utils": [
+      {
+        "cask": "swift-utils",
+        "count": "16"
+      }
+    ],
+    "swiftdefaultappsprefpane": [
+      {
+        "cask": "swiftdefaultappsprefpane",
+        "count": "345"
+      }
+    ],
+    "swiftformat-for-xcode": [
+      {
+        "cask": "swiftformat-for-xcode",
+        "count": "1,747"
+      }
+    ],
+    "swiftpm-catalog": [
+      {
+        "cask": "swiftpm-catalog",
+        "count": "9"
+      }
+    ],
+    "swiftstack-client": [
+      {
+        "cask": "swiftstack-client",
+        "count": "24"
+      }
+    ],
+    "swiftstackclient": [
+      {
+        "cask": "swiftstackclient",
+        "count": "1"
+      }
+    ],
+    "swifty": [
+      {
+        "cask": "swifty",
+        "count": "4"
+      }
+    ],
+    "swiftybeaver": [
+      {
+        "cask": "swiftybeaver",
+        "count": "49"
+      }
+    ],
+    "swimat": [
+      {
+        "cask": "swimat",
+        "count": "2,018"
+      }
+    ],
+    "swinsian": [
+      {
+        "cask": "swinsian",
+        "count": "149"
+      }
+    ],
+    "swish": [
+      {
+        "cask": "swish",
+        "count": "295"
+      }
+    ],
+    "switch": [
+      {
+        "cask": "switch",
+        "count": "82"
+      }
+    ],
+    "switchhosts": [
+      {
+        "cask": "switchhosts",
+        "count": "3,270"
+      }
+    ],
+    "switchkey": [
+      {
+        "cask": "switchkey",
+        "count": "294"
+      }
+    ],
+    "switchresx": [
+      {
+        "cask": "switchresx",
+        "count": "1,595"
+      }
+    ],
+    "symboliclinker": [
+      {
+        "cask": "symboliclinker",
+        "count": "157"
+      }
+    ],
+    "synalyze-it-pro": [
+      {
+        "cask": "synalyze-it-pro",
+        "count": "49"
+      }
+    ],
+    "synapse-audio-dune": [
+      {
+        "cask": "synapse-audio-dune",
+        "count": "1"
+      }
+    ],
+    "sync": [
+      {
+        "cask": "sync",
+        "count": "356"
+      }
+    ],
+    "sync-my-l2p": [
+      {
+        "cask": "sync-my-l2p",
+        "count": "15"
+      }
+    ],
+    "syncmate": [
+      {
+        "cask": "syncmate",
+        "count": "132"
+      }
+    ],
+    "syncovery": [
+      {
+        "cask": "syncovery",
+        "count": "9"
+      }
+    ],
+    "syncplay": [
+      {
+        "cask": "syncplay",
+        "count": "162"
+      }
+    ],
+    "syncterm": [
+      {
+        "cask": "syncterm",
+        "count": "80"
+      }
+    ],
+    "syncthing": [
+      {
+        "cask": "syncthing",
+        "count": "2,421"
+      }
+    ],
+    "syncthing-bar": [
+      {
+        "cask": "syncthing-bar",
+        "count": "37"
+      }
+    ],
+    "syncthing-brewbar": [
+      {
+        "cask": "syncthing-brewbar",
+        "count": "13"
+      }
+    ],
+    "syncwalkman": [
+      {
+        "cask": "syncwalkman",
+        "count": "8"
+      }
+    ],
+    "synergy": [
+      {
+        "cask": "synergy",
+        "count": "3,285"
+      }
+    ],
+    "synergy-beta": [
+      {
+        "cask": "synergy-beta",
+        "count": "140"
+      }
+    ],
+    "synfigstudio": [
+      {
+        "cask": "synfigstudio",
+        "count": "165"
+      }
+    ],
+    "synology-assistant": [
+      {
+        "cask": "synology-assistant",
+        "count": "9"
+      }
+    ],
+    "synology-chat": [
+      {
+        "cask": "synology-chat",
+        "count": "76"
+      }
+    ],
+    "synology-cloud-station-backup": [
+      {
+        "cask": "synology-cloud-station-backup",
+        "count": "64"
+      }
+    ],
+    "synology-drive": [
+      {
+        "cask": "synology-drive",
+        "count": "934"
+      }
+    ],
+    "synology-drive-client": [
+      {
+        "cask": "synology-drive-client",
+        "count": "6"
+      }
+    ],
+    "synology-drive-custom": [
+      {
+        "cask": "synology-drive-custom",
+        "count": "1"
+      }
+    ],
+    "synology-note-station-client": [
+      {
+        "cask": "synology-note-station-client",
+        "count": "95"
+      }
+    ],
+    "synology-photo-station-uploader": [
+      {
+        "cask": "synology-photo-station-uploader",
+        "count": "55"
+      }
+    ],
+    "synology-surveillance-station-client": [
+      {
+        "cask": "synology-surveillance-station-client",
+        "count": "76"
+      }
+    ],
+    "synologyassistant": [
+      {
+        "cask": "synologyassistant",
+        "count": "200"
+      }
+    ],
+    "synoptico": [
+      {
+        "cask": "synoptico",
+        "count": "6"
+      }
+    ],
+    "syntax-highlight": [
+      {
+        "cask": "syntax-highlight",
+        "count": "19"
+      }
+    ],
+    "syntaxhighlight": [
+      {
+        "cask": "syntaxhighlight",
+        "count": "1"
+      }
+    ],
+    "synth1-au": [
+      {
+        "cask": "synth1-au",
+        "count": "3"
+      }
+    ],
+    "synth1-vst": [
+      {
+        "cask": "synth1-vst",
+        "count": "1"
+      }
+    ],
+    "synthesia": [
+      {
+        "cask": "synthesia",
+        "count": "116"
+      }
+    ],
+    "syrem": [
+      {
+        "cask": "syrem",
+        "count": "1"
+      }
+    ],
+    "sysdig-inspect": [
+      {
+        "cask": "sysdig-inspect",
+        "count": "85"
+      }
+    ],
+    "sysex-librarian": [
+      {
+        "cask": "sysex-librarian",
+        "count": "85"
+      }
+    ],
+    "systemupdate": [
+      {
+        "cask": "systemupdate",
+        "count": "2"
+      }
+    ],
+    "systhist": [
+      {
+        "cask": "systhist",
+        "count": "14"
+      }
+    ],
+    "t2m2": [
+      {
+        "cask": "t2m2",
+        "count": "25"
+      }
+    ],
+    "tablauncher": [
+      {
+        "cask": "tablauncher",
+        "count": "1"
+      }
+    ],
+    "table-tool": [
+      {
+        "cask": "table-tool",
+        "count": "640"
+      }
+    ],
+    "tableau": [
+      {
+        "cask": "tableau",
+        "count": "1,158"
+      }
+    ],
+    "tableau-beta": [
+      {
+        "cask": "tableau-beta",
+        "count": "1"
+      }
+    ],
+    "tableau-log-viewer": [
+      {
+        "cask": "tableau-log-viewer",
+        "count": "6"
+      }
+    ],
+    "tableau-prep": [
+      {
+        "cask": "tableau-prep",
+        "count": "142"
+      }
+    ],
+    "tableau-public": [
+      {
+        "cask": "tableau-public",
+        "count": "318"
+      }
+    ],
+    "tableau-reader": [
+      {
+        "cask": "tableau-reader",
+        "count": "136"
+      }
+    ],
+    "tableflip": [
+      {
+        "cask": "tableflip",
+        "count": "47"
+      }
+    ],
+    "tableplus": [
+      {
+        "cask": "tableplus",
+        "count": "8,346"
+      }
+    ],
+    "tableplus2": [
+      {
+        "cask": "tableplus2",
+        "count": "2"
+      }
+    ],
+    "tabula": [
+      {
+        "cask": "tabula",
+        "count": "376"
+      }
+    ],
+    "taccy": [
+      {
+        "cask": "taccy",
+        "count": "16"
+      }
+    ],
+    "tad": [
+      {
+        "cask": "tad",
+        "count": "252"
+      }
+    ],
+    "tag": [
+      {
+        "cask": "tag",
+        "count": "39"
+      }
+    ],
+    "tagaini-jisho": [
+      {
+        "cask": "tagaini-jisho",
+        "count": "6"
+      }
+    ],
+    "tagalicious": [
+      {
+        "cask": "tagalicious",
+        "count": "2"
+      }
+    ],
+    "tagger": [
+      {
+        "cask": "tagger",
+        "count": "64"
+      }
+    ],
+    "tagr": [
+      {
+        "cask": "tagr",
+        "count": "2"
+      }
+    ],
+    "tagspaces": [
+      {
+        "cask": "tagspaces",
+        "count": "169"
+      }
+    ],
+    "tal-chorus-lx": [
+      {
+        "cask": "tal-chorus-lx",
+        "count": "3"
+      }
+    ],
+    "tal-elek7ro": [
+      {
+        "cask": "tal-elek7ro",
+        "count": "1"
+      }
+    ],
+    "tal-filter": [
+      {
+        "cask": "tal-filter",
+        "count": "3"
+      }
+    ],
+    "tal-filter2": [
+      {
+        "cask": "tal-filter2",
+        "count": "3"
+      }
+    ],
+    "tal-noisemaker": [
+      {
+        "cask": "tal-noisemaker",
+        "count": "10"
+      }
+    ],
+    "tal-reverb-2": [
+      {
+        "cask": "tal-reverb-2",
+        "count": "5"
+      }
+    ],
+    "tal-reverb-3": [
+      {
+        "cask": "tal-reverb-3",
+        "count": "2"
+      }
+    ],
+    "tal-reverb-4": [
+      {
+        "cask": "tal-reverb-4",
+        "count": "2"
+      }
+    ],
+    "tal-reverb2": [
+      {
+        "cask": "tal-reverb2",
+        "count": "3"
+      }
+    ],
+    "tal-reverb3": [
+      {
+        "cask": "tal-reverb3",
+        "count": "3"
+      }
+    ],
+    "tal-reverb4": [
+      {
+        "cask": "tal-reverb4",
+        "count": "6"
+      }
+    ],
+    "tal-vocoder": [
+      {
+        "cask": "tal-vocoder",
+        "count": "5"
+      }
+    ],
+    "tales-of-majeyal": [
+      {
+        "cask": "tales-of-majeyal",
+        "count": "26"
+      }
+    ],
+    "talon": [
+      {
+        "cask": "talon",
+        "count": "35"
+      }
+    ],
+    "tandem": [
+      {
+        "cask": "tandem",
+        "count": "118"
+      }
+    ],
+    "tap": [
+      {
+        "cask": "tap",
+        "count": "204"
+      }
+    ],
+    "tapaal": [
+      {
+        "cask": "tapaal",
+        "count": "6"
+      }
+    ],
+    "task-till-dawn": [
+      {
+        "cask": "task-till-dawn",
+        "count": "2"
+      }
+    ],
+    "taskade": [
+      {
+        "cask": "taskade",
+        "count": "81"
+      }
+    ],
+    "taskexplorer": [
+      {
+        "cask": "taskexplorer",
+        "count": "477"
+      }
+    ],
+    "taskpaper": [
+      {
+        "cask": "taskpaper",
+        "count": "228"
+      }
+    ],
+    "taskpomodoro": [
+      {
+        "cask": "taskpomodoro",
+        "count": "1"
+      }
+    ],
+    "taskquor": [
+      {
+        "cask": "taskquor",
+        "count": "52"
+      }
+    ],
+    "taskwarrior-pomodoro": [
+      {
+        "cask": "taskwarrior-pomodoro",
+        "count": "352"
+      }
+    ],
+    "tastyworks": [
+      {
+        "cask": "tastyworks",
+        "count": "67"
+      }
+    ],
+    "tau": [
+      {
+        "cask": "tau",
+        "count": "33"
+      }
+    ],
+    "tbe": [
+      {
+        "cask": "tbe",
+        "count": "5"
+      }
+    ],
+    "tbs-studio": [
+      {
+        "cask": "tbs-studio",
+        "count": "16"
+      }
+    ],
+    "tc": [
+      {
+        "cask": "tc",
+        "count": "2"
+      }
+    ],
+    "tccalc": [
+      {
+        "cask": "tccalc",
+        "count": "1"
+      }
+    ],
+    "tcl": [
+      {
+        "cask": "tcl",
+        "count": "2,033"
+      }
+    ],
+    "td-agent": [
+      {
+        "cask": "td-agent",
+        "count": "305"
+      }
+    ],
+    "tdr-kotelnikov": [
+      {
+        "cask": "tdr-kotelnikov",
+        "count": "4"
+      }
+    ],
+    "tdr-nova": [
+      {
+        "cask": "tdr-nova",
+        "count": "4"
+      }
+    ],
+    "tdr-proximity": [
+      {
+        "cask": "tdr-proximity",
+        "count": "2"
+      }
+    ],
+    "tdr-vos-slickeq": [
+      {
+        "cask": "tdr-vos-slickeq",
+        "count": "4"
+      }
+    ],
+    "teacode": [
+      {
+        "cask": "teacode",
+        "count": "40"
+      }
+    ],
+    "team-lab-ball-firmware-updater": [
+      {
+        "cask": "team-lab-ball-firmware-updater",
+        "count": "2"
+      }
+    ],
+    "teambition": [
+      {
+        "cask": "teambition",
+        "count": "116"
+      }
+    ],
+    "teamdrive": [
+      {
+        "cask": "teamdrive",
+        "count": "25"
+      }
+    ],
+    "teamspeak-client": [
+      {
+        "cask": "teamspeak-client",
+        "count": "1,214"
+      }
+    ],
+    "teamspeak-server": [
+      {
+        "cask": "teamspeak-server",
+        "count": "1"
+      }
+    ],
+    "teamsql": [
+      {
+        "cask": "teamsql",
+        "count": "188"
+      }
+    ],
+    "teamviewer": [
+      {
+        "cask": "teamviewer",
+        "count": "23,646"
+      }
+    ],
+    "teamviewer-custom": [
+      {
+        "cask": "teamviewer-custom",
+        "count": "31"
+      }
+    ],
+    "teamviewer-host": [
+      {
+        "cask": "teamviewer-host",
+        "count": "427"
+      }
+    ],
+    "teamviewer-quickjoin": [
+      {
+        "cask": "teamviewer-quickjoin",
+        "count": "178"
+      }
+    ],
+    "teamviewer-quicksupport": [
+      {
+        "cask": "teamviewer-quicksupport",
+        "count": "322"
+      }
+    ],
+    "teamviewer13": [
+      {
+        "cask": "teamviewer13",
+        "count": "2"
+      }
+    ],
+    "teamviewer8": [
+      {
+        "cask": "teamviewer8",
+        "count": "4"
+      }
+    ],
+    "teamviewer_host": [
+      {
+        "cask": "teamviewer_host",
+        "count": "28"
+      }
+    ],
+    "teamviz": [
+      {
+        "cask": "teamviz",
+        "count": "1"
+      }
+    ],
+    "teamwire": [
+      {
+        "cask": "teamwire",
+        "count": "3"
+      }
+    ],
+    "teensy": [
+      {
+        "cask": "teensy",
+        "count": "247"
+      }
+    ],
+    "teeworlds": [
+      {
+        "cask": "teeworlds",
+        "count": "94"
+      }
+    ],
+    "telavox-flow": [
+      {
+        "cask": "telavox-flow",
+        "count": "15"
+      }
+    ],
+    "telegram": [
+      {
+        "cask": "telegram",
+        "count": "20,890"
+      }
+    ],
+    "telegram-alpha": [
+      {
+        "cask": "telegram-alpha",
+        "count": "197"
+      }
+    ],
+    "telegram-desktop": [
+      {
+        "cask": "telegram-desktop",
+        "count": "5,961"
+      }
+    ],
+    "telegram-desktop-dev": [
+      {
+        "cask": "telegram-desktop-dev",
+        "count": "305"
+      }
+    ],
+    "tembo": [
+      {
+        "cask": "tembo",
+        "count": "2"
+      }
+    ],
+    "tempo": [
+      {
+        "cask": "tempo",
+        "count": "20"
+      }
+    ],
+    "ten9-cli": [
+      {
+        "cask": "ten9-cli",
+        "count": "9"
+      }
+    ],
+    "tencent-lemon": [
+      {
+        "cask": "tencent-lemon",
+        "count": "1,933"
+      }
+    ],
+    "tencent-meeting": [
+      {
+        "cask": "tencent-meeting",
+        "count": "18"
+      }
+    ],
+    "tencentmeeting": [
+      {
+        "cask": "tencentmeeting",
+        "count": "1"
+      }
+    ],
+    "tenor": [
+      {
+        "cask": "tenor",
+        "count": "36"
+      }
+    ],
+    "tenvideo": [
+      {
+        "cask": "tenvideo",
+        "count": "1"
+      }
+    ],
+    "termhere": [
+      {
+        "cask": "termhere",
+        "count": "132"
+      }
+    ],
+    "terminology": [
+      {
+        "cask": "terminology",
+        "count": "289"
+      }
+    ],
+    "terminus": [
+      {
+        "cask": "terminus",
+        "count": "1,764"
+      }
+    ],
+    "termius": [
+      {
+        "cask": "termius",
+        "count": "1,464"
+      }
+    ],
+    "termius-beta": [
+      {
+        "cask": "termius-beta",
+        "count": "24"
+      }
+    ],
+    "terraform-0.10.0": [
+      {
+        "cask": "terraform-0.10.0",
+        "count": "6"
+      }
+    ],
+    "terraform-0.10.3": [
+      {
+        "cask": "terraform-0.10.3",
+        "count": "3"
+      }
+    ],
+    "terraform-0.10.4": [
+      {
+        "cask": "terraform-0.10.4",
+        "count": "1"
+      }
+    ],
+    "terraform-0.10.6": [
+      {
+        "cask": "terraform-0.10.6",
+        "count": "3"
+      }
+    ],
+    "terraform-0.10.7": [
+      {
+        "cask": "terraform-0.10.7",
+        "count": "18"
+      }
+    ],
+    "terraform-0.10.8": [
+      {
+        "cask": "terraform-0.10.8",
+        "count": "42"
+      }
+    ],
+    "terraform-0.11.0": [
+      {
+        "cask": "terraform-0.11.0",
+        "count": "20"
+      }
+    ],
+    "terraform-0.11.1": [
+      {
+        "cask": "terraform-0.11.1",
+        "count": "15"
+      }
+    ],
+    "terraform-0.11.10": [
+      {
+        "cask": "terraform-0.11.10",
+        "count": "62"
+      }
+    ],
+    "terraform-0.11.11": [
+      {
+        "cask": "terraform-0.11.11",
+        "count": "154"
+      }
+    ],
+    "terraform-0.11.12": [
+      {
+        "cask": "terraform-0.11.12",
+        "count": "40"
+      }
+    ],
+    "terraform-0.11.13": [
+      {
+        "cask": "terraform-0.11.13",
+        "count": "302"
+      }
+    ],
+    "terraform-0.11.14": [
+      {
+        "cask": "terraform-0.11.14",
+        "count": "559"
+      }
+    ],
+    "terraform-0.11.2": [
+      {
+        "cask": "terraform-0.11.2",
+        "count": "18"
+      }
+    ],
+    "terraform-0.11.3": [
+      {
+        "cask": "terraform-0.11.3",
+        "count": "119"
+      }
+    ],
+    "terraform-0.11.4": [
+      {
+        "cask": "terraform-0.11.4",
+        "count": "55"
+      }
+    ],
+    "terraform-0.11.5": [
+      {
+        "cask": "terraform-0.11.5",
+        "count": "17"
+      }
+    ],
+    "terraform-0.11.6": [
+      {
+        "cask": "terraform-0.11.6",
+        "count": "13"
+      }
+    ],
+    "terraform-0.11.7": [
+      {
+        "cask": "terraform-0.11.7",
+        "count": "132"
+      }
+    ],
+    "terraform-0.11.8": [
+      {
+        "cask": "terraform-0.11.8",
+        "count": "119"
+      }
+    ],
+    "terraform-0.11.9": [
+      {
+        "cask": "terraform-0.11.9",
+        "count": "18"
+      }
+    ],
+    "terraform-0.11.9-beta1": [
+      {
+        "cask": "terraform-0.11.9-beta1",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.0": [
+      {
+        "cask": "terraform-0.12.0",
+        "count": "153"
+      }
+    ],
+    "terraform-0.12.0-beta1": [
+      {
+        "cask": "terraform-0.12.0-beta1",
+        "count": "2"
+      }
+    ],
+    "terraform-0.12.0-beta2": [
+      {
+        "cask": "terraform-0.12.0-beta2",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.0-rc1": [
+      {
+        "cask": "terraform-0.12.0-rc1",
+        "count": "7"
+      }
+    ],
+    "terraform-0.12.1": [
+      {
+        "cask": "terraform-0.12.1",
+        "count": "97"
+      }
+    ],
+    "terraform-0.12.10": [
+      {
+        "cask": "terraform-0.12.10",
+        "count": "88"
+      }
+    ],
+    "terraform-0.12.11": [
+      {
+        "cask": "terraform-0.12.11",
+        "count": "15"
+      }
+    ],
+    "terraform-0.12.12": [
+      {
+        "cask": "terraform-0.12.12",
+        "count": "110"
+      }
+    ],
+    "terraform-0.12.13": [
+      {
+        "cask": "terraform-0.12.13",
+        "count": "123"
+      }
+    ],
+    "terraform-0.12.14": [
+      {
+        "cask": "terraform-0.12.14",
+        "count": "18"
+      }
+    ],
+    "terraform-0.12.15": [
+      {
+        "cask": "terraform-0.12.15",
+        "count": "33"
+      }
+    ],
+    "terraform-0.12.16": [
+      {
+        "cask": "terraform-0.12.16",
+        "count": "105"
+      }
+    ],
+    "terraform-0.12.17": [
+      {
+        "cask": "terraform-0.12.17",
+        "count": "63"
+      }
+    ],
+    "terraform-0.12.18": [
+      {
+        "cask": "terraform-0.12.18",
+        "count": "150"
+      }
+    ],
+    "terraform-0.12.19": [
+      {
+        "cask": "terraform-0.12.19",
+        "count": "89"
+      }
+    ],
+    "terraform-0.12.2": [
+      {
+        "cask": "terraform-0.12.2",
+        "count": "100"
+      }
+    ],
+    "terraform-0.12.20": [
+      {
+        "cask": "terraform-0.12.20",
+        "count": "168"
+      }
+    ],
+    "terraform-0.12.21": [
+      {
+        "cask": "terraform-0.12.21",
+        "count": "88"
+      }
+    ],
+    "terraform-0.12.23": [
+      {
+        "cask": "terraform-0.12.23",
+        "count": "100"
+      }
+    ],
+    "terraform-0.12.24": [
+      {
+        "cask": "terraform-0.12.24",
+        "count": "133"
+      }
+    ],
+    "terraform-0.12.3": [
+      {
+        "cask": "terraform-0.12.3",
+        "count": "84"
+      }
+    ],
+    "terraform-0.12.4": [
+      {
+        "cask": "terraform-0.12.4",
+        "count": "47"
+      }
+    ],
+    "terraform-0.12.5": [
+      {
+        "cask": "terraform-0.12.5",
+        "count": "100"
+      }
+    ],
+    "terraform-0.12.6": [
+      {
+        "cask": "terraform-0.12.6",
+        "count": "181"
+      }
+    ],
+    "terraform-0.12.7": [
+      {
+        "cask": "terraform-0.12.7",
+        "count": "100"
+      }
+    ],
+    "terraform-0.12.8": [
+      {
+        "cask": "terraform-0.12.8",
+        "count": "163"
+      }
+    ],
+    "terraform-0.12.9": [
+      {
+        "cask": "terraform-0.12.9",
+        "count": "122"
+      }
+    ],
+    "terraform-0.6.10": [
+      {
+        "cask": "terraform-0.6.10",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.11": [
+      {
+        "cask": "terraform-0.6.11",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.12": [
+      {
+        "cask": "terraform-0.6.12",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.13": [
+      {
+        "cask": "terraform-0.6.13",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.14": [
+      {
+        "cask": "terraform-0.6.14",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.15": [
+      {
+        "cask": "terraform-0.6.15",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.16": [
+      {
+        "cask": "terraform-0.6.16",
+        "count": "2"
+      }
+    ],
+    "terraform-0.6.6": [
+      {
+        "cask": "terraform-0.6.6",
+        "count": "1"
+      }
+    ],
+    "terraform-0.6.9": [
+      {
+        "cask": "terraform-0.6.9",
+        "count": "9"
+      }
+    ],
+    "terraform-0.7.0": [
+      {
+        "cask": "terraform-0.7.0",
+        "count": "1"
+      }
+    ],
+    "terraform-0.7.1": [
+      {
+        "cask": "terraform-0.7.1",
+        "count": "1"
+      }
+    ],
+    "terraform-0.7.13": [
+      {
+        "cask": "terraform-0.7.13",
+        "count": "1"
+      }
+    ],
+    "terraform-0.7.2": [
+      {
+        "cask": "terraform-0.7.2",
+        "count": "3"
+      }
+    ],
+    "terraform-0.7.4": [
+      {
+        "cask": "terraform-0.7.4",
+        "count": "3"
+      }
+    ],
+    "terraform-0.8.0": [
+      {
+        "cask": "terraform-0.8.0",
+        "count": "1"
+      }
+    ],
+    "terraform-0.8.2": [
+      {
+        "cask": "terraform-0.8.2",
+        "count": "1"
+      }
+    ],
+    "terraform-0.8.5": [
+      {
+        "cask": "terraform-0.8.5",
+        "count": "2"
+      }
+    ],
+    "terraform-0.8.6": [
+      {
+        "cask": "terraform-0.8.6",
+        "count": "1"
+      }
+    ],
+    "terraform-0.8.7": [
+      {
+        "cask": "terraform-0.8.7",
+        "count": "1"
+      }
+    ],
+    "terraform-0.8.8": [
+      {
+        "cask": "terraform-0.8.8",
+        "count": "13"
+      }
+    ],
+    "terraform-0.9.1": [
+      {
+        "cask": "terraform-0.9.1",
+        "count": "2"
+      }
+    ],
+    "terraform-0.9.11": [
+      {
+        "cask": "terraform-0.9.11",
+        "count": "5"
+      }
+    ],
+    "terraform-0.9.2": [
+      {
+        "cask": "terraform-0.9.2",
+        "count": "2"
+      }
+    ],
+    "terraform-0.9.3": [
+      {
+        "cask": "terraform-0.9.3",
+        "count": "2"
+      }
+    ],
+    "terraform-0.9.4": [
+      {
+        "cask": "terraform-0.9.4",
+        "count": "2"
+      }
+    ],
+    "terraform-0.9.5": [
+      {
+        "cask": "terraform-0.9.5",
+        "count": "3"
+      }
+    ],
+    "terraform-0.9.6": [
+      {
+        "cask": "terraform-0.9.6",
+        "count": "4"
+      }
+    ],
+    "terraform-0.9.8": [
+      {
+        "cask": "terraform-0.9.8",
+        "count": "1"
+      }
+    ],
+    "terraform-provider-ansible": [
+      {
+        "cask": "terraform-provider-ansible",
+        "count": "7"
+      }
+    ],
+    "terraform-provider-mongodbatlas": [
+      {
+        "cask": "terraform-provider-mongodbatlas",
+        "count": "12"
+      }
+    ],
+    "terraform-provider-sentry": [
+      {
+        "cask": "terraform-provider-sentry",
+        "count": "2"
+      }
+    ],
+    "terraform-provider-slack": [
+      {
+        "cask": "terraform-provider-slack",
+        "count": "4"
+      }
+    ],
+    "test": [
+      {
+        "cask": "test",
+        "count": "3"
+      }
+    ],
+    "test-formula": [
+      {
+        "cask": "test-formula",
+        "count": "5"
+      }
+    ],
+    "test-mplab": [
+      {
+        "cask": "test-mplab",
+        "count": "1"
+      }
+    ],
+    "testvpn": [
+      {
+        "cask": "testvpn",
+        "count": "2"
+      }
+    ],
+    "tex-live-utility": [
+      {
+        "cask": "tex-live-utility",
+        "count": "2,046"
+      }
+    ],
+    "texgraph": [
+      {
+        "cask": "texgraph",
+        "count": "2"
+      }
+    ],
+    "texmacs": [
+      {
+        "cask": "texmacs",
+        "count": "442"
+      }
+    ],
+    "texmaker": [
+      {
+        "cask": "texmaker",
+        "count": "3,465"
+      }
+    ],
+    "texnicle": [
+      {
+        "cask": "texnicle",
+        "count": "27"
+      }
+    ],
+    "texpad": [
+      {
+        "cask": "texpad",
+        "count": "815"
+      }
+    ],
+    "texshop": [
+      {
+        "cask": "texshop",
+        "count": "1,187"
+      }
+    ],
+    "texstudio": [
+      {
+        "cask": "texstudio",
+        "count": "3,977"
+      }
+    ],
+    "texstudio-beta": [
+      {
+        "cask": "texstudio-beta",
+        "count": "11"
+      }
+    ],
+    "textadept": [
+      {
+        "cask": "textadept",
+        "count": "91"
+      }
+    ],
+    "textbar": [
+      {
+        "cask": "textbar",
+        "count": "50"
+      }
+    ],
+    "textexpander": [
+      {
+        "cask": "textexpander",
+        "count": "950"
+      }
+    ],
+    "textexpander5": [
+      {
+        "cask": "textexpander5",
+        "count": "16"
+      }
+    ],
+    "textmate": [
+      {
+        "cask": "textmate",
+        "count": "8,791"
+      }
+    ],
+    "textmate-chapel": [
+      {
+        "cask": "textmate-chapel",
+        "count": "2"
+      }
+    ],
+    "textmate-crystal": [
+      {
+        "cask": "textmate-crystal",
+        "count": "216"
+      }
+    ],
+    "textmate-cucumber": [
+      {
+        "cask": "textmate-cucumber",
+        "count": "216"
+      }
+    ],
+    "textmate-editorconfig": [
+      {
+        "cask": "textmate-editorconfig",
+        "count": "216"
+      }
+    ],
+    "textmate-elcapitan": [
+      {
+        "cask": "textmate-elcapitan",
+        "count": "1"
+      }
+    ],
+    "textmate-elixir": [
+      {
+        "cask": "textmate-elixir",
+        "count": "216"
+      }
+    ],
+    "textmate-fish": [
+      {
+        "cask": "textmate-fish",
+        "count": "216"
+      }
+    ],
+    "textmate-glsl": [
+      {
+        "cask": "textmate-glsl",
+        "count": "216"
+      }
+    ],
+    "textmate-javascript-babel": [
+      {
+        "cask": "textmate-javascript-babel",
+        "count": "216"
+      }
+    ],
+    "textmate-javascript-eslint": [
+      {
+        "cask": "textmate-javascript-eslint",
+        "count": "216"
+      }
+    ],
+    "textmate-marko": [
+      {
+        "cask": "textmate-marko",
+        "count": "2"
+      }
+    ],
+    "textmate-onsave": [
+      {
+        "cask": "textmate-onsave",
+        "count": "216"
+      }
+    ],
+    "textmate-opencl": [
+      {
+        "cask": "textmate-opencl",
+        "count": "217"
+      }
+    ],
+    "textmate-openhab": [
+      {
+        "cask": "textmate-openhab",
+        "count": "216"
+      }
+    ],
+    "textmate-preview": [
+      {
+        "cask": "textmate-preview",
+        "count": "188"
+      }
+    ],
+    "textmate-rubocop": [
+      {
+        "cask": "textmate-rubocop",
+        "count": "216"
+      }
+    ],
+    "textmate-rust": [
+      {
+        "cask": "textmate-rust",
+        "count": "218"
+      }
+    ],
+    "textmate-solarized": [
+      {
+        "cask": "textmate-solarized",
+        "count": "217"
+      }
+    ],
+    "textricator": [
+      {
+        "cask": "textricator",
+        "count": "11"
+      }
+    ],
+    "texts": [
+      {
+        "cask": "texts",
+        "count": "44"
+      }
+    ],
+    "textsoap": [
+      {
+        "cask": "textsoap",
+        "count": "1"
+      }
+    ],
+    "textual": [
+      {
+        "cask": "textual",
+        "count": "620"
+      }
+    ],
+    "textual-beta": [
+      {
+        "cask": "textual-beta",
+        "count": "2"
+      }
+    ],
+    "texturepacker": [
+      {
+        "cask": "texturepacker",
+        "count": "175"
+      }
+    ],
+    "textwrangler": [
+      {
+        "cask": "textwrangler",
+        "count": "1"
+      }
+    ],
+    "texworks": [
+      {
+        "cask": "texworks",
+        "count": "311"
+      }
+    ],
+    "tftpserver": [
+      {
+        "cask": "tftpserver",
+        "count": "1,167"
+      }
+    ],
+    "tg-pro": [
+      {
+        "cask": "tg-pro",
+        "count": "307"
+      }
+    ],
+    "th-makerx": [
+      {
+        "cask": "th-makerx",
+        "count": "32"
+      }
+    ],
+    "thai-dict": [
+      {
+        "cask": "thai-dict",
+        "count": "5"
+      }
+    ],
+    "thai-national-fonts": [
+      {
+        "cask": "thai-national-fonts",
+        "count": "5"
+      }
+    ],
+    "the-anvil": [
+      {
+        "cask": "the-anvil",
+        "count": "2"
+      }
+    ],
+    "the-archive-browser": [
+      {
+        "cask": "the-archive-browser",
+        "count": "247"
+      }
+    ],
+    "the-battle-for-wesnoth": [
+      {
+        "cask": "the-battle-for-wesnoth",
+        "count": "161"
+      }
+    ],
+    "the-cheat": [
+      {
+        "cask": "the-cheat",
+        "count": "108"
+      }
+    ],
+    "the-clock": [
+      {
+        "cask": "the-clock",
+        "count": "66"
+      }
+    ],
+    "the-hit-list": [
+      {
+        "cask": "the-hit-list",
+        "count": "24"
+      }
+    ],
+    "the-tagger": [
+      {
+        "cask": "the-tagger",
+        "count": "53"
+      }
+    ],
+    "the-unarchiver": [
+      {
+        "cask": "the-unarchiver",
+        "count": "22,571"
+      }
+    ],
+    "the-ur-quan-masters": [
+      {
+        "cask": "the-ur-quan-masters",
+        "count": "3"
+      }
+    ],
+    "the-witness": [
+      {
+        "cask": "the-witness",
+        "count": "2"
+      }
+    ],
+    "thebrain": [
+      {
+        "cask": "thebrain",
+        "count": "138"
+      }
+    ],
+    "thedesk": [
+      {
+        "cask": "thedesk",
+        "count": "136"
+      }
+    ],
+    "themeengine": [
+      {
+        "cask": "themeengine",
+        "count": "59"
+      }
+    ],
+    "thenewplayerfree": [
+      {
+        "cask": "thenewplayerfree",
+        "count": "3"
+      }
+    ],
+    "there": [
+      {
+        "cask": "there",
+        "count": "226"
+      }
+    ],
+    "therm": [
+      {
+        "cask": "therm",
+        "count": "365"
+      }
+    ],
+    "thetube": [
+      {
+        "cask": "thetube",
+        "count": "4"
+      }
+    ],
+    "thingsmacsandboxhelper": [
+      {
+        "cask": "thingsmacsandboxhelper",
+        "count": "268"
+      }
+    ],
+    "thinkorswim": [
+      {
+        "cask": "thinkorswim",
+        "count": "327"
+      }
+    ],
+    "thisservice": [
+      {
+        "cask": "thisservice",
+        "count": "1"
+      }
+    ],
+    "thonny": [
+      {
+        "cask": "thonny",
+        "count": "372"
+      }
+    ],
+    "thonny-xxl": [
+      {
+        "cask": "thonny-xxl",
+        "count": "4"
+      }
+    ],
+    "thor": [
+      {
+        "cask": "thor",
+        "count": "29"
+      }
+    ],
+    "thorn": [
+      {
+        "cask": "thorn",
+        "count": "1"
+      }
+    ],
+    "thorn-writing": [
+      {
+        "cask": "thorn-writing",
+        "count": "3"
+      }
+    ],
+    "thought-train": [
+      {
+        "cask": "thought-train",
+        "count": "14"
+      }
+    ],
+    "threads": [
+      {
+        "cask": "threads",
+        "count": "20"
+      }
+    ],
+    "thrustshell": [
+      {
+        "cask": "thrustshell",
+        "count": "1"
+      }
+    ],
+    "thumbsup": [
+      {
+        "cask": "thumbsup",
+        "count": "24"
+      }
+    ],
+    "thunder": [
+      {
+        "cask": "thunder",
+        "count": "4,621"
+      }
+    ],
+    "thunder301": [
+      {
+        "cask": "thunder301",
+        "count": "4"
+      }
+    ],
+    "thunderbird": [
+      {
+        "cask": "thunderbird",
+        "count": "9,587"
+      }
+    ],
+    "thunderbird-beta": [
+      {
+        "cask": "thunderbird-beta",
+        "count": "153"
+      }
+    ],
+    "thunderbird-daily": [
+      {
+        "cask": "thunderbird-daily",
+        "count": "38"
+      }
+    ],
+    "thyme": [
+      {
+        "cask": "thyme",
+        "count": "147"
+      }
+    ],
+    "ti-connect-ce": [
+      {
+        "cask": "ti-connect-ce",
+        "count": "71"
+      }
+    ],
+    "tiat": [
+      {
+        "cask": "tiat",
+        "count": "11"
+      }
+    ],
+    "tibco-jaspersoft-studio": [
+      {
+        "cask": "tibco-jaspersoft-studio",
+        "count": "470"
+      }
+    ],
+    "tickeys": [
+      {
+        "cask": "tickeys",
+        "count": "522"
+      }
+    ],
+    "ticktick": [
+      {
+        "cask": "ticktick",
+        "count": "1,396"
+      }
+    ],
+    "tidal": [
+      {
+        "cask": "tidal",
+        "count": "1,330"
+      }
+    ],
+    "tiddly": [
+      {
+        "cask": "tiddly",
+        "count": "107"
+      }
+    ],
+    "tidepool-uploader": [
+      {
+        "cask": "tidepool-uploader",
+        "count": "6"
+      }
+    ],
+    "tidy-up": [
+      {
+        "cask": "tidy-up",
+        "count": "1"
+      }
+    ],
+    "tifig": [
+      {
+        "cask": "tifig",
+        "count": "65"
+      }
+    ],
+    "tiger-trade": [
+      {
+        "cask": "tiger-trade",
+        "count": "39"
+      }
+    ],
+    "tigervnc-viewer": [
+      {
+        "cask": "tigervnc-viewer",
+        "count": "6,111"
+      }
+    ],
+    "tigervpn": [
+      {
+        "cask": "tigervpn",
+        "count": "39"
+      }
+    ],
+    "tikz-editor": [
+      {
+        "cask": "tikz-editor",
+        "count": "209"
+      }
+    ],
+    "tikzit": [
+      {
+        "cask": "tikzit",
+        "count": "199"
+      }
+    ],
+    "tiled": [
+      {
+        "cask": "tiled",
+        "count": "419"
+      }
+    ],
+    "tiles": [
+      {
+        "cask": "tiles",
+        "count": "442"
+      }
+    ],
+    "tilio": [
+      {
+        "cask": "tilio",
+        "count": "2"
+      }
+    ],
+    "tilt-functions": [
+      {
+        "cask": "tilt-functions",
+        "count": "8"
+      }
+    ],
+    "tilt_functions": [
+      {
+        "cask": "tilt_functions",
+        "count": "1"
+      }
+    ],
+    "time-lapse-assembler": [
+      {
+        "cask": "time-lapse-assembler",
+        "count": "50"
+      }
+    ],
+    "time-out": [
+      {
+        "cask": "time-out",
+        "count": "640"
+      }
+    ],
+    "time-sink": [
+      {
+        "cask": "time-sink",
+        "count": "26"
+      }
+    ],
+    "time-tracker": [
+      {
+        "cask": "time-tracker",
+        "count": "27"
+      }
+    ],
+    "timecamp": [
+      {
+        "cask": "timecamp",
+        "count": "24"
+      }
+    ],
+    "timelane": [
+      {
+        "cask": "timelane",
+        "count": "4"
+      }
+    ],
+    "timely": [
+      {
+        "cask": "timely",
+        "count": "54"
+      }
+    ],
+    "timemachineeditor": [
+      {
+        "cask": "timemachineeditor",
+        "count": "864"
+      }
+    ],
+    "timemator": [
+      {
+        "cask": "timemator",
+        "count": "13"
+      }
+    ],
+    "timeme": [
+      {
+        "cask": "timeme",
+        "count": "1"
+      }
+    ],
+    "timer": [
+      {
+        "cask": "timer",
+        "count": "400"
+      }
+    ],
+    "timestamp": [
+      {
+        "cask": "timestamp",
+        "count": "167"
+      }
+    ],
+    "timeular": [
+      {
+        "cask": "timeular",
+        "count": "80"
+      }
+    ],
+    "timing": [
+      {
+        "cask": "timing",
+        "count": "516"
+      }
+    ],
+    "timings": [
+      {
+        "cask": "timings",
+        "count": "32"
+      }
+    ],
+    "tinderbox": [
+      {
+        "cask": "tinderbox",
+        "count": "68"
+      }
+    ],
+    "ting-en": [
+      {
+        "cask": "ting-en",
+        "count": "1"
+      }
+    ],
+    "ting-es": [
+      {
+        "cask": "ting-es",
+        "count": "1"
+      }
+    ],
+    "ting-fr": [
+      {
+        "cask": "ting-fr",
+        "count": "1"
+      }
+    ],
+    "tinkerwell": [
+      {
+        "cask": "tinkerwell",
+        "count": "24"
+      }
+    ],
+    "tiny-player": [
+      {
+        "cask": "tiny-player",
+        "count": "100"
+      }
+    ],
+    "tinymediamanager": [
+      {
+        "cask": "tinymediamanager",
+        "count": "323"
+      }
+    ],
+    "tinypng4mac": [
+      {
+        "cask": "tinypng4mac",
+        "count": "663"
+      }
+    ],
+    "tinyumbrella": [
+      {
+        "cask": "tinyumbrella",
+        "count": "19"
+      }
+    ],
+    "tipp10": [
+      {
+        "cask": "tipp10",
+        "count": "125"
+      }
+    ],
+    "tiptoi-manager": [
+      {
+        "cask": "tiptoi-manager",
+        "count": "54"
+      }
+    ],
+    "tla-plus-toolbox": [
+      {
+        "cask": "tla-plus-toolbox",
+        "count": "589"
+      }
+    ],
+    "tla-plus-toolbox-nightly": [
+      {
+        "cask": "tla-plus-toolbox-nightly",
+        "count": "37"
+      }
+    ],
+    "tlv": [
+      {
+        "cask": "tlv",
+        "count": "1"
+      }
+    ],
+    "tn3270-x": [
+      {
+        "cask": "tn3270-x",
+        "count": "122"
+      }
+    ],
+    "tn5250": [
+      {
+        "cask": "tn5250",
+        "count": "5"
+      }
+    ],
+    "tnefs-enough": [
+      {
+        "cask": "tnefs-enough",
+        "count": "208"
+      }
+    ],
+    "tnoodle": [
+      {
+        "cask": "tnoodle",
+        "count": "1"
+      }
+    ],
+    "to": [
+      {
+        "cask": "to",
+        "count": "2"
+      }
+    ],
+    "toast-feature-flags": [
+      {
+        "cask": "toast-feature-flags",
+        "count": "3"
+      }
+    ],
+    "today-scripts": [
+      {
+        "cask": "today-scripts",
+        "count": "57"
+      }
+    ],
+    "todometer": [
+      {
+        "cask": "todometer",
+        "count": "48"
+      }
+    ],
+    "todos": [
+      {
+        "cask": "todos",
+        "count": "41"
+      }
+    ],
+    "todotxt": [
+      {
+        "cask": "todotxt",
+        "count": "209"
+      }
+    ],
+    "todour": [
+      {
+        "cask": "todour",
+        "count": "43"
+      }
+    ],
+    "tofu": [
+      {
+        "cask": "tofu",
+        "count": "30"
+      }
+    ],
+    "toggl": [
+      {
+        "cask": "toggl",
+        "count": "2,625"
+      }
+    ],
+    "toggl-beta": [
+      {
+        "cask": "toggl-beta",
+        "count": "23"
+      }
+    ],
+    "toggl-dev": [
+      {
+        "cask": "toggl-dev",
+        "count": "24"
+      }
+    ],
+    "toggl@7.4.373": [
+      {
+        "cask": "toggl@7.4.373",
+        "count": "1"
+      }
+    ],
+    "tomahawk": [
+      {
+        "cask": "tomahawk",
+        "count": "1"
+      }
+    ],
+    "tomighty": [
+      {
+        "cask": "tomighty",
+        "count": "472"
+      }
+    ],
+    "tomtom-mydrive-connect": [
+      {
+        "cask": "tomtom-mydrive-connect",
+        "count": "48"
+      }
+    ],
+    "tomtom-sports-connect": [
+      {
+        "cask": "tomtom-sports-connect",
+        "count": "24"
+      }
+    ],
+    "toneprint": [
+      {
+        "cask": "toneprint",
+        "count": "4"
+      }
+    ],
+    "tonespace": [
+      {
+        "cask": "tonespace",
+        "count": "1"
+      }
+    ],
+    "tonespace-au": [
+      {
+        "cask": "tonespace-au",
+        "count": "1"
+      }
+    ],
+    "tonespace-vst": [
+      {
+        "cask": "tonespace-vst",
+        "count": "1"
+      }
+    ],
+    "tongbu": [
+      {
+        "cask": "tongbu",
+        "count": "69"
+      }
+    ],
+    "tonido": [
+      {
+        "cask": "tonido",
+        "count": "3"
+      }
+    ],
+    "toontown-rewritten": [
+      {
+        "cask": "toontown-rewritten",
+        "count": "26"
+      }
+    ],
+    "topcat": [
+      {
+        "cask": "topcat",
+        "count": "43"
+      }
+    ],
+    "toptracker": [
+      {
+        "cask": "toptracker",
+        "count": "54"
+      }
+    ],
+    "tor-browser": [
+      {
+        "cask": "tor-browser",
+        "count": "14,131"
+      }
+    ],
+    "tor-browser-alpha": [
+      {
+        "cask": "tor-browser-alpha",
+        "count": "143"
+      }
+    ],
+    "tor-browser-test": [
+      {
+        "cask": "tor-browser-test",
+        "count": "1"
+      }
+    ],
+    "torguard": [
+      {
+        "cask": "torguard",
+        "count": "341"
+      }
+    ],
+    "torrent-file-editor": [
+      {
+        "cask": "torrent-file-editor",
+        "count": "75"
+      }
+    ],
+    "tortoisehg": [
+      {
+        "cask": "tortoisehg",
+        "count": "525"
+      }
+    ],
+    "torustrooper": [
+      {
+        "cask": "torustrooper",
+        "count": "1"
+      }
+    ],
+    "totalfinder": [
+      {
+        "cask": "totalfinder",
+        "count": "4"
+      }
+    ],
+    "totals": [
+      {
+        "cask": "totals",
+        "count": "1"
+      }
+    ],
+    "totalspaces": [
+      {
+        "cask": "totalspaces",
+        "count": "7"
+      }
+    ],
+    "touch-bar-pong": [
+      {
+        "cask": "touch-bar-pong",
+        "count": "104"
+      }
+    ],
+    "touch-bar-simulator": [
+      {
+        "cask": "touch-bar-simulator",
+        "count": "823"
+      }
+    ],
+    "touchbarserver": [
+      {
+        "cask": "touchbarserver",
+        "count": "7"
+      }
+    ],
+    "touchdesigner": [
+      {
+        "cask": "touchdesigner",
+        "count": "136"
+      }
+    ],
+    "touche": [
+      {
+        "cask": "touche",
+        "count": "17"
+      }
+    ],
+    "touchosc-bridge": [
+      {
+        "cask": "touchosc-bridge",
+        "count": "35"
+      }
+    ],
+    "touchosc-editor": [
+      {
+        "cask": "touchosc-editor",
+        "count": "57"
+      }
+    ],
+    "touchswitcher": [
+      {
+        "cask": "touchswitcher",
+        "count": "211"
+      }
+    ],
+    "tower": [
+      {
+        "cask": "tower",
+        "count": "3,119"
+      }
+    ],
+    "tower-beta": [
+      {
+        "cask": "tower-beta",
+        "count": "1"
+      }
+    ],
+    "tower2": [
+      {
+        "cask": "tower2",
+        "count": "329"
+      }
+    ],
+    "towerim-tower": [
+      {
+        "cask": "towerim-tower",
+        "count": "3"
+      }
+    ],
+    "townwifi": [
+      {
+        "cask": "townwifi",
+        "count": "71"
+      }
+    ],
+    "tpa1": [
+      {
+        "cask": "tpa1",
+        "count": "2"
+      }
+    ],
+    "tracer": [
+      {
+        "cask": "tracer",
+        "count": "3"
+      }
+    ],
+    "track-o-bot": [
+      {
+        "cask": "track-o-bot",
+        "count": "2"
+      }
+    ],
+    "tracker-osp": [
+      {
+        "cask": "tracker-osp",
+        "count": "2"
+      }
+    ],
+    "trackereditor": [
+      {
+        "cask": "trackereditor",
+        "count": "3"
+      }
+    ],
+    "tracks-live": [
+      {
+        "cask": "tracks-live",
+        "count": "5"
+      }
+    ],
+    "trader-workstation": [
+      {
+        "cask": "trader-workstation",
+        "count": "72"
+      }
+    ],
+    "trader-workstation-latest": [
+      {
+        "cask": "trader-workstation-latest",
+        "count": "3"
+      }
+    ],
+    "traderpro": [
+      {
+        "cask": "traderpro",
+        "count": "2"
+      }
+    ],
+    "trailer": [
+      {
+        "cask": "trailer",
+        "count": "402"
+      }
+    ],
+    "trailrunner": [
+      {
+        "cask": "trailrunner",
+        "count": "16"
+      }
+    ],
+    "trainerroad": [
+      {
+        "cask": "trainerroad",
+        "count": "34"
+      }
+    ],
+    "tranquility": [
+      {
+        "cask": "tranquility",
+        "count": "23"
+      }
+    ],
+    "transcribe": [
+      {
+        "cask": "transcribe",
+        "count": "1"
+      }
+    ],
+    "transfer": [
+      {
+        "cask": "transfer",
+        "count": "2"
+      }
+    ],
+    "transfert": [
+      {
+        "cask": "transfert",
+        "count": "1"
+      }
+    ],
+    "transformant": [
+      {
+        "cask": "transformant",
+        "count": "2"
+      }
+    ],
+    "translator": [
+      {
+        "cask": "translator",
+        "count": "3"
+      }
+    ],
+    "transmission": [
+      {
+        "cask": "transmission",
+        "count": "24,746"
+      }
+    ],
+    "transmission-nightly": [
+      {
+        "cask": "transmission-nightly",
+        "count": "194"
+      }
+    ],
+    "transmission-remote-gui": [
+      {
+        "cask": "transmission-remote-gui",
+        "count": "3,190"
+      }
+    ],
+    "transmit": [
+      {
+        "cask": "transmit",
+        "count": "6,306"
+      }
+    ],
+    "transmit-disk": [
+      {
+        "cask": "transmit-disk",
+        "count": "81"
+      }
+    ],
+    "transmit4": [
+      {
+        "cask": "transmit4",
+        "count": "132"
+      }
+    ],
+    "transocks": [
+      {
+        "cask": "transocks",
+        "count": "20"
+      }
+    ],
+    "transtype": [
+      {
+        "cask": "transtype",
+        "count": "21"
+      }
+    ],
+    "trash-it": [
+      {
+        "cask": "trash-it",
+        "count": "33"
+      }
+    ],
+    "traverse": [
+      {
+        "cask": "traverse",
+        "count": "1"
+      }
+    ],
+    "trayplay": [
+      {
+        "cask": "trayplay",
+        "count": "34"
+      }
+    ],
+    "treemaker": [
+      {
+        "cask": "treemaker",
+        "count": "5"
+      }
+    ],
+    "treesheets": [
+      {
+        "cask": "treesheets",
+        "count": "68"
+      }
+    ],
+    "tresorit": [
+      {
+        "cask": "tresorit",
+        "count": "930"
+      }
+    ],
+    "trezor-bridge": [
+      {
+        "cask": "trezor-bridge",
+        "count": "110"
+      }
+    ],
+    "tribler": [
+      {
+        "cask": "tribler",
+        "count": "61"
+      }
+    ],
+    "tricent": [
+      {
+        "cask": "tricent",
+        "count": "5"
+      }
+    ],
+    "trickster": [
+      {
+        "cask": "trickster",
+        "count": "3"
+      }
+    ],
+    "trilium-notes": [
+      {
+        "cask": "trilium-notes",
+        "count": "324"
+      }
+    ],
+    "trillian-beta": [
+      {
+        "cask": "trillian-beta",
+        "count": "2"
+      }
+    ],
+    "trim-enabler": [
+      {
+        "cask": "trim-enabler",
+        "count": "116"
+      }
+    ],
+    "trinity": [
+      {
+        "cask": "trinity",
+        "count": "136"
+      }
+    ],
+    "triple-cheese": [
+      {
+        "cask": "triple-cheese",
+        "count": "5"
+      }
+    ],
+    "triplecheese": [
+      {
+        "cask": "triplecheese",
+        "count": "12"
+      }
+    ],
+    "tripmode": [
+      {
+        "cask": "tripmode",
+        "count": "716"
+      }
+    ],
+    "tritag": [
+      {
+        "cask": "tritag",
+        "count": "1"
+      }
+    ],
+    "trojan-qt5": [
+      {
+        "cask": "trojan-qt5",
+        "count": "30"
+      }
+    ],
+    "trolcommander": [
+      {
+        "cask": "trolcommander",
+        "count": "121"
+      }
+    ],
+    "tropy": [
+      {
+        "cask": "tropy",
+        "count": "26"
+      }
+    ],
+    "truecrypt": [
+      {
+        "cask": "truecrypt",
+        "count": "36"
+      }
+    ],
+    "truefire": [
+      {
+        "cask": "truefire",
+        "count": "7"
+      }
+    ],
+    "trufont": [
+      {
+        "cask": "trufont",
+        "count": "30"
+      }
+    ],
+    "ts999": [
+      {
+        "cask": "ts999",
+        "count": "2"
+      }
+    ],
+    "tsb1": [
+      {
+        "cask": "tsb1",
+        "count": "2"
+      }
+    ],
+    "tsmuxergui": [
+      {
+        "cask": "tsmuxergui",
+        "count": "5"
+      }
+    ],
+    "ttscoff-mmd-quicklook": [
+      {
+        "cask": "ttscoff-mmd-quicklook",
+        "count": "144"
+      }
+    ],
+    "tuck": [
+      {
+        "cask": "tuck",
+        "count": "24"
+      }
+    ],
+    "tunefish3": [
+      {
+        "cask": "tunefish3",
+        "count": "1"
+      }
+    ],
+    "tunefish4": [
+      {
+        "cask": "tunefish4",
+        "count": "2"
+      }
+    ],
+    "tuneinstructor": [
+      {
+        "cask": "tuneinstructor",
+        "count": "13"
+      }
+    ],
+    "tuneskit-m4v-converter": [
+      {
+        "cask": "tuneskit-m4v-converter",
+        "count": "46"
+      }
+    ],
+    "tunnelbear": [
+      {
+        "cask": "tunnelbear",
+        "count": "1,640"
+      }
+    ],
+    "tunnelblick": [
+      {
+        "cask": "tunnelblick",
+        "count": "30,480"
+      }
+    ],
+    "tunnelblick-beta": [
+      {
+        "cask": "tunnelblick-beta",
+        "count": "316"
+      }
+    ],
+    "tunnelblick-custom": [
+      {
+        "cask": "tunnelblick-custom",
+        "count": "1"
+      }
+    ],
+    "tuntap": [
+      {
+        "cask": "tuntap",
+        "count": "4,494"
+      }
+    ],
+    "tuple": [
+      {
+        "cask": "tuple",
+        "count": "395"
+      }
+    ],
+    "turbo-boost-switcher": [
+      {
+        "cask": "turbo-boost-switcher",
+        "count": "1,254"
+      }
+    ],
+    "turbo-boost-switcher-pro": [
+      {
+        "cask": "turbo-boost-switcher-pro",
+        "count": "1"
+      }
+    ],
+    "turbovnc-viewer": [
+      {
+        "cask": "turbovnc-viewer",
+        "count": "711"
+      }
+    ],
+    "turtl": [
+      {
+        "cask": "turtl",
+        "count": "151"
+      }
+    ],
+    "tusk": [
+      {
+        "cask": "tusk",
+        "count": "270"
+      }
+    ],
+    "tutanota": [
+      {
+        "cask": "tutanota",
+        "count": "190"
+      }
+    ],
+    "tuxera-ntfs": [
+      {
+        "cask": "tuxera-ntfs",
+        "count": "772"
+      }
+    ],
+    "tuxguitar": [
+      {
+        "cask": "tuxguitar",
+        "count": "577"
+      }
+    ],
+    "tv-browser": [
+      {
+        "cask": "tv-browser",
+        "count": "78"
+      }
+    ],
+    "tvrenamer": [
+      {
+        "cask": "tvrenamer",
+        "count": "56"
+      }
+    ],
+    "tvshows": [
+      {
+        "cask": "tvshows",
+        "count": "1"
+      }
+    ],
+    "tweet-tray": [
+      {
+        "cask": "tweet-tray",
+        "count": "36"
+      }
+    ],
+    "tweetbot": [
+      {
+        "cask": "tweetbot",
+        "count": "259"
+      }
+    ],
+    "tweeten": [
+      {
+        "cask": "tweeten",
+        "count": "298"
+      }
+    ],
+    "twelf": [
+      {
+        "cask": "twelf",
+        "count": "12"
+      }
+    ],
+    "twelvesouth-bassjump": [
+      {
+        "cask": "twelvesouth-bassjump",
+        "count": "2"
+      }
+    ],
+    "twine": [
+      {
+        "cask": "twine",
+        "count": "809"
+      }
+    ],
+    "twist": [
+      {
+        "cask": "twist",
+        "count": "184"
+      }
+    ],
+    "twitch": [
+      {
+        "cask": "twitch",
+        "count": "1,916"
+      }
+    ],
+    "twitter-mini": [
+      {
+        "cask": "twitter-mini",
+        "count": "2"
+      }
+    ],
+    "twitterrific": [
+      {
+        "cask": "twitterrific",
+        "count": "7"
+      }
+    ],
+    "twonkyserver": [
+      {
+        "cask": "twonkyserver",
+        "count": "11"
+      }
+    ],
+    "tyke": [
+      {
+        "cask": "tyke",
+        "count": "145"
+      }
+    ],
+    "typeface": [
+      {
+        "cask": "typeface",
+        "count": "44"
+      }
+    ],
+    "typeit4me": [
+      {
+        "cask": "typeit4me",
+        "count": "40"
+      }
+    ],
+    "typinator": [
+      {
+        "cask": "typinator",
+        "count": "244"
+      }
+    ],
+    "typora": [
+      {
+        "cask": "typora",
+        "count": "16,527"
+      }
+    ],
+    "tyrelln6": [
+      {
+        "cask": "tyrelln6",
+        "count": "4"
+      }
+    ],
+    "tysimulator": [
+      {
+        "cask": "tysimulator",
+        "count": "17"
+      }
+    ],
+    "u-he-mfm2": [
+      {
+        "cask": "u-he-mfm2",
+        "count": "1"
+      }
+    ],
+    "u-he-satin": [
+      {
+        "cask": "u-he-satin",
+        "count": "1"
+      }
+    ],
+    "u-he-uhbik": [
+      {
+        "cask": "u-he-uhbik",
+        "count": "1"
+      }
+    ],
+    "u-he-zebra": [
+      {
+        "cask": "u-he-zebra",
+        "count": "1"
+      }
+    ],
+    "ubar": [
+      {
+        "cask": "ubar",
+        "count": "234"
+      }
+    ],
+    "uber-network-fuser": [
+      {
+        "cask": "uber-network-fuser",
+        "count": "1"
+      }
+    ],
+    "uberconference": [
+      {
+        "cask": "uberconference",
+        "count": "3"
+      }
+    ],
+    "ubersicht": [
+      {
+        "cask": "ubersicht",
+        "count": "1,670"
+      }
+    ],
+    "ubiquiti-unifi-controller": [
+      {
+        "cask": "ubiquiti-unifi-controller",
+        "count": "769"
+      }
+    ],
+    "ubiquiti-unifi-controller-lts": [
+      {
+        "cask": "ubiquiti-unifi-controller-lts",
+        "count": "45"
+      }
+    ],
+    "uc-one": [
+      {
+        "cask": "uc-one",
+        "count": "6"
+      }
+    ],
+    "udeler": [
+      {
+        "cask": "udeler",
+        "count": "233"
+      }
+    ],
+    "udig": [
+      {
+        "cask": "udig",
+        "count": "32"
+      }
+    ],
+    "ueli": [
+      {
+        "cask": "ueli",
+        "count": "31"
+      }
+    ],
+    "ugene": [
+      {
+        "cask": "ugene",
+        "count": "2"
+      }
+    ],
+    "uhe-diva": [
+      {
+        "cask": "uhe-diva",
+        "count": "4"
+      }
+    ],
+    "uhe-zebra": [
+      {
+        "cask": "uhe-zebra",
+        "count": "5"
+      }
+    ],
+    "uhk-agent": [
+      {
+        "cask": "uhk-agent",
+        "count": "84"
+      }
+    ],
+    "ui-browser": [
+      {
+        "cask": "ui-browser",
+        "count": "83"
+      }
+    ],
+    "ui-desktop": [
+      {
+        "cask": "ui-desktop",
+        "count": "2"
+      }
+    ],
+    "uielementinspector": [
+      {
+        "cask": "uielementinspector",
+        "count": "7"
+      }
+    ],
+    "ukelele": [
+      {
+        "cask": "ukelele",
+        "count": "867"
+      }
+    ],
+    "ukrainian-typographic-keyboard": [
+      {
+        "cask": "ukrainian-typographic-keyboard",
+        "count": "22"
+      }
+    ],
+    "ukrainian-unicode-layout": [
+      {
+        "cask": "ukrainian-unicode-layout",
+        "count": "87"
+      }
+    ],
+    "ulbow": [
+      {
+        "cask": "ulbow",
+        "count": "9"
+      }
+    ],
+    "ultimaker-cura": [
+      {
+        "cask": "ultimaker-cura",
+        "count": "2,120"
+      }
+    ],
+    "ultimate": [
+      {
+        "cask": "ultimate",
+        "count": "23"
+      }
+    ],
+    "ultimate-control": [
+      {
+        "cask": "ultimate-control",
+        "count": "9"
+      }
+    ],
+    "ultrastardeluxe": [
+      {
+        "cask": "ultrastardeluxe",
+        "count": "63"
+      }
+    ],
+    "umbrella": [
+      {
+        "cask": "umbrella",
+        "count": "1"
+      }
+    ],
+    "uncolored": [
+      {
+        "cask": "uncolored",
+        "count": "17"
+      }
+    ],
+    "uncrustifyx": [
+      {
+        "cask": "uncrustifyx",
+        "count": "39"
+      }
+    ],
+    "undercover": [
+      {
+        "cask": "undercover",
+        "count": "7"
+      }
+    ],
+    "understand": [
+      {
+        "cask": "understand",
+        "count": "225"
+      }
+    ],
+    "unetbootin": [
+      {
+        "cask": "unetbootin",
+        "count": "7,270"
+      }
+    ],
+    "uni": [
+      {
+        "cask": "uni",
+        "count": "13"
+      }
+    ],
+    "unicodechecker": [
+      {
+        "cask": "unicodechecker",
+        "count": "286"
+      }
+    ],
+    "uniconverter": [
+      {
+        "cask": "uniconverter",
+        "count": "144"
+      }
+    ],
+    "unified-remote": [
+      {
+        "cask": "unified-remote",
+        "count": "240"
+      }
+    ],
+    "unil-instant-support": [
+      {
+        "cask": "unil-instant-support",
+        "count": "3"
+      }
+    ],
+    "unil-inv": [
+      {
+        "cask": "unil-inv",
+        "count": "1"
+      }
+    ],
+    "uninstallpkg": [
+      {
+        "cask": "uninstallpkg",
+        "count": "508"
+      }
+    ],
+    "unison": [
+      {
+        "cask": "unison",
+        "count": "1,724"
+      }
+    ],
+    "unison248": [
+      {
+        "cask": "unison248",
+        "count": "6"
+      }
+    ],
+    "unite": [
+      {
+        "cask": "unite",
+        "count": "58"
+      }
+    ],
+    "unity": [
+      {
+        "cask": "unity",
+        "count": "14,621"
+      }
+    ],
+    "unity-2017-4-1f1": [
+      {
+        "cask": "unity-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-2018-2-5f1": [
+      {
+        "cask": "unity-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-2018-4-8f1": [
+      {
+        "cask": "unity-2018-4-8f1",
+        "count": "2"
+      }
+    ],
+    "unity-2019.3.4f1": [
+      {
+        "cask": "unity-2019.3.4f1",
+        "count": "5"
+      }
+    ],
+    "unity-5-6-6f2": [
+      {
+        "cask": "unity-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor": [
+      {
+        "cask": "unity-android-support-for-editor",
+        "count": "189"
+      }
+    ],
+    "unity-android-support-for-editor-2017-4-1f1": [
+      {
+        "cask": "unity-android-support-for-editor-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor-2018-2-5f1": [
+      {
+        "cask": "unity-android-support-for-editor-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor-5-6-6f2": [
+      {
+        "cask": "unity-android-support-for-editor-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2017.3.1f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.3.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.16f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.16f1",
+        "count": "9"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.25f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.25f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.27f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.27f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.28f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.34f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.34f1",
+        "count": "30"
+      }
+    ],
+    "unity-android-support-for-editor@2018.2.15f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.2.16f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.2.16f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2018.2.18f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.2.21f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.2.21f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.0f2": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.0f2",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.10f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.10f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.11f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.11f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.12f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.12f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.14f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.14f1",
+        "count": "16"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.4f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.4f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.6f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.6f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.7f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.8f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.8f1",
+        "count": "50"
+      }
+    ],
+    "unity-android-support-for-editor@2018.3.9f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.3.9f1",
+        "count": "14"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.0f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.0f1",
+        "count": "7"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.12f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.12f1",
+        "count": "5"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.14f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.14f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.15f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.17f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.17f1",
+        "count": "12"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.20f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.20f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.2f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.2f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.3f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.3f1",
+        "count": "13"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.4f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.4f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.5f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.6f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.6f1",
+        "count": "25"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.7f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.7f1",
+        "count": "16"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.8f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.8f1",
+        "count": "16"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.9f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.9f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.10f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.10f1",
+        "count": "19"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.14f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.14f1",
+        "count": "7"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.1f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.1f1",
+        "count": "5"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.2f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.2f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.4f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.4f1",
+        "count": "26"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.5f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.5f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.7f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.7f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.1.8f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.1.8f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.10f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.10f1",
+        "count": "5"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.11f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.11f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.12f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.12f1",
+        "count": "6"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.14f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.14f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.15f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.15f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.16f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.16f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.17f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.17f1",
+        "count": "3"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.18f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.19f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.19f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.21f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.5f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.6f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.6f1",
+        "count": "5"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.7f2": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.7f2",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.8f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.8f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.0b6": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.0b6",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.0b9": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.0b9",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.0f6": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.0f6",
+        "count": "8"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.1f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.1f1",
+        "count": "8"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.9f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@5.5.1f1": [
+      {
+        "cask": "unity-android-support-for-editor@5.5.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@5.5.3f1": [
+      {
+        "cask": "unity-android-support-for-editor@5.5.3f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@5.6.1f1": [
+      {
+        "cask": "unity-android-support-for-editor@5.6.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@5.6.1p4": [
+      {
+        "cask": "unity-android-support-for-editor@5.6.1p4",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@5.6.4f1": [
+      {
+        "cask": "unity-android-support-for-editor@5.6.4f1",
+        "count": "1"
+      }
+    ],
+    "unity-appletv-support-for-editor@2018.4.1f1": [
+      {
+        "cask": "unity-appletv-support-for-editor@2018.4.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-appletv-support-for-editor@2018.4.7f1": [
+      {
+        "cask": "unity-appletv-support-for-editor@2018.4.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-documentation@2018.2.21f1": [
+      {
+        "cask": "unity-documentation@2018.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity-download-assistant": [
+      {
+        "cask": "unity-download-assistant",
+        "count": "302"
+      }
+    ],
+    "unity-hub": [
+      {
+        "cask": "unity-hub",
+        "count": "2,880"
+      }
+    ],
+    "unity-hub-custom": [
+      {
+        "cask": "unity-hub-custom",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor": [
+      {
+        "cask": "unity-ios-support-for-editor",
+        "count": "268"
+      }
+    ],
+    "unity-ios-support-for-editor-2017-4-1f1": [
+      {
+        "cask": "unity-ios-support-for-editor-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor-2018-2-5f1": [
+      {
+        "cask": "unity-ios-support-for-editor-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor-5-6-6f2": [
+      {
+        "cask": "unity-ios-support-for-editor-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.3.1f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.3.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.16f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.16f1",
+        "count": "11"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.20f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.25f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.25f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.27f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.27f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.28f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.34f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.34f1",
+        "count": "26"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.36f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.36f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.2.15f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.2.16f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.2.16f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.2.18f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.2.18f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.2.21f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.2.21f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.0f2": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.0f2",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.10f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.12f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.12f1",
+        "count": "4"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.14f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.14f1",
+        "count": "16"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.4f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.4f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.7f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.8f1",
+        "count": "48"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.3.9f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.3.9f1",
+        "count": "14"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.0f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.0f1",
+        "count": "6"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.12f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.12f1",
+        "count": "5"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.14f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.14f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.15f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.17f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.17f1",
+        "count": "13"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.1f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.20f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.2f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.2f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.3f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.3f1",
+        "count": "15"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.4f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.4f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.5f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.6f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.6f1",
+        "count": "25"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.7f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.7f1",
+        "count": "17"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.8f1",
+        "count": "17"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.9f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.9f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.10f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.10f1",
+        "count": "19"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.12f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.12f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.14f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.14f1",
+        "count": "7"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.1f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.1f1",
+        "count": "12"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.2f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.2f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.4f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.4f1",
+        "count": "26"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.5f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.5f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.7f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.7f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.1.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.1.8f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.10f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.10f1",
+        "count": "5"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.11f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.11f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.12f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.12f1",
+        "count": "6"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.14f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.14f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.15f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.15f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.16f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.16f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.17f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.17f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.18f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.19f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.19f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.21f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.5f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.6f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.6f1",
+        "count": "6"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.7f2": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.7f2",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.8f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.0f6": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.0f6",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.7f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.8f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.9f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@5.6.4f1": [
+      {
+        "cask": "unity-ios-support-for-editor@5.6.4f1",
+        "count": "3"
+      }
+    ],
+    "unity-linux-support-for-editor": [
+      {
+        "cask": "unity-linux-support-for-editor",
+        "count": "76"
+      }
+    ],
+    "unity-linux-support-for-editor@2017.4.6f1": [
+      {
+        "cask": "unity-linux-support-for-editor@2017.4.6f1",
+        "count": "1"
+      }
+    ],
+    "unity-linux-support-for-editor@2018.4.16f1": [
+      {
+        "cask": "unity-linux-support-for-editor@2018.4.16f1",
+        "count": "1"
+      }
+    ],
+    "unity-linux-support-for-editor@2019.1.5f1": [
+      {
+        "cask": "unity-linux-support-for-editor@2019.1.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-lumin-support-for-editor": [
+      {
+        "cask": "unity-lumin-support-for-editor",
+        "count": "28"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2018.4.1f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2018.4.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2018.4.7f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2018.4.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2019.2.12f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2019.2.12f1",
+        "count": "1"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2019.2.18f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2019.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2019.2.19f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2019.2.19f1",
+        "count": "1"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-standard-assets": [
+      {
+        "cask": "unity-standard-assets",
+        "count": "118"
+      }
+    ],
+    "unity-tvos-support-for-editor-2017-4-1f1": [
+      {
+        "cask": "unity-tvos-support-for-editor-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-tvos-support-for-editor-2018-2-5f1": [
+      {
+        "cask": "unity-tvos-support-for-editor-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-tvos-support-for-editor-5-6-6f2": [
+      {
+        "cask": "unity-tvos-support-for-editor-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-vuforia-ar-support-for-editor": [
+      {
+        "cask": "unity-vuforia-ar-support-for-editor",
+        "count": "10"
+      }
+    ],
+    "unity-vuforia-ar-support-for-editor@2017.3.1f1": [
+      {
+        "cask": "unity-vuforia-ar-support-for-editor@2017.3.1f1",
+        "count": "1"
+      }
+    ],
+    "unity-vuforia-ar-support-for-editor@2017.4.27f1": [
+      {
+        "cask": "unity-vuforia-ar-support-for-editor@2017.4.27f1",
+        "count": "1"
+      }
+    ],
+    "unity-vuforia-ar-support-for-editor@2018.2.15f1": [
+      {
+        "cask": "unity-vuforia-ar-support-for-editor@2018.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-vuforia-ar-support-for-editor@2018.4.0f1": [
+      {
+        "cask": "unity-vuforia-ar-support-for-editor@2018.4.0f1",
+        "count": "1"
+      }
+    ],
+    "unity-vuforia-ar-support-for-editor@2019.1.2f1": [
+      {
+        "cask": "unity-vuforia-ar-support-for-editor@2019.1.2f1",
+        "count": "1"
+      }
+    ],
+    "unity-web-player": [
+      {
+        "cask": "unity-web-player",
+        "count": "74"
+      }
+    ],
+    "unity-webgl-support-for-editor": [
+      {
+        "cask": "unity-webgl-support-for-editor",
+        "count": "127"
+      }
+    ],
+    "unity-webgl-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-webgl-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2018.4.13f1",
+        "count": "1"
+      }
+    ],
+    "unity-webgl-support-for-editor@2018.4.5f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2018.4.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-webgl-support-for-editor@2019.2.11f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2019.2.11f1",
+        "count": "2"
+      }
+    ],
+    "unity-webgl-support-for-editor@2019.2.15f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2019.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-webgl-support-for-editor@5.5.3f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@5.5.3f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2018.4.16f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2018.4.16f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.1.5f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.1.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.2.12f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.2.12f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.2.18f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.2.19f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.2.19f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-support-for-editor": [
+      {
+        "cask": "unity-windows-support-for-editor",
+        "count": "167"
+      }
+    ],
+    "unity-windows-support-for-editor@2017.4.20f2": [
+      {
+        "cask": "unity-windows-support-for-editor@2017.4.20f2",
+        "count": "1"
+      }
+    ],
+    "unity-windows-support-for-editor@2017.4.6f1": [
+      {
+        "cask": "unity-windows-support-for-editor@2017.4.6f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.3.1f1": [
+      {
+        "cask": "unity@2017.3.1f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.10f1": [
+      {
+        "cask": "unity@2017.4.10f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.16f1": [
+      {
+        "cask": "unity@2017.4.16f1",
+        "count": "15"
+      }
+    ],
+    "unity@2017.4.20f1": [
+      {
+        "cask": "unity@2017.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.20f2": [
+      {
+        "cask": "unity@2017.4.20f2",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.22f1": [
+      {
+        "cask": "unity@2017.4.22f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.25f1": [
+      {
+        "cask": "unity@2017.4.25f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.27f1": [
+      {
+        "cask": "unity@2017.4.27f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.28f1": [
+      {
+        "cask": "unity@2017.4.28f1",
+        "count": "4"
+      }
+    ],
+    "unity@2017.4.34f1": [
+      {
+        "cask": "unity@2017.4.34f1",
+        "count": "30"
+      }
+    ],
+    "unity@2017.4.36f1": [
+      {
+        "cask": "unity@2017.4.36f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.6f1": [
+      {
+        "cask": "unity@2017.4.6f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.1.3f1": [
+      {
+        "cask": "unity@2018.1.3f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.2.15f1": [
+      {
+        "cask": "unity@2018.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.2.16f1": [
+      {
+        "cask": "unity@2018.2.16f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.2.18f1": [
+      {
+        "cask": "unity@2018.2.18f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.2.21f1": [
+      {
+        "cask": "unity@2018.2.21f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.3.0f2": [
+      {
+        "cask": "unity@2018.3.0f2",
+        "count": "6"
+      }
+    ],
+    "unity@2018.3.10f1": [
+      {
+        "cask": "unity@2018.3.10f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.3.11f1": [
+      {
+        "cask": "unity@2018.3.11f1",
+        "count": "4"
+      }
+    ],
+    "unity@2018.3.12f1": [
+      {
+        "cask": "unity@2018.3.12f1",
+        "count": "4"
+      }
+    ],
+    "unity@2018.3.13f1": [
+      {
+        "cask": "unity@2018.3.13f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.3.14f1": [
+      {
+        "cask": "unity@2018.3.14f1",
+        "count": "17"
+      }
+    ],
+    "unity@2018.3.2f1": [
+      {
+        "cask": "unity@2018.3.2f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.3.4f1": [
+      {
+        "cask": "unity@2018.3.4f1",
+        "count": "4"
+      }
+    ],
+    "unity@2018.3.6f1": [
+      {
+        "cask": "unity@2018.3.6f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.3.8f1": [
+      {
+        "cask": "unity@2018.3.8f1",
+        "count": "51"
+      }
+    ],
+    "unity@2018.3.9f1": [
+      {
+        "cask": "unity@2018.3.9f1",
+        "count": "16"
+      }
+    ],
+    "unity@2018.4.0f1": [
+      {
+        "cask": "unity@2018.4.0f1",
+        "count": "8"
+      }
+    ],
+    "unity@2018.4.10f1": [
+      {
+        "cask": "unity@2018.4.10f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.11f1": [
+      {
+        "cask": "unity@2018.4.11f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.12f1": [
+      {
+        "cask": "unity@2018.4.12f1",
+        "count": "10"
+      }
+    ],
+    "unity@2018.4.13f1": [
+      {
+        "cask": "unity@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.14f1": [
+      {
+        "cask": "unity@2018.4.14f1",
+        "count": "5"
+      }
+    ],
+    "unity@2018.4.15f1": [
+      {
+        "cask": "unity@2018.4.15f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.16f1": [
+      {
+        "cask": "unity@2018.4.16f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.17f1": [
+      {
+        "cask": "unity@2018.4.17f1",
+        "count": "16"
+      }
+    ],
+    "unity@2018.4.18f1": [
+      {
+        "cask": "unity@2018.4.18f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.19f1": [
+      {
+        "cask": "unity@2018.4.19f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.1f1": [
+      {
+        "cask": "unity@2018.4.1f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.20f1": [
+      {
+        "cask": "unity@2018.4.20f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.4.21f1": [
+      {
+        "cask": "unity@2018.4.21f1",
+        "count": "19"
+      }
+    ],
+    "unity@2018.4.2f1": [
+      {
+        "cask": "unity@2018.4.2f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.3f1": [
+      {
+        "cask": "unity@2018.4.3f1",
+        "count": "17"
+      }
+    ],
+    "unity@2018.4.4f1": [
+      {
+        "cask": "unity@2018.4.4f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.5f1": [
+      {
+        "cask": "unity@2018.4.5f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.6f1": [
+      {
+        "cask": "unity@2018.4.6f1",
+        "count": "25"
+      }
+    ],
+    "unity@2018.4.7f1": [
+      {
+        "cask": "unity@2018.4.7f1",
+        "count": "18"
+      }
+    ],
+    "unity@2018.4.8f1": [
+      {
+        "cask": "unity@2018.4.8f1",
+        "count": "18"
+      }
+    ],
+    "unity@2018.4.9f1": [
+      {
+        "cask": "unity@2018.4.9f1",
+        "count": "3"
+      }
+    ],
+    "unity@2019.1.0f2": [
+      {
+        "cask": "unity@2019.1.0f2",
+        "count": "1"
+      }
+    ],
+    "unity@2019.1.10f1": [
+      {
+        "cask": "unity@2019.1.10f1",
+        "count": "19"
+      }
+    ],
+    "unity@2019.1.12f1": [
+      {
+        "cask": "unity@2019.1.12f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.1.13f1": [
+      {
+        "cask": "unity@2019.1.13f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.1.14f1": [
+      {
+        "cask": "unity@2019.1.14f1",
+        "count": "7"
+      }
+    ],
+    "unity@2019.1.1f1": [
+      {
+        "cask": "unity@2019.1.1f1",
+        "count": "19"
+      }
+    ],
+    "unity@2019.1.2f1": [
+      {
+        "cask": "unity@2019.1.2f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.1.4f1": [
+      {
+        "cask": "unity@2019.1.4f1",
+        "count": "27"
+      }
+    ],
+    "unity@2019.1.5f1": [
+      {
+        "cask": "unity@2019.1.5f1",
+        "count": "5"
+      }
+    ],
+    "unity@2019.1.7f1": [
+      {
+        "cask": "unity@2019.1.7f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.1.8f1": [
+      {
+        "cask": "unity@2019.1.8f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.1.9f1": [
+      {
+        "cask": "unity@2019.1.9f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.2.10f1": [
+      {
+        "cask": "unity@2019.2.10f1",
+        "count": "5"
+      }
+    ],
+    "unity@2019.2.11f1": [
+      {
+        "cask": "unity@2019.2.11f1",
+        "count": "3"
+      }
+    ],
+    "unity@2019.2.12f1": [
+      {
+        "cask": "unity@2019.2.12f1",
+        "count": "6"
+      }
+    ],
+    "unity@2019.2.14f1": [
+      {
+        "cask": "unity@2019.2.14f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.2.15f1": [
+      {
+        "cask": "unity@2019.2.15f1",
+        "count": "3"
+      }
+    ],
+    "unity@2019.2.16f1": [
+      {
+        "cask": "unity@2019.2.16f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.2.17f1": [
+      {
+        "cask": "unity@2019.2.17f1",
+        "count": "4"
+      }
+    ],
+    "unity@2019.2.18f1": [
+      {
+        "cask": "unity@2019.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.2.19f1": [
+      {
+        "cask": "unity@2019.2.19f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.2.21f1": [
+      {
+        "cask": "unity@2019.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.2.6f1": [
+      {
+        "cask": "unity@2019.2.6f1",
+        "count": "7"
+      }
+    ],
+    "unity@2019.2.7f2": [
+      {
+        "cask": "unity@2019.2.7f2",
+        "count": "2"
+      }
+    ],
+    "unity@2019.2.8f1": [
+      {
+        "cask": "unity@2019.2.8f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.0b4": [
+      {
+        "cask": "unity@2019.3.0b4",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.0b6": [
+      {
+        "cask": "unity@2019.3.0b6",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.0b9": [
+      {
+        "cask": "unity@2019.3.0b9",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.0f6": [
+      {
+        "cask": "unity@2019.3.0f6",
+        "count": "8"
+      }
+    ],
+    "unity@2019.3.10f1": [
+      {
+        "cask": "unity@2019.3.10f1",
+        "count": "3"
+      }
+    ],
+    "unity@2019.3.1f1": [
+      {
+        "cask": "unity@2019.3.1f1",
+        "count": "8"
+      }
+    ],
+    "unity@2019.3.2f1": [
+      {
+        "cask": "unity@2019.3.2f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.4f1": [
+      {
+        "cask": "unity@2019.3.4f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.7f1": [
+      {
+        "cask": "unity@2019.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.8f1": [
+      {
+        "cask": "unity@2019.3.8f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.9f1": [
+      {
+        "cask": "unity@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity@2020.1.0b6": [
+      {
+        "cask": "unity@2020.1.0b6",
+        "count": "1"
+      }
+    ],
+    "unity@5.5.1f1": [
+      {
+        "cask": "unity@5.5.1f1",
+        "count": "1"
+      }
+    ],
+    "unity@5.5.3f1": [
+      {
+        "cask": "unity@5.5.3f1",
+        "count": "2"
+      }
+    ],
+    "unity@5.6.1f1": [
+      {
+        "cask": "unity@5.6.1f1",
+        "count": "1"
+      }
+    ],
+    "unity@5.6.1p4": [
+      {
+        "cask": "unity@5.6.1p4",
+        "count": "1"
+      }
+    ],
+    "unity@5.6.4f1": [
+      {
+        "cask": "unity@5.6.4f1",
+        "count": "33"
+      }
+    ],
+    "universal-media-server": [
+      {
+        "cask": "universal-media-server",
+        "count": "354"
+      }
+    ],
+    "universalmailer": [
+      {
+        "cask": "universalmailer",
+        "count": "18"
+      }
+    ],
+    "unlox": [
+      {
+        "cask": "unlox",
+        "count": "269"
+      }
+    ],
+    "unlox-beta": [
+      {
+        "cask": "unlox-beta",
+        "count": "5"
+      }
+    ],
+    "unofficial-wineskin": [
+      {
+        "cask": "unofficial-wineskin",
+        "count": "4"
+      }
+    ],
+    "unorml": [
+      {
+        "cask": "unorml",
+        "count": "5"
+      }
+    ],
+    "unpkg": [
+      {
+        "cask": "unpkg",
+        "count": "298"
+      }
+    ],
+    "unshaky": [
+      {
+        "cask": "unshaky",
+        "count": "559"
+      }
+    ],
+    "upic": [
+      {
+        "cask": "upic",
+        "count": "1,877"
+      }
+    ],
+    "upm": [
+      {
+        "cask": "upm",
+        "count": "23"
+      }
+    ],
+    "upterm": [
+      {
+        "cask": "upterm",
+        "count": "934"
+      }
+    ],
+    "upwork": [
+      {
+        "cask": "upwork",
+        "count": "348"
+      }
+    ],
+    "urbanterror": [
+      {
+        "cask": "urbanterror",
+        "count": "19"
+      }
+    ],
+    "usage": [
+      {
+        "cask": "usage",
+        "count": "115"
+      }
+    ],
+    "usb-overdrive": [
+      {
+        "cask": "usb-overdrive",
+        "count": "355"
+      }
+    ],
+    "use-engine": [
+      {
+        "cask": "use-engine",
+        "count": "1,216"
+      }
+    ],
+    "utc-menu-clock": [
+      {
+        "cask": "utc-menu-clock",
+        "count": "563"
+      }
+    ],
+    "utcmenuclock": [
+      {
+        "cask": "utcmenuclock",
+        "count": "1"
+      }
+    ],
+    "utiutility": [
+      {
+        "cask": "utiutility",
+        "count": "5"
+      }
+    ],
+    "utools": [
+      {
+        "cask": "utools",
+        "count": "101"
+      }
+    ],
+    "utopia": [
+      {
+        "cask": "utopia",
+        "count": "1"
+      }
+    ],
+    "utorrent": [
+      {
+        "cask": "utorrent",
+        "count": "6"
+      }
+    ],
+    "utox": [
+      {
+        "cask": "utox",
+        "count": "118"
+      }
+    ],
+    "uu-booster": [
+      {
+        "cask": "uu-booster",
+        "count": "45"
+      }
+    ],
+    "uxprotect": [
+      {
+        "cask": "uxprotect",
+        "count": "59"
+      }
+    ],
+    "v2rayu": [
+      {
+        "cask": "v2rayu",
+        "count": "12,941"
+      }
+    ],
+    "v2rayx": [
+      {
+        "cask": "v2rayx",
+        "count": "9,600"
+      }
+    ],
+    "vagrant": [
+      {
+        "cask": "vagrant",
+        "count": "87,110"
+      }
+    ],
+    "vagrant-1.8.7": [
+      {
+        "cask": "vagrant-1.8.7",
+        "count": "1"
+      }
+    ],
+    "vagrant-manager": [
+      {
+        "cask": "vagrant-manager",
+        "count": "15,620"
+      }
+    ],
+    "vagrant-vmware-utility": [
+      {
+        "cask": "vagrant-vmware-utility",
+        "count": "1,152"
+      }
+    ],
+    "vagrant174": [
+      {
+        "cask": "vagrant174",
+        "count": "1"
+      }
+    ],
+    "vagrant@2.2.6": [
+      {
+        "cask": "vagrant@2.2.6",
+        "count": "1"
+      }
+    ],
+    "valentina-studio": [
+      {
+        "cask": "valentina-studio",
+        "count": "778"
+      }
+    ],
+    "valhallafreqecho": [
+      {
+        "cask": "valhallafreqecho",
+        "count": "4"
+      }
+    ],
+    "validator-sac": [
+      {
+        "cask": "validator-sac",
+        "count": "18"
+      }
+    ],
+    "valley": [
+      {
+        "cask": "valley",
+        "count": "69"
+      }
+    ],
+    "vanilla": [
+      {
+        "cask": "vanilla",
+        "count": "2,517"
+      }
+    ],
+    "vapor": [
+      {
+        "cask": "vapor",
+        "count": "214"
+      }
+    ],
+    "vassal": [
+      {
+        "cask": "vassal",
+        "count": "120"
+      }
+    ],
+    "vault-token-helper-osx-keychain": [
+      {
+        "cask": "vault-token-helper-osx-keychain",
+        "count": "5"
+      }
+    ],
+    "vault-tool": [
+      {
+        "cask": "vault-tool",
+        "count": "3"
+      }
+    ],
+    "vault@1.3.0": [
+      {
+        "cask": "vault@1.3.0",
+        "count": "1"
+      }
+    ],
+    "vbox-6-0-16": [
+      {
+        "cask": "vbox-6-0-16",
+        "count": "2"
+      }
+    ],
+    "vcs-vision": [
+      {
+        "cask": "vcs-vision",
+        "count": "4"
+      }
+    ],
+    "vcv-rack": [
+      {
+        "cask": "vcv-rack",
+        "count": "477"
+      }
+    ],
+    "vdmx": [
+      {
+        "cask": "vdmx",
+        "count": "2"
+      }
+    ],
+    "vectoraster": [
+      {
+        "cask": "vectoraster",
+        "count": "7"
+      }
+    ],
+    "vectr": [
+      {
+        "cask": "vectr",
+        "count": "1,285"
+      }
+    ],
+    "vega": [
+      {
+        "cask": "vega",
+        "count": "3"
+      }
+    ],
+    "vellum": [
+      {
+        "cask": "vellum",
+        "count": "26"
+      }
+    ],
+    "veonim": [
+      {
+        "cask": "veonim",
+        "count": "180"
+      }
+    ],
+    "veracrypt": [
+      {
+        "cask": "veracrypt",
+        "count": "4,299"
+      }
+    ],
+    "veraview": [
+      {
+        "cask": "veraview",
+        "count": "1"
+      }
+    ],
+    "versions": [
+      {
+        "cask": "versions",
+        "count": "213"
+      }
+    ],
+    "vesta": [
+      {
+        "cask": "vesta",
+        "count": "194"
+      }
+    ],
+    "veusz": [
+      {
+        "cask": "veusz",
+        "count": "102"
+      }
+    ],
+    "viber": [
+      {
+        "cask": "viber",
+        "count": "3,577"
+      }
+    ],
+    "vidcutter": [
+      {
+        "cask": "vidcutter",
+        "count": "177"
+      }
+    ],
+    "video-downloadhelper-companion-app": [
+      {
+        "cask": "video-downloadhelper-companion-app",
+        "count": "1"
+      }
+    ],
+    "videobox": [
+      {
+        "cask": "videobox",
+        "count": "11"
+      }
+    ],
+    "videostream": [
+      {
+        "cask": "videostream",
+        "count": "259"
+      }
+    ],
+    "vidrio": [
+      {
+        "cask": "vidrio",
+        "count": "16"
+      }
+    ],
+    "vidyo": [
+      {
+        "cask": "vidyo",
+        "count": "101"
+      }
+    ],
+    "vienna": [
+      {
+        "cask": "vienna",
+        "count": "1,167"
+      }
+    ],
+    "viewber": [
+      {
+        "cask": "viewber",
+        "count": "2"
+      }
+    ],
+    "vimac": [
+      {
+        "cask": "vimac",
+        "count": "7"
+      }
+    ],
+    "vimapp": [
+      {
+        "cask": "vimapp",
+        "count": "2"
+      }
+    ],
+    "vimediamanager": [
+      {
+        "cask": "vimediamanager",
+        "count": "39"
+      }
+    ],
+    "vimr": [
+      {
+        "cask": "vimr",
+        "count": "3,019"
+      }
+    ],
+    "vin047-abgx360": [
+      {
+        "cask": "vin047-abgx360",
+        "count": "69"
+      }
+    ],
+    "vip-access": [
+      {
+        "cask": "vip-access",
+        "count": "54"
+      }
+    ],
+    "vipriser": [
+      {
+        "cask": "vipriser",
+        "count": "2"
+      }
+    ],
+    "virtaal": [
+      {
+        "cask": "virtaal",
+        "count": "4"
+      }
+    ],
+    "virtual-ii": [
+      {
+        "cask": "virtual-ii",
+        "count": "75"
+      }
+    ],
+    "virtualbox": [
+      {
+        "cask": "virtualbox",
+        "count": "138,709"
+      }
+    ],
+    "virtualbox-5.1.10": [
+      {
+        "cask": "virtualbox-5.1.10",
+        "count": "1"
+      }
+    ],
+    "virtualbox-5.2": [
+      {
+        "cask": "virtualbox-5.2",
+        "count": "16"
+      }
+    ],
+    "virtualbox-6.0.14.133895": [
+      {
+        "cask": "virtualbox-6.0.14.133895",
+        "count": "3"
+      }
+    ],
+    "virtualbox-beta": [
+      {
+        "cask": "virtualbox-beta",
+        "count": "480"
+      }
+    ],
+    "virtualbox-extension-pack": [
+      {
+        "cask": "virtualbox-extension-pack",
+        "count": "22,053"
+      }
+    ],
+    "virtualbox-extension-pack-5.2": [
+      {
+        "cask": "virtualbox-extension-pack-5.2",
+        "count": "2"
+      }
+    ],
+    "virtualbox-extension-pack-beta": [
+      {
+        "cask": "virtualbox-extension-pack-beta",
+        "count": "177"
+      }
+    ],
+    "virtualbox-extension-pack-snapshot": [
+      {
+        "cask": "virtualbox-extension-pack-snapshot",
+        "count": "3"
+      }
+    ],
+    "virtualbox-extension-pack@6.0": [
+      {
+        "cask": "virtualbox-extension-pack@6.0",
+        "count": "3"
+      }
+    ],
+    "virtualbox-extension-pack@6.0.14": [
+      {
+        "cask": "virtualbox-extension-pack@6.0.14",
+        "count": "1"
+      }
+    ],
+    "virtualbox-menulet": [
+      {
+        "cask": "virtualbox-menulet",
+        "count": "21"
+      }
+    ],
+    "virtualbox-snapshot": [
+      {
+        "cask": "virtualbox-snapshot",
+        "count": "3"
+      }
+    ],
+    "virtualbox52": [
+      {
+        "cask": "virtualbox52",
+        "count": "1"
+      }
+    ],
+    "virtualbox@5.2": [
+      {
+        "cask": "virtualbox@5.2",
+        "count": "2"
+      }
+    ],
+    "virtualbox@5.2.22": [
+      {
+        "cask": "virtualbox@5.2.22",
+        "count": "1"
+      }
+    ],
+    "virtualbox@6.0": [
+      {
+        "cask": "virtualbox@6.0",
+        "count": "4"
+      }
+    ],
+    "virtualbox@6.0.14": [
+      {
+        "cask": "virtualbox@6.0.14",
+        "count": "1"
+      }
+    ],
+    "virtualc64": [
+      {
+        "cask": "virtualc64",
+        "count": "158"
+      }
+    ],
+    "virtualgl": [
+      {
+        "cask": "virtualgl",
+        "count": "17"
+      }
+    ],
+    "virtualhere": [
+      {
+        "cask": "virtualhere",
+        "count": "100"
+      }
+    ],
+    "virtualhereserver": [
+      {
+        "cask": "virtualhereserver",
+        "count": "58"
+      }
+    ],
+    "virtualhostx": [
+      {
+        "cask": "virtualhostx",
+        "count": "73"
+      }
+    ],
+    "virtualkvm": [
+      {
+        "cask": "virtualkvm",
+        "count": "1"
+      }
+    ],
+    "virustotaluploader": [
+      {
+        "cask": "virustotaluploader",
+        "count": "99"
+      }
+    ],
+    "viscosity": [
+      {
+        "cask": "viscosity",
+        "count": "4,127"
+      }
+    ],
+    "visicut": [
+      {
+        "cask": "visicut",
+        "count": "7"
+      }
+    ],
+    "visit": [
+      {
+        "cask": "visit",
+        "count": "162"
+      }
+    ],
+    "vista": [
+      {
+        "cask": "vista",
+        "count": "1"
+      }
+    ],
+    "visual": [
+      {
+        "cask": "visual",
+        "count": "141"
+      }
+    ],
+    "visual-paradigm": [
+      {
+        "cask": "visual-paradigm",
+        "count": "250"
+      }
+    ],
+    "visual-paradigm-ce": [
+      {
+        "cask": "visual-paradigm-ce",
+        "count": "475"
+      }
+    ],
+    "visual-paradigm-project-viewer": [
+      {
+        "cask": "visual-paradigm-project-viewer",
+        "count": "2"
+      }
+    ],
+    "visual-studio": [
+      {
+        "cask": "visual-studio",
+        "count": "7,249"
+      }
+    ],
+    "visual-studio-code": [
+      {
+        "cask": "visual-studio-code",
+        "count": "183,591"
+      }
+    ],
+    "visual-studio-code-custom": [
+      {
+        "cask": "visual-studio-code-custom",
+        "count": "1"
+      }
+    ],
+    "visual-studio-code-insiders": [
+      {
+        "cask": "visual-studio-code-insiders",
+        "count": "5,693"
+      }
+    ],
+    "visualboyadvance-m": [
+      {
+        "cask": "visualboyadvance-m",
+        "count": "144"
+      }
+    ],
+    "visualvm": [
+      {
+        "cask": "visualvm",
+        "count": "5,032"
+      }
+    ],
+    "vitalsource-bookshelf": [
+      {
+        "cask": "vitalsource-bookshelf",
+        "count": "205"
+      }
+    ],
+    "vitamin-r": [
+      {
+        "cask": "vitamin-r",
+        "count": "83"
+      }
+    ],
+    "vivaldi": [
+      {
+        "cask": "vivaldi",
+        "count": "7,871"
+      }
+    ],
+    "vivaldi-snapshot": [
+      {
+        "cask": "vivaldi-snapshot",
+        "count": "187"
+      }
+    ],
+    "vivi": [
+      {
+        "cask": "vivi",
+        "count": "6"
+      }
+    ],
+    "vk-messenger": [
+      {
+        "cask": "vk-messenger",
+        "count": "125"
+      }
+    ],
+    "vlc": [
+      {
+        "cask": "vlc",
+        "count": "80,947"
+      }
+    ],
+    "vlc-custom": [
+      {
+        "cask": "vlc-custom",
+        "count": "35"
+      }
+    ],
+    "vlc-nightly": [
+      {
+        "cask": "vlc-nightly",
+        "count": "566"
+      }
+    ],
+    "vlc-protocol": [
+      {
+        "cask": "vlc-protocol",
+        "count": "24"
+      }
+    ],
+    "vlc-webplugin": [
+      {
+        "cask": "vlc-webplugin",
+        "count": "631"
+      }
+    ],
+    "vlcstreamer": [
+      {
+        "cask": "vlcstreamer",
+        "count": "271"
+      }
+    ],
+    "vmix-desktop-capture": [
+      {
+        "cask": "vmix-desktop-capture",
+        "count": "1"
+      }
+    ],
+    "vmpk": [
+      {
+        "cask": "vmpk",
+        "count": "65"
+      }
+    ],
+    "vmware-fusion": [
+      {
+        "cask": "vmware-fusion",
+        "count": "9,810"
+      }
+    ],
+    "vmware-fusion-11-1-1": [
+      {
+        "cask": "vmware-fusion-11-1-1",
+        "count": "2"
+      }
+    ],
+    "vmware-fusion-tech-preview": [
+      {
+        "cask": "vmware-fusion-tech-preview",
+        "count": "20"
+      }
+    ],
+    "vmware-fusion10": [
+      {
+        "cask": "vmware-fusion10",
+        "count": "420"
+      }
+    ],
+    "vmware-fusion7": [
+      {
+        "cask": "vmware-fusion7",
+        "count": "31"
+      }
+    ],
+    "vmware-fusion8": [
+      {
+        "cask": "vmware-fusion8",
+        "count": "150"
+      }
+    ],
+    "vmware-horizon-client": [
+      {
+        "cask": "vmware-horizon-client",
+        "count": "1,565"
+      }
+    ],
+    "vmware-ovf-tool": [
+      {
+        "cask": "vmware-ovf-tool",
+        "count": "1"
+      }
+    ],
+    "vmware-remote-console": [
+      {
+        "cask": "vmware-remote-console",
+        "count": "530"
+      }
+    ],
+    "vnc-server": [
+      {
+        "cask": "vnc-server",
+        "count": "965"
+      }
+    ],
+    "vnc-viewer": [
+      {
+        "cask": "vnc-viewer",
+        "count": "9,577"
+      }
+    ],
+    "vnote": [
+      {
+        "cask": "vnote",
+        "count": "1,581"
+      }
+    ],
+    "voicemac": [
+      {
+        "cask": "voicemac",
+        "count": "22"
+      }
+    ],
+    "voikkospellservice": [
+      {
+        "cask": "voikkospellservice",
+        "count": "19"
+      }
+    ],
+    "volkswagen-discovercare": [
+      {
+        "cask": "volkswagen-discovercare",
+        "count": "10"
+      }
+    ],
+    "volt": [
+      {
+        "cask": "volt",
+        "count": "167"
+      }
+    ],
+    "voodoopad": [
+      {
+        "cask": "voodoopad",
+        "count": "37"
+      }
+    ],
+    "vookiimageviewer-macos": [
+      {
+        "cask": "vookiimageviewer-macos",
+        "count": "7"
+      }
+    ],
+    "vorta": [
+      {
+        "cask": "vorta",
+        "count": "514"
+      }
+    ],
+    "vox": [
+      {
+        "cask": "vox",
+        "count": "1,775"
+      }
+    ],
+    "vox-preferences-pane": [
+      {
+        "cask": "vox-preferences-pane",
+        "count": "136"
+      }
+    ],
+    "vox2": [
+      {
+        "cask": "vox2",
+        "count": "39"
+      }
+    ],
+    "voxengo-deft-compressor-au-aax": [
+      {
+        "cask": "voxengo-deft-compressor-au-aax",
+        "count": "1"
+      }
+    ],
+    "voxengo-deft-compressor-vst-vst3": [
+      {
+        "cask": "voxengo-deft-compressor-vst-vst3",
+        "count": "1"
+      }
+    ],
+    "voxengo-elephant-au-aax": [
+      {
+        "cask": "voxengo-elephant-au-aax",
+        "count": "1"
+      }
+    ],
+    "voxengo-elephant-vst-vst3": [
+      {
+        "cask": "voxengo-elephant-vst-vst3",
+        "count": "1"
+      }
+    ],
+    "voxengo-glisseq-au-aax": [
+      {
+        "cask": "voxengo-glisseq-au-aax",
+        "count": "1"
+      }
+    ],
+    "voxengo-glisseq-vst-vst3": [
+      {
+        "cask": "voxengo-glisseq-vst-vst3",
+        "count": "1"
+      }
+    ],
+    "voxengo-msed-au-aax": [
+      {
+        "cask": "voxengo-msed-au-aax",
+        "count": "1"
+      }
+    ],
+    "voxengo-msed-vst-vst3": [
+      {
+        "cask": "voxengo-msed-vst-vst3",
+        "count": "1"
+      }
+    ],
+    "voxengo-span-au-aax": [
+      {
+        "cask": "voxengo-span-au-aax",
+        "count": "1"
+      }
+    ],
+    "voxengo-span-vst-vst3": [
+      {
+        "cask": "voxengo-span-vst-vst3",
+        "count": "1"
+      }
+    ],
+    "voxengo-voxformer-au-aax": [
+      {
+        "cask": "voxengo-voxformer-au-aax",
+        "count": "1"
+      }
+    ],
+    "voxengo-voxformer-vst-vst3": [
+      {
+        "cask": "voxengo-voxformer-vst-vst3",
+        "count": "2"
+      }
+    ],
+    "voxql": [
+      {
+        "cask": "voxql",
+        "count": "33"
+      }
+    ],
+    "vpaint": [
+      {
+        "cask": "vpaint",
+        "count": "2"
+      }
+    ],
+    "vpn-enabler": [
+      {
+        "cask": "vpn-enabler",
+        "count": "68"
+      }
+    ],
+    "vrep": [
+      {
+        "cask": "vrep",
+        "count": "60"
+      }
+    ],
+    "vrouter": [
+      {
+        "cask": "vrouter",
+        "count": "7"
+      }
+    ],
+    "vscodium": [
+      {
+        "cask": "vscodium",
+        "count": "13,515"
+      }
+    ],
+    "vsee": [
+      {
+        "cask": "vsee",
+        "count": "41"
+      }
+    ],
+    "vu": [
+      {
+        "cask": "vu",
+        "count": "22"
+      }
+    ],
+    "vuescan": [
+      {
+        "cask": "vuescan",
+        "count": "540"
+      }
+    ],
+    "vuescan-x32": [
+      {
+        "cask": "vuescan-x32",
+        "count": "8"
+      }
+    ],
+    "vulkan-sdk": [
+      {
+        "cask": "vulkan-sdk",
+        "count": "1,774"
+      }
+    ],
+    "vuo-editor": [
+      {
+        "cask": "vuo-editor",
+        "count": "1"
+      }
+    ],
+    "vuze": [
+      {
+        "cask": "vuze",
+        "count": "496"
+      }
+    ],
+    "vv": [
+      {
+        "cask": "vv",
+        "count": "170"
+      }
+    ],
+    "vyprvpn": [
+      {
+        "cask": "vyprvpn",
+        "count": "274"
+      }
+    ],
+    "vysor": [
+      {
+        "cask": "vysor",
+        "count": "809"
+      }
+    ],
+    "wacom-bamboo-tablet": [
+      {
+        "cask": "wacom-bamboo-tablet",
+        "count": "24"
+      }
+    ],
+    "wacom-inkspace": [
+      {
+        "cask": "wacom-inkspace",
+        "count": "98"
+      }
+    ],
+    "wacom-intuos-tablet": [
+      {
+        "cask": "wacom-intuos-tablet",
+        "count": "1"
+      }
+    ],
+    "wacom-intuos3-tablet": [
+      {
+        "cask": "wacom-intuos3-tablet",
+        "count": "14"
+      }
+    ],
+    "wacom-pentablet@5.3.7-6": [
+      {
+        "cask": "wacom-pentablet@5.3.7-6",
+        "count": "1"
+      }
+    ],
+    "wacom-tablet": [
+      {
+        "cask": "wacom-tablet",
+        "count": "1,034"
+      }
+    ],
+    "wacom-tablet-patched@5.3.7-6": [
+      {
+        "cask": "wacom-tablet-patched@5.3.7-6",
+        "count": "3"
+      }
+    ],
+    "wadoku": [
+      {
+        "cask": "wadoku",
+        "count": "1"
+      }
+    ],
+    "wail": [
+      {
+        "cask": "wail",
+        "count": "37"
+      }
+    ],
+    "wakeonlan": [
+      {
+        "cask": "wakeonlan",
+        "count": "259"
+      }
+    ],
+    "wallpaper-wizard": [
+      {
+        "cask": "wallpaper-wizard",
+        "count": "147"
+      }
+    ],
+    "wally": [
+      {
+        "cask": "wally",
+        "count": "3"
+      }
+    ],
+    "wally-cli": [
+      {
+        "cask": "wally-cli",
+        "count": "2"
+      }
+    ],
+    "waltr": [
+      {
+        "cask": "waltr",
+        "count": "193"
+      }
+    ],
+    "wanna": [
+      {
+        "cask": "wanna",
+        "count": "7"
+      }
+    ],
+    "wanwallet": [
+      {
+        "cask": "wanwallet",
+        "count": "1"
+      }
+    ],
+    "warsow": [
+      {
+        "cask": "warsow",
+        "count": "33"
+      }
+    ],
+    "wasabi-wallet": [
+      {
+        "cask": "wasabi-wallet",
+        "count": "106"
+      }
+    ],
+    "watchguard-mobile-vpn-with-ssl": [
+      {
+        "cask": "watchguard-mobile-vpn-with-ssl",
+        "count": "68"
+      }
+    ],
+    "waterfox": [
+      {
+        "cask": "waterfox",
+        "count": "720"
+      }
+    ],
+    "waterfox-classic": [
+      {
+        "cask": "waterfox-classic",
+        "count": "47"
+      }
+    ],
+    "waterfox-current": [
+      {
+        "cask": "waterfox-current",
+        "count": "54"
+      }
+    ],
+    "watts": [
+      {
+        "cask": "watts",
+        "count": "18"
+      }
+    ],
+    "wavebox": [
+      {
+        "cask": "wavebox",
+        "count": "468"
+      }
+    ],
+    "waves-central": [
+      {
+        "cask": "waves-central",
+        "count": "94"
+      }
+    ],
+    "wavesurfer": [
+      {
+        "cask": "wavesurfer",
+        "count": "49"
+      }
+    ],
+    "wavtap": [
+      {
+        "cask": "wavtap",
+        "count": "19"
+      }
+    ],
+    "waylensstudio": [
+      {
+        "cask": "waylensstudio",
+        "count": "1"
+      }
+    ],
+    "wch-ch34x-usb-serial-driver": [
+      {
+        "cask": "wch-ch34x-usb-serial-driver",
+        "count": "389"
+      }
+    ],
+    "wd-firmware-updater": [
+      {
+        "cask": "wd-firmware-updater",
+        "count": "33"
+      }
+    ],
+    "wd-security": [
+      {
+        "cask": "wd-security",
+        "count": "35"
+      }
+    ],
+    "web-sharing": [
+      {
+        "cask": "web-sharing",
+        "count": "48"
+      }
+    ],
+    "webarchiveextractor": [
+      {
+        "cask": "webarchiveextractor",
+        "count": "56"
+      }
+    ],
+    "webarchiveplayer": [
+      {
+        "cask": "webarchiveplayer",
+        "count": "2"
+      }
+    ],
+    "webcamoid": [
+      {
+        "cask": "webcamoid",
+        "count": "450"
+      }
+    ],
+    "webcatalog": [
+      {
+        "cask": "webcatalog",
+        "count": "84"
+      }
+    ],
+    "webex-meetings": [
+      {
+        "cask": "webex-meetings",
+        "count": "1,643"
+      }
+    ],
+    "webex-meetings-installer": [
+      {
+        "cask": "webex-meetings-installer",
+        "count": "3"
+      }
+    ],
+    "webex-nbr-player": [
+      {
+        "cask": "webex-nbr-player",
+        "count": "134"
+      }
+    ],
+    "webex-teams": [
+      {
+        "cask": "webex-teams",
+        "count": "1,097"
+      }
+    ],
+    "webex-wrf-player": [
+      {
+        "cask": "webex-wrf-player",
+        "count": "50"
+      }
+    ],
+    "webhook": [
+      {
+        "cask": "webhook",
+        "count": "5"
+      }
+    ],
+    "webkit-build-archive": [
+      {
+        "cask": "webkit-build-archive",
+        "count": "1"
+      }
+    ],
+    "webpack-dashboard": [
+      {
+        "cask": "webpack-dashboard",
+        "count": "123"
+      }
+    ],
+    "webplotdigitizer": [
+      {
+        "cask": "webplotdigitizer",
+        "count": "62"
+      }
+    ],
+    "webponize": [
+      {
+        "cask": "webponize",
+        "count": "1,290"
+      }
+    ],
+    "webpquicklook": [
+      {
+        "cask": "webpquicklook",
+        "count": "15,160"
+      }
+    ],
+    "webrecorder-player": [
+      {
+        "cask": "webrecorder-player",
+        "count": "40"
+      }
+    ],
+    "website-watchman": [
+      {
+        "cask": "website-watchman",
+        "count": "9"
+      }
+    ],
+    "webstorm": [
+      {
+        "cask": "webstorm",
+        "count": "8,863"
+      }
+    ],
+    "webstorm-custom": [
+      {
+        "cask": "webstorm-custom",
+        "count": "4"
+      }
+    ],
+    "webstorm-eap": [
+      {
+        "cask": "webstorm-eap",
+        "count": "1"
+      }
+    ],
+    "webtorrent": [
+      {
+        "cask": "webtorrent",
+        "count": "1,871"
+      }
+    ],
+    "webviewscreensaver": [
+      {
+        "cask": "webviewscreensaver",
+        "count": "44"
+      }
+    ],
+    "wechat": [
+      {
+        "cask": "wechat",
+        "count": "7,629"
+      }
+    ],
+    "wechatwebdevtools": [
+      {
+        "cask": "wechatwebdevtools",
+        "count": "1,314"
+      }
+    ],
+    "wechatwork": [
+      {
+        "cask": "wechatwork",
+        "count": "1,399"
+      }
+    ],
+    "wechsel": [
+      {
+        "cask": "wechsel",
+        "count": "89"
+      }
+    ],
+    "weflow": [
+      {
+        "cask": "weflow",
+        "count": "1"
+      }
+    ],
+    "weiyun": [
+      {
+        "cask": "weiyun",
+        "count": "235"
+      }
+    ],
+    "weka": [
+      {
+        "cask": "weka",
+        "count": "721"
+      }
+    ],
+    "weka-dev": [
+      {
+        "cask": "weka-dev",
+        "count": "2"
+      }
+    ],
+    "welly": [
+      {
+        "cask": "welly",
+        "count": "618"
+      }
+    ],
+    "wercker": [
+      {
+        "cask": "wercker",
+        "count": "30"
+      }
+    ],
+    "wercker-cli": [
+      {
+        "cask": "wercker-cli",
+        "count": "41"
+      }
+    ],
+    "wewechat": [
+      {
+        "cask": "wewechat",
+        "count": "364"
+      }
+    ],
+    "wey": [
+      {
+        "cask": "wey",
+        "count": "25"
+      }
+    ],
+    "whale": [
+      {
+        "cask": "whale",
+        "count": "80"
+      }
+    ],
+    "whalebird": [
+      {
+        "cask": "whalebird",
+        "count": "213"
+      }
+    ],
+    "whatpulse": [
+      {
+        "cask": "whatpulse",
+        "count": "31"
+      }
+    ],
+    "whatroute": [
+      {
+        "cask": "whatroute",
+        "count": "117"
+      }
+    ],
+    "whatsapp": [
+      {
+        "cask": "whatsapp",
+        "count": "24,663"
+      }
+    ],
+    "whatsapp-pocket": [
+      {
+        "cask": "whatsapp-pocket",
+        "count": "18"
+      }
+    ],
+    "whatsize": [
+      {
+        "cask": "whatsize",
+        "count": "74"
+      }
+    ],
+    "whatsyoursign": [
+      {
+        "cask": "whatsyoursign",
+        "count": "233"
+      }
+    ],
+    "whereami": [
+      {
+        "cask": "whereami",
+        "count": "5"
+      }
+    ],
+    "whichspace": [
+      {
+        "cask": "whichspace",
+        "count": "135"
+      }
+    ],
+    "whiskey": [
+      {
+        "cask": "whiskey",
+        "count": "1"
+      }
+    ],
+    "whiteclock": [
+      {
+        "cask": "whiteclock",
+        "count": "2"
+      }
+    ],
+    "whither": [
+      {
+        "cask": "whither",
+        "count": "5"
+      }
+    ],
+    "whoozle-android-file-transfer": [
+      {
+        "cask": "whoozle-android-file-transfer",
+        "count": "593"
+      }
+    ],
+    "whoozle-android-file-transfer-nightly": [
+      {
+        "cask": "whoozle-android-file-transfer-nightly",
+        "count": "82"
+      }
+    ],
+    "wickrme": [
+      {
+        "cask": "wickrme",
+        "count": "366"
+      }
+    ],
+    "wickrpro": [
+      {
+        "cask": "wickrpro",
+        "count": "53"
+      }
+    ],
+    "widelands": [
+      {
+        "cask": "widelands",
+        "count": "79"
+      }
+    ],
+    "widgetrunner": [
+      {
+        "cask": "widgetrunner",
+        "count": "1"
+      }
+    ],
+    "wifi-explorer": [
+      {
+        "cask": "wifi-explorer",
+        "count": "549"
+      }
+    ],
+    "wifispoof": [
+      {
+        "cask": "wifispoof",
+        "count": "218"
+      }
+    ],
+    "wifispy-1-0-1": [
+      {
+        "cask": "wifispy-1-0-1",
+        "count": "1"
+      }
+    ],
+    "wiiuinjector-gui": [
+      {
+        "cask": "wiiuinjector-gui",
+        "count": "29"
+      }
+    ],
+    "wimlib-1.13.1.tar.gz": [
+      {
+        "cask": "wimlib-1.13.1.tar.gz",
+        "count": "1"
+      }
+    ],
+    "window-switch": [
+      {
+        "cask": "window-switch",
+        "count": "32"
+      }
+    ],
+    "windows95": [
+      {
+        "cask": "windows95",
+        "count": "258"
+      }
+    ],
+    "windowswitcher": [
+      {
+        "cask": "windowswitcher",
+        "count": "1"
+      }
+    ],
+    "winds": [
+      {
+        "cask": "winds",
+        "count": "126"
+      }
+    ],
+    "windscribe": [
+      {
+        "cask": "windscribe",
+        "count": "1,512"
+      }
+    ],
+    "wine-crossover": [
+      {
+        "cask": "wine-crossover",
+        "count": "76"
+      }
+    ],
+    "wine-devel": [
+      {
+        "cask": "wine-devel",
+        "count": "4,188"
+      }
+    ],
+    "wine-stable": [
+      {
+        "cask": "wine-stable",
+        "count": "43,139"
+      }
+    ],
+    "wine-staging": [
+      {
+        "cask": "wine-staging",
+        "count": "1,361"
+      }
+    ],
+    "winebottler": [
+      {
+        "cask": "winebottler",
+        "count": "81"
+      }
+    ],
+    "wineskin-winery": [
+      {
+        "cask": "wineskin-winery",
+        "count": "2,027"
+      }
+    ],
+    "winfo": [
+      {
+        "cask": "winfo",
+        "count": "2"
+      }
+    ],
+    "wingfs": [
+      {
+        "cask": "wingfs",
+        "count": "1"
+      }
+    ],
+    "wingpersonal": [
+      {
+        "cask": "wingpersonal",
+        "count": "61"
+      }
+    ],
+    "wings3d": [
+      {
+        "cask": "wings3d",
+        "count": "94"
+      }
+    ],
+    "wintertime": [
+      {
+        "cask": "wintertime",
+        "count": "40"
+      }
+    ],
+    "winzip": [
+      {
+        "cask": "winzip",
+        "count": "572"
+      }
+    ],
+    "wire": [
+      {
+        "cask": "wire",
+        "count": "432"
+      }
+    ],
+    "wireframe-sketcher": [
+      {
+        "cask": "wireframe-sketcher",
+        "count": "34"
+      }
+    ],
+    "wireshark": [
+      {
+        "cask": "wireshark",
+        "count": "42,704"
+      }
+    ],
+    "wireshark-chmodbpf": [
+      {
+        "cask": "wireshark-chmodbpf",
+        "count": "3,347"
+      }
+    ],
+    "wireshark_": [
+      {
+        "cask": "wireshark_",
+        "count": "1"
+      }
+    ],
+    "wiretap-studio": [
+      {
+        "cask": "wiretap-studio",
+        "count": "1"
+      }
+    ],
+    "wiring": [
+      {
+        "cask": "wiring",
+        "count": "2"
+      }
+    ],
+    "wisealpha-development-environment-cask": [
+      {
+        "cask": "wisealpha-development-environment-cask",
+        "count": "1"
+      }
+    ],
+    "witch": [
+      {
+        "cask": "witch",
+        "count": "588"
+      }
+    ],
+    "with-binary": [
+      {
+        "cask": "with-binary",
+        "count": "1"
+      }
+    ],
+    "with-caveats": [
+      {
+        "cask": "with-caveats",
+        "count": "1"
+      }
+    ],
+    "with-depends-on-arch": [
+      {
+        "cask": "with-depends-on-arch",
+        "count": "2"
+      }
+    ],
+    "with-depends-on-cask": [
+      {
+        "cask": "with-depends-on-cask",
+        "count": "1"
+      }
+    ],
+    "with-depends-on-macos-array": [
+      {
+        "cask": "with-depends-on-macos-array",
+        "count": "2"
+      }
+    ],
+    "with-depends-on-macos-comparison": [
+      {
+        "cask": "with-depends-on-macos-comparison",
+        "count": "2"
+      }
+    ],
+    "with-depends-on-macos-symbol": [
+      {
+        "cask": "with-depends-on-macos-symbol",
+        "count": "2"
+      }
+    ],
+    "with-depends-on-x11": [
+      {
+        "cask": "with-depends-on-x11",
+        "count": "1"
+      }
+    ],
+    "with-depends-on-x11-false": [
+      {
+        "cask": "with-depends-on-x11-false",
+        "count": "1"
+      }
+    ],
+    "with-installer-manual": [
+      {
+        "cask": "with-installer-manual",
+        "count": "1"
+      }
+    ],
+    "with-macosx-dir": [
+      {
+        "cask": "with-macosx-dir",
+        "count": "1"
+      }
+    ],
+    "with-uninstall-script-app": [
+      {
+        "cask": "with-uninstall-script-app",
+        "count": "4"
+      }
+    ],
+    "withings-scale": [
+      {
+        "cask": "withings-scale",
+        "count": "1"
+      }
+    ],
+    "wiznote": [
+      {
+        "cask": "wiznote",
+        "count": "241"
+      }
+    ],
+    "wjoy": [
+      {
+        "cask": "wjoy",
+        "count": "43"
+      }
+    ],
+    "wkhtmltopdf": [
+      {
+        "cask": "wkhtmltopdf",
+        "count": "22,166"
+      }
+    ],
+    "wkhtmltopdf01221": [
+      {
+        "cask": "wkhtmltopdf01221",
+        "count": "3"
+      }
+    ],
+    "wkhtmltopdf0125": [
+      {
+        "cask": "wkhtmltopdf0125",
+        "count": "26"
+      }
+    ],
+    "wko": [
+      {
+        "cask": "wko",
+        "count": "9"
+      }
+    ],
+    "wonderfultools": [
+      {
+        "cask": "wonderfultools",
+        "count": "2"
+      }
+    ],
+    "wonderfultools-screensaver": [
+      {
+        "cask": "wonderfultools-screensaver",
+        "count": "29"
+      }
+    ],
+    "wondershare-filmora": [
+      {
+        "cask": "wondershare-filmora",
+        "count": "97"
+      }
+    ],
+    "wondershare-player": [
+      {
+        "cask": "wondershare-player",
+        "count": "17"
+      }
+    ],
+    "wordmark": [
+      {
+        "cask": "wordmark",
+        "count": "7"
+      }
+    ],
+    "wordpresscom": [
+      {
+        "cask": "wordpresscom",
+        "count": "386"
+      }
+    ],
+    "wordservice": [
+      {
+        "cask": "wordservice",
+        "count": "62"
+      }
+    ],
+    "workbench": [
+      {
+        "cask": "workbench",
+        "count": "373"
+      }
+    ],
+    "workflowy": [
+      {
+        "cask": "workflowy",
+        "count": "717"
+      }
+    ],
+    "workflowy-beta": [
+      {
+        "cask": "workflowy-beta",
+        "count": "11"
+      }
+    ],
+    "workplace-chat": [
+      {
+        "cask": "workplace-chat",
+        "count": "502"
+      }
+    ],
+    "world-of-tanks": [
+      {
+        "cask": "world-of-tanks",
+        "count": "6"
+      }
+    ],
+    "wowdoge": [
+      {
+        "cask": "wowdoge",
+        "count": "1"
+      }
+    ],
+    "wowmatrix": [
+      {
+        "cask": "wowmatrix",
+        "count": "34"
+      }
+    ],
+    "wpilib": [
+      {
+        "cask": "wpilib",
+        "count": "14"
+      }
+    ],
+    "wpilib@2019": [
+      {
+        "cask": "wpilib@2019",
+        "count": "4"
+      }
+    ],
+    "wpsoffice": [
+      {
+        "cask": "wpsoffice",
+        "count": "2,733"
+      }
+    ],
+    "wpsoffice-cn": [
+      {
+        "cask": "wpsoffice-cn",
+        "count": "2"
+      }
+    ],
+    "wraparound": [
+      {
+        "cask": "wraparound",
+        "count": "57"
+      }
+    ],
+    "wrike": [
+      {
+        "cask": "wrike",
+        "count": "82"
+      }
+    ],
+    "writefull": [
+      {
+        "cask": "writefull",
+        "count": "84"
+      }
+    ],
+    "writemapper": [
+      {
+        "cask": "writemapper",
+        "count": "4"
+      }
+    ],
+    "writer": [
+      {
+        "cask": "writer",
+        "count": "33"
+      }
+    ],
+    "wwdc": [
+      {
+        "cask": "wwdc",
+        "count": "784"
+      }
+    ],
+    "wwdcsrt": [
+      {
+        "cask": "wwdcsrt",
+        "count": "6"
+      }
+    ],
+    "www.do365.vip.monosnap-3.5.5": [
+      {
+        "cask": "www.do365.vip.monosnap-3.5.5",
+        "count": "9"
+      }
+    ],
+    "www.do365.vip.navicat-for-mongodb12.1.13-tnt": [
+      {
+        "cask": "www.do365.vip.navicat-for-mongodb12.1.13-tnt",
+        "count": "6"
+      }
+    ],
+    "wxcrafter": [
+      {
+        "cask": "wxcrafter",
+        "count": "27"
+      }
+    ],
+    "x-air-edit": [
+      {
+        "cask": "x-air-edit",
+        "count": "1"
+      }
+    ],
+    "x-lite": [
+      {
+        "cask": "x-lite",
+        "count": "287"
+      }
+    ],
+    "x-mirage": [
+      {
+        "cask": "x-mirage",
+        "count": "59"
+      }
+    ],
+    "x-moto": [
+      {
+        "cask": "x-moto",
+        "count": "23"
+      }
+    ],
+    "x2goclient": [
+      {
+        "cask": "x2goclient",
+        "count": "1,628"
+      }
+    ],
+    "x32-edit": [
+      {
+        "cask": "x32-edit",
+        "count": "1"
+      }
+    ],
+    "x48": [
+      {
+        "cask": "x48",
+        "count": "92"
+      }
+    ],
+    "xact": [
+      {
+        "cask": "xact",
+        "count": "236"
+      }
+    ],
+    "xamarin": [
+      {
+        "cask": "xamarin",
+        "count": "344"
+      }
+    ],
+    "xamarin-android": [
+      {
+        "cask": "xamarin-android",
+        "count": "511"
+      }
+    ],
+    "xamarin-android-player": [
+      {
+        "cask": "xamarin-android-player",
+        "count": "58"
+      }
+    ],
+    "xamarin-ios": [
+      {
+        "cask": "xamarin-ios",
+        "count": "459"
+      }
+    ],
+    "xamarin-ios-preview": [
+      {
+        "cask": "xamarin-ios-preview",
+        "count": "2"
+      }
+    ],
+    "xamarin-mac": [
+      {
+        "cask": "xamarin-mac",
+        "count": "233"
+      }
+    ],
+    "xamarin-profiler": [
+      {
+        "cask": "xamarin-profiler",
+        "count": "73"
+      }
+    ],
+    "xamarin-studio": [
+      {
+        "cask": "xamarin-studio",
+        "count": "237"
+      }
+    ],
+    "xamarin-workbooks": [
+      {
+        "cask": "xamarin-workbooks",
+        "count": "29"
+      }
+    ],
+    "xampp": [
+      {
+        "cask": "xampp",
+        "count": "1,999"
+      }
+    ],
+    "xampp-vm": [
+      {
+        "cask": "xampp-vm",
+        "count": "125"
+      }
+    ],
+    "xaos": [
+      {
+        "cask": "xaos",
+        "count": "84"
+      }
+    ],
+    "xattred": [
+      {
+        "cask": "xattred",
+        "count": "11"
+      }
+    ],
+    "xbench": [
+      {
+        "cask": "xbench",
+        "count": "111"
+      }
+    ],
+    "xbox360-controller-driver-unofficial": [
+      {
+        "cask": "xbox360-controller-driver-unofficial",
+        "count": "285"
+      }
+    ],
+    "xca": [
+      {
+        "cask": "xca",
+        "count": "675"
+      }
+    ],
+    "xccello": [
+      {
+        "cask": "xccello",
+        "count": "1"
+      }
+    ],
+    "xcode-clang-format": [
+      {
+        "cask": "xcode-clang-format",
+        "count": "10"
+      }
+    ],
+    "xcode@10.3": [
+      {
+        "cask": "xcode@10.3",
+        "count": "1"
+      }
+    ],
+    "xctu": [
+      {
+        "cask": "xctu",
+        "count": "43"
+      }
+    ],
+    "xdm": [
+      {
+        "cask": "xdm",
+        "count": "207"
+      }
+    ],
+    "xee": [
+      {
+        "cask": "xee",
+        "count": "609"
+      }
+    ],
+    "xerox-phaser-3250-driver": [
+      {
+        "cask": "xerox-phaser-3250-driver",
+        "count": "2"
+      }
+    ],
+    "xerox-print-driver": [
+      {
+        "cask": "xerox-print-driver",
+        "count": "145"
+      }
+    ],
+    "xfer-op-1-drum-utility": [
+      {
+        "cask": "xfer-op-1-drum-utility",
+        "count": "1"
+      }
+    ],
+    "xiami": [
+      {
+        "cask": "xiami",
+        "count": "470"
+      }
+    ],
+    "ximalaya": [
+      {
+        "cask": "ximalaya",
+        "count": "87"
+      }
+    ],
+    "xit": [
+      {
+        "cask": "xit",
+        "count": "52"
+      }
+    ],
+    "xld": [
+      {
+        "cask": "xld",
+        "count": "3,034"
+      }
+    ],
+    "xlink-kai": [
+      {
+        "cask": "xlink-kai",
+        "count": "2"
+      }
+    ],
+    "xlplayer": [
+      {
+        "cask": "xlplayer",
+        "count": "94"
+      }
+    ],
+    "xm-mt4": [
+      {
+        "cask": "xm-mt4",
+        "count": "1"
+      }
+    ],
+    "xm-mt5": [
+      {
+        "cask": "xm-mt5",
+        "count": "1"
+      }
+    ],
+    "xmenu": [
+      {
+        "cask": "xmenu",
+        "count": "2"
+      }
+    ],
+    "xmind": [
+      {
+        "cask": "xmind",
+        "count": "3,539"
+      }
+    ],
+    "xmind-zen": [
+      {
+        "cask": "xmind-zen",
+        "count": "1,695"
+      }
+    ],
+    "xmplify": [
+      {
+        "cask": "xmplify",
+        "count": "71"
+      }
+    ],
+    "xmrouter": [
+      {
+        "cask": "xmrouter",
+        "count": "27"
+      }
+    ],
+    "xnconvert": [
+      {
+        "cask": "xnconvert",
+        "count": "617"
+      }
+    ],
+    "xnview-mp": [
+      {
+        "cask": "xnview-mp",
+        "count": "1"
+      }
+    ],
+    "xnviewmp": [
+      {
+        "cask": "xnviewmp",
+        "count": "1,327"
+      }
+    ],
+    "xoctave": [
+      {
+        "cask": "xoctave",
+        "count": "521"
+      }
+    ],
+    "xonotic": [
+      {
+        "cask": "xonotic",
+        "count": "146"
+      }
+    ],
+    "xpoce": [
+      {
+        "cask": "xpoce",
+        "count": "4"
+      }
+    ],
+    "xpra": [
+      {
+        "cask": "xpra",
+        "count": "609"
+      }
+    ],
+    "xquartz": [
+      {
+        "cask": "xquartz",
+        "count": "165,381"
+      }
+    ],
+    "xquartz-beta": [
+      {
+        "cask": "xquartz-beta",
+        "count": "1"
+      }
+    ],
+    "xrg": [
+      {
+        "cask": "xrg",
+        "count": "259"
+      }
+    ],
+    "xronomorph": [
+      {
+        "cask": "xronomorph",
+        "count": "1"
+      }
+    ],
+    "xscope": [
+      {
+        "cask": "xscope",
+        "count": "723"
+      }
+    ],
+    "xscreensaver": [
+      {
+        "cask": "xscreensaver",
+        "count": "489"
+      }
+    ],
+    "xsymbolicate": [
+      {
+        "cask": "xsymbolicate",
+        "count": "1"
+      }
+    ],
+    "xtorrent": [
+      {
+        "cask": "xtorrent",
+        "count": "535"
+      }
+    ],
+    "xtrafinder": [
+      {
+        "cask": "xtrafinder",
+        "count": "2"
+      }
+    ],
+    "xversion": [
+      {
+        "cask": "xversion",
+        "count": "1"
+      }
+    ],
+    "xylink": [
+      {
+        "cask": "xylink",
+        "count": "1"
+      }
+    ],
+    "yabumi": [
+      {
+        "cask": "yabumi",
+        "count": "4"
+      }
+    ],
+    "yacreader": [
+      {
+        "cask": "yacreader",
+        "count": "2,328"
+      }
+    ],
+    "yahoo-keykey": [
+      {
+        "cask": "yahoo-keykey",
+        "count": "33"
+      }
+    ],
+    "yakyak": [
+      {
+        "cask": "yakyak",
+        "count": "781"
+      }
+    ],
+    "yam-display": [
+      {
+        "cask": "yam-display",
+        "count": "34"
+      }
+    ],
+    "yammer": [
+      {
+        "cask": "yammer",
+        "count": "279"
+      }
+    ],
+    "yandex": [
+      {
+        "cask": "yandex",
+        "count": "570"
+      }
+    ],
+    "yandex-beta": [
+      {
+        "cask": "yandex-beta",
+        "count": "8"
+      }
+    ],
+    "yandex-cloud-cli": [
+      {
+        "cask": "yandex-cloud-cli",
+        "count": "35"
+      }
+    ],
+    "yandex-disk": [
+      {
+        "cask": "yandex-disk",
+        "count": "432"
+      }
+    ],
+    "yandexradio": [
+      {
+        "cask": "yandexradio",
+        "count": "60"
+      }
+    ],
+    "yasu": [
+      {
+        "cask": "yasu",
+        "count": "5"
+      }
+    ],
+    "yate": [
+      {
+        "cask": "yate",
+        "count": "215"
+      }
+    ],
+    "yc-yandexcloud": [
+      {
+        "cask": "yc-yandexcloud",
+        "count": "5"
+      }
+    ],
+    "yed": [
+      {
+        "cask": "yed",
+        "count": "1,778"
+      }
+    ],
+    "yemuzip": [
+      {
+        "cask": "yemuzip",
+        "count": "44"
+      }
+    ],
+    "yep": [
+      {
+        "cask": "yep",
+        "count": "30"
+      }
+    ],
+    "yinxiangbiji": [
+      {
+        "cask": "yinxiangbiji",
+        "count": "977"
+      }
+    ],
+    "ymc": [
+      {
+        "cask": "ymc",
+        "count": "3"
+      }
+    ],
+    "ynab": [
+      {
+        "cask": "ynab",
+        "count": "104"
+      }
+    ],
+    "yo": [
+      {
+        "cask": "yo",
+        "count": "167"
+      }
+    ],
+    "yoda": [
+      {
+        "cask": "yoda",
+        "count": "54"
+      }
+    ],
+    "yojimbo": [
+      {
+        "cask": "yojimbo",
+        "count": "29"
+      }
+    ],
+    "youdaodict": [
+      {
+        "cask": "youdaodict",
+        "count": "1,277"
+      }
+    ],
+    "youdaonote": [
+      {
+        "cask": "youdaonote",
+        "count": "875"
+      }
+    ],
+    "youku": [
+      {
+        "cask": "youku",
+        "count": "1,197"
+      }
+    ],
+    "youll-never-take-me-alive": [
+      {
+        "cask": "youll-never-take-me-alive",
+        "count": "18"
+      }
+    ],
+    "yourkit-java-profiler": [
+      {
+        "cask": "yourkit-java-profiler",
+        "count": "623"
+      }
+    ],
+    "youtrack-workflow": [
+      {
+        "cask": "youtrack-workflow",
+        "count": "41"
+      }
+    ],
+    "youtube-to-mp3": [
+      {
+        "cask": "youtube-to-mp3",
+        "count": "790"
+      }
+    ],
+    "youview": [
+      {
+        "cask": "youview",
+        "count": "13"
+      }
+    ],
+    "yq2.3.0": [
+      {
+        "cask": "yq2.3.0",
+        "count": "2"
+      }
+    ],
+    "ysyy": [
+      {
+        "cask": "ysyy",
+        "count": "1"
+      }
+    ],
+    "yt-music": [
+      {
+        "cask": "yt-music",
+        "count": "1,670"
+      }
+    ],
+    "yu-writer": [
+      {
+        "cask": "yu-writer",
+        "count": "67"
+      }
+    ],
+    "yubico-authenticator": [
+      {
+        "cask": "yubico-authenticator",
+        "count": "928"
+      }
+    ],
+    "yubico-yubihsm2-sdk": [
+      {
+        "cask": "yubico-yubihsm2-sdk",
+        "count": "5"
+      }
+    ],
+    "yubico-yubikey-manager": [
+      {
+        "cask": "yubico-yubikey-manager",
+        "count": "1,314"
+      }
+    ],
+    "yubico-yubikey-personalization-gui": [
+      {
+        "cask": "yubico-yubikey-personalization-gui",
+        "count": "595"
+      }
+    ],
+    "yubico-yubikey-piv-manager": [
+      {
+        "cask": "yubico-yubikey-piv-manager",
+        "count": "316"
+      }
+    ],
+    "yubikey-manager-qt": [
+      {
+        "cask": "yubikey-manager-qt",
+        "count": "1"
+      }
+    ],
+    "yubioath-desktop-beta": [
+      {
+        "cask": "yubioath-desktop-beta",
+        "count": "11"
+      }
+    ],
+    "yujitach-menumeters": [
+      {
+        "cask": "yujitach-menumeters",
+        "count": "48"
+      }
+    ],
+    "yummy-ftp": [
+      {
+        "cask": "yummy-ftp",
+        "count": "173"
+      }
+    ],
+    "yy": [
+      {
+        "cask": "yy",
+        "count": "102"
+      }
+    ],
+    "yyets": [
+      {
+        "cask": "yyets",
+        "count": "348"
+      }
+    ],
+    "zalo": [
+      {
+        "cask": "zalo",
+        "count": "148"
+      }
+    ],
+    "zampler_rx": [
+      {
+        "cask": "zampler_rx",
+        "count": "3"
+      }
+    ],
+    "zampler_trickster": [
+      {
+        "cask": "zampler_trickster",
+        "count": "1"
+      }
+    ],
+    "zandronum": [
+      {
+        "cask": "zandronum",
+        "count": "45"
+      }
+    ],
+    "zappy": [
+      {
+        "cask": "zappy",
+        "count": "29"
+      }
+    ],
+    "zazu": [
+      {
+        "cask": "zazu",
+        "count": "213"
+      }
+    ],
+    "zdoom": [
+      {
+        "cask": "zdoom",
+        "count": "55"
+      }
+    ],
+    "zebralette": [
+      {
+        "cask": "zebralette",
+        "count": "3"
+      }
+    ],
+    "zecwallet": [
+      {
+        "cask": "zecwallet",
+        "count": "7"
+      }
+    ],
+    "zeebe-modeler": [
+      {
+        "cask": "zeebe-modeler",
+        "count": "454"
+      }
+    ],
+    "zekr": [
+      {
+        "cask": "zekr",
+        "count": "4"
+      }
+    ],
+    "zenbeats": [
+      {
+        "cask": "zenbeats",
+        "count": "5"
+      }
+    ],
+    "zend-studio": [
+      {
+        "cask": "zend-studio",
+        "count": "6"
+      }
+    ],
+    "zenmap": [
+      {
+        "cask": "zenmap",
+        "count": "4,246"
+      }
+    ],
+    "zenmate-vpn": [
+      {
+        "cask": "zenmate-vpn",
+        "count": "55"
+      }
+    ],
+    "zeplin": [
+      {
+        "cask": "zeplin",
+        "count": "5,339"
+      }
+    ],
+    "zerobranestudio": [
+      {
+        "cask": "zerobranestudio",
+        "count": "189"
+      }
+    ],
+    "zeronet": [
+      {
+        "cask": "zeronet",
+        "count": "319"
+      }
+    ],
+    "zerotier-one": [
+      {
+        "cask": "zerotier-one",
+        "count": "1,783"
+      }
+    ],
+    "zesarux": [
+      {
+        "cask": "zesarux",
+        "count": "18"
+      }
+    ],
+    "zettelkasten": [
+      {
+        "cask": "zettelkasten",
+        "count": "71"
+      }
+    ],
+    "zettlr": [
+      {
+        "cask": "zettlr",
+        "count": "1,296"
+      }
+    ],
+    "zig": [
+      {
+        "cask": "zig",
+        "count": "5"
+      }
+    ],
+    "zijiewebdevtools": [
+      {
+        "cask": "zijiewebdevtools",
+        "count": "1"
+      }
+    ],
+    "zim-app": [
+      {
+        "cask": "zim-app",
+        "count": "1"
+      }
+    ],
+    "zipcleaner": [
+      {
+        "cask": "zipcleaner",
+        "count": "56"
+      }
+    ],
+    "zipeg": [
+      {
+        "cask": "zipeg",
+        "count": "62"
+      }
+    ],
+    "zoc": [
+      {
+        "cask": "zoc",
+        "count": "374"
+      }
+    ],
+    "zoho-docs": [
+      {
+        "cask": "zoho-docs",
+        "count": "28"
+      }
+    ],
+    "zoho-mail": [
+      {
+        "cask": "zoho-mail",
+        "count": "114"
+      }
+    ],
+    "zoho-workdrive": [
+      {
+        "cask": "zoho-workdrive",
+        "count": "21"
+      }
+    ],
+    "zookeeper": [
+      {
+        "cask": "zookeeper",
+        "count": "5"
+      }
+    ],
+    "zoolz": [
+      {
+        "cask": "zoolz",
+        "count": "8"
+      }
+    ],
+    "zoom": [
+      {
+        "cask": "zoom",
+        "count": "12,853"
+      }
+    ],
+    "zoom-in": [
+      {
+        "cask": "zoom-in",
+        "count": "17"
+      }
+    ],
+    "zoom-meeting": [
+      {
+        "cask": "zoom-meeting",
+        "count": "1"
+      }
+    ],
+    "zoom-us": [
+      {
+        "cask": "zoom-us",
+        "count": "1"
+      }
+    ],
+    "zoomus": [
+      {
+        "cask": "zoomus",
+        "count": "35,830"
+      }
+    ],
+    "zoomus-outlook-plugin": [
+      {
+        "cask": "zoomus-outlook-plugin",
+        "count": "751"
+      }
+    ],
+    "zotero": [
+      {
+        "cask": "zotero",
+        "count": "4,370"
+      }
+    ],
+    "zsa-wally": [
+      {
+        "cask": "zsa-wally",
+        "count": "144"
+      }
+    ],
+    "zterm": [
+      {
+        "cask": "zterm",
+        "count": "478"
+      }
+    ],
+    "zulip": [
+      {
+        "cask": "zulip",
+        "count": "553"
+      }
+    ],
+    "zulu": [
+      {
+        "cask": "zulu",
+        "count": "1,091"
+      }
+    ],
+    "zulu-cck@8": [
+      {
+        "cask": "zulu-cck@8",
+        "count": "1"
+      }
+    ],
+    "zulu-jdk11": [
+      {
+        "cask": "zulu-jdk11",
+        "count": "138"
+      }
+    ],
+    "zulu-jdk12": [
+      {
+        "cask": "zulu-jdk12",
+        "count": "22"
+      }
+    ],
+    "zulu-jdk13": [
+      {
+        "cask": "zulu-jdk13",
+        "count": "41"
+      }
+    ],
+    "zulu-jdk14": [
+      {
+        "cask": "zulu-jdk14",
+        "count": "17"
+      }
+    ],
+    "zulu-jdk15ea": [
+      {
+        "cask": "zulu-jdk15ea",
+        "count": "4"
+      }
+    ],
+    "zulu-jdk7": [
+      {
+        "cask": "zulu-jdk7",
+        "count": "19"
+      }
+    ],
+    "zulu-jdk8": [
+      {
+        "cask": "zulu-jdk8",
+        "count": "113"
+      }
+    ],
+    "zulu-mc": [
+      {
+        "cask": "zulu-mc",
+        "count": "30"
+      }
+    ],
+    "zulu-mission-control": [
+      {
+        "cask": "zulu-mission-control",
+        "count": "6"
+      }
+    ],
+    "zulu10": [
+      {
+        "cask": "zulu10",
+        "count": "1"
+      }
+    ],
+    "zulu11": [
+      {
+        "cask": "zulu11",
+        "count": "2,462"
+      }
+    ],
+    "zulu13": [
+      {
+        "cask": "zulu13",
+        "count": "34"
+      }
+    ],
+    "zulu14": [
+      {
+        "cask": "zulu14",
+        "count": "1"
+      }
+    ],
+    "zulu7": [
+      {
+        "cask": "zulu7",
+        "count": "1,503"
+      }
+    ],
+    "zulu8": [
+      {
+        "cask": "zulu8",
+        "count": "5,192"
+      }
+    ],
+    "zulu8sa@38": [
+      {
+        "cask": "zulu8sa@38",
+        "count": "4"
+      }
+    ],
+    "zulu9": [
+      {
+        "cask": "zulu9",
+        "count": "1"
+      }
+    ],
+    "zulu@11": [
+      {
+        "cask": "zulu@11",
+        "count": "1"
+      }
+    ],
+    "zulu@8": [
+      {
+        "cask": "zulu@8",
+        "count": "1"
+      }
+    ],
+    "zulutest": [
+      {
+        "cask": "zuluTest",
+        "count": "2"
+      }
+    ],
+    "zwift": [
+      {
+        "cask": "zwift",
+        "count": "204"
+      }
+    ],
+    "zxfast": [
+      {
+        "cask": "zxfast",
+        "count": "1"
+      }
+    ],
+    "zxpinstaller": [
+      {
+        "cask": "zxpinstaller",
+        "count": "74"
+      }
+    ]
+  }
+}

--- a/_data/analytics/cask-install/homebrew-cask/90d.json
+++ b/_data/analytics/cask-install/homebrew-cask/90d.json
@@ -1,0 +1,37353 @@
+{
+  "category": "cask_install",
+  "total_items": 6224,
+  "start_date": "2020-02-06",
+  "end_date": "2020-05-06",
+  "total_count": 13953085,
+  "formulae": {
+    "0-ad": [
+      {
+        "cask": "0-ad",
+        "count": "113"
+      }
+    ],
+    "010-editor": [
+      {
+        "cask": "010-editor",
+        "count": "102"
+      }
+    ],
+    "0xed": [
+      {
+        "cask": "0xed",
+        "count": "274"
+      }
+    ],
+    "115browser": [
+      {
+        "cask": "115browser",
+        "count": "92"
+      }
+    ],
+    "1clipboard": [
+      {
+        "cask": "1clipboard",
+        "count": "95"
+      }
+    ],
+    "1password": [
+      {
+        "cask": "1password",
+        "count": "6,376"
+      }
+    ],
+    "1password-beta": [
+      {
+        "cask": "1password-beta",
+        "count": "119"
+      }
+    ],
+    "1password-cli": [
+      {
+        "cask": "1password-cli",
+        "count": "1,826"
+      }
+    ],
+    "1password6": [
+      {
+        "cask": "1password6",
+        "count": "97"
+      }
+    ],
+    "2fatotray": [
+      {
+        "cask": "2fatotray",
+        "count": "11"
+      }
+    ],
+    "32-bitcheck": [
+      {
+        "cask": "32-bitcheck",
+        "count": "7"
+      }
+    ],
+    "33-rpm": [
+      {
+        "cask": "33-rpm",
+        "count": "2"
+      }
+    ],
+    "360safe": [
+      {
+        "cask": "360safe",
+        "count": "19"
+      }
+    ],
+    "3cxphone": [
+      {
+        "cask": "3cxphone",
+        "count": "75"
+      }
+    ],
+    "3dconnexion": [
+      {
+        "cask": "3dconnexion",
+        "count": "14"
+      }
+    ],
+    "3dgenceslicer": [
+      {
+        "cask": "3dgenceslicer",
+        "count": "5"
+      }
+    ],
+    "4k-slideshow-maker": [
+      {
+        "cask": "4k-slideshow-maker",
+        "count": "9"
+      }
+    ],
+    "4k-stogram": [
+      {
+        "cask": "4k-stogram",
+        "count": "23"
+      }
+    ],
+    "4k-video-downloader": [
+      {
+        "cask": "4k-video-downloader",
+        "count": "392"
+      }
+    ],
+    "4k-video-to-mp3": [
+      {
+        "cask": "4k-video-to-mp3",
+        "count": "15"
+      }
+    ],
+    "4k-youtube-to-mp3": [
+      {
+        "cask": "4k-youtube-to-mp3",
+        "count": "108"
+      }
+    ],
+    "4peaks": [
+      {
+        "cask": "4peaks",
+        "count": "9"
+      }
+    ],
+    "5kplayer": [
+      {
+        "cask": "5kplayer",
+        "count": "126"
+      }
+    ],
+    "8bitdo-firmware-updater": [
+      {
+        "cask": "8bitdo-firmware-updater",
+        "count": "39"
+      }
+    ],
+    "a-better-finder-attributes": [
+      {
+        "cask": "a-better-finder-attributes",
+        "count": "48"
+      }
+    ],
+    "a-better-finder-rename": [
+      {
+        "cask": "a-better-finder-rename",
+        "count": "326"
+      }
+    ],
+    "a-slower-speed-of-light": [
+      {
+        "cask": "a-slower-speed-of-light",
+        "count": "11"
+      }
+    ],
+    "ableton-live": [
+      {
+        "cask": "ableton-live",
+        "count": "53"
+      }
+    ],
+    "ableton-live-intro": [
+      {
+        "cask": "ableton-live-intro",
+        "count": "15"
+      }
+    ],
+    "ableton-live-lite": [
+      {
+        "cask": "ableton-live-lite",
+        "count": "55"
+      }
+    ],
+    "ableton-live-standard": [
+      {
+        "cask": "ableton-live-standard",
+        "count": "13"
+      }
+    ],
+    "ableton-live-suite": [
+      {
+        "cask": "ableton-live-suite",
+        "count": "135"
+      }
+    ],
+    "ableton-live-suite9": [
+      {
+        "cask": "ableton-live-suite9",
+        "count": "8"
+      }
+    ],
+    "abricotine": [
+      {
+        "cask": "abricotine",
+        "count": "30"
+      }
+    ],
+    "abscissa": [
+      {
+        "cask": "abscissa",
+        "count": "16"
+      }
+    ],
+    "abstract": [
+      {
+        "cask": "abstract",
+        "count": "206"
+      }
+    ],
+    "accessmenubarapps": [
+      {
+        "cask": "accessmenubarapps",
+        "count": "45"
+      }
+    ],
+    "accurics-cli": [
+      {
+        "cask": "accurics-cli",
+        "count": "3"
+      }
+    ],
+    "ace-link": [
+      {
+        "cask": "ace-link",
+        "count": "356"
+      }
+    ],
+    "acorn": [
+      {
+        "cask": "acorn",
+        "count": "72"
+      }
+    ],
+    "acousticbrainz-gui": [
+      {
+        "cask": "acousticbrainz-gui",
+        "count": "8"
+      }
+    ],
+    "acquia-dev": [
+      {
+        "cask": "acquia-dev",
+        "count": "14"
+      }
+    ],
+    "acronis-true-image": [
+      {
+        "cask": "acronis-true-image",
+        "count": "15"
+      }
+    ],
+    "acs-acr39u-smartcard-driver": [
+      {
+        "cask": "acs-acr39u-smartcard-driver",
+        "count": "3"
+      }
+    ],
+    "acslogo": [
+      {
+        "cask": "acslogo",
+        "count": "11"
+      }
+    ],
+    "activedock": [
+      {
+        "cask": "activedock",
+        "count": "34"
+      }
+    ],
+    "activitywatch": [
+      {
+        "cask": "activitywatch",
+        "count": "119"
+      }
+    ],
+    "actual-odbc-pack": [
+      {
+        "cask": "actual-odbc-pack",
+        "count": "26"
+      }
+    ],
+    "adafruit-arduino": [
+      {
+        "cask": "adafruit-arduino",
+        "count": "20"
+      }
+    ],
+    "adapter": [
+      {
+        "cask": "adapter",
+        "count": "126"
+      }
+    ],
+    "adguard": [
+      {
+        "cask": "adguard",
+        "count": "457"
+      }
+    ],
+    "adguard-nightly": [
+      {
+        "cask": "adguard-nightly",
+        "count": "34"
+      }
+    ],
+    "adium": [
+      {
+        "cask": "adium",
+        "count": "427"
+      }
+    ],
+    "adobe-acrobat-pro": [
+      {
+        "cask": "adobe-acrobat-pro",
+        "count": "350"
+      }
+    ],
+    "adobe-acrobat-reader": [
+      {
+        "cask": "adobe-acrobat-reader",
+        "count": "5,131"
+      }
+    ],
+    "adobe-air": [
+      {
+        "cask": "adobe-air",
+        "count": "326"
+      }
+    ],
+    "adobe-air-sdk": [
+      {
+        "cask": "adobe-air-sdk",
+        "count": "20"
+      }
+    ],
+    "adobe-connect": [
+      {
+        "cask": "adobe-connect",
+        "count": "140"
+      }
+    ],
+    "adobe-creative-cloud": [
+      {
+        "cask": "adobe-creative-cloud",
+        "count": "3,339"
+      }
+    ],
+    "adobe-creative-cloud-cleaner-tool": [
+      {
+        "cask": "adobe-creative-cloud-cleaner-tool",
+        "count": "168"
+      }
+    ],
+    "adobe-digital-editions": [
+      {
+        "cask": "adobe-digital-editions",
+        "count": "370"
+      }
+    ],
+    "adobe-dng-converter": [
+      {
+        "cask": "adobe-dng-converter",
+        "count": "78"
+      }
+    ],
+    "adobe-lens-profile-creator": [
+      {
+        "cask": "adobe-lens-profile-creator",
+        "count": "6"
+      }
+    ],
+    "adobe_creative_cloud": [
+      {
+        "cask": "adobe_creative_cloud",
+        "count": "17"
+      }
+    ],
+    "adoptopenjdk": [
+      {
+        "cask": "adoptopenjdk",
+        "count": "16,460"
+      }
+    ],
+    "adoptopenjdk10": [
+      {
+        "cask": "adoptopenjdk10",
+        "count": "1,152"
+      }
+    ],
+    "adoptopenjdk11": [
+      {
+        "cask": "adoptopenjdk11",
+        "count": "16,350"
+      }
+    ],
+    "adoptopenjdk11-jre": [
+      {
+        "cask": "adoptopenjdk11-jre",
+        "count": "230"
+      }
+    ],
+    "adoptopenjdk11-openj9": [
+      {
+        "cask": "adoptopenjdk11-openj9",
+        "count": "316"
+      }
+    ],
+    "adoptopenjdk11-openj9-jre": [
+      {
+        "cask": "adoptopenjdk11-openj9-jre",
+        "count": "29"
+      }
+    ],
+    "adoptopenjdk11-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk11-openj9-jre-large",
+        "count": "8"
+      }
+    ],
+    "adoptopenjdk11-openj9-large": [
+      {
+        "cask": "adoptopenjdk11-openj9-large",
+        "count": "39"
+      }
+    ],
+    "adoptopenjdk12": [
+      {
+        "cask": "adoptopenjdk12",
+        "count": "2,449"
+      }
+    ],
+    "adoptopenjdk12-jre": [
+      {
+        "cask": "adoptopenjdk12-jre",
+        "count": "30"
+      }
+    ],
+    "adoptopenjdk12-openj9": [
+      {
+        "cask": "adoptopenjdk12-openj9",
+        "count": "45"
+      }
+    ],
+    "adoptopenjdk12-openj9-jre": [
+      {
+        "cask": "adoptopenjdk12-openj9-jre",
+        "count": "4"
+      }
+    ],
+    "adoptopenjdk12-openj9-large": [
+      {
+        "cask": "adoptopenjdk12-openj9-large",
+        "count": "5"
+      }
+    ],
+    "adoptopenjdk13": [
+      {
+        "cask": "adoptopenjdk13",
+        "count": "4,073"
+      }
+    ],
+    "adoptopenjdk13-jre": [
+      {
+        "cask": "adoptopenjdk13-jre",
+        "count": "273"
+      }
+    ],
+    "adoptopenjdk13-openj9": [
+      {
+        "cask": "adoptopenjdk13-openj9",
+        "count": "156"
+      }
+    ],
+    "adoptopenjdk13-openj9-jre": [
+      {
+        "cask": "adoptopenjdk13-openj9-jre",
+        "count": "30"
+      }
+    ],
+    "adoptopenjdk13-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk13-openj9-jre-large",
+        "count": "4"
+      }
+    ],
+    "adoptopenjdk13-openj9-large": [
+      {
+        "cask": "adoptopenjdk13-openj9-large",
+        "count": "16"
+      }
+    ],
+    "adoptopenjdk14": [
+      {
+        "cask": "adoptopenjdk14",
+        "count": "3,105"
+      }
+    ],
+    "adoptopenjdk14-jre": [
+      {
+        "cask": "adoptopenjdk14-jre",
+        "count": "104"
+      }
+    ],
+    "adoptopenjdk14-openj9": [
+      {
+        "cask": "adoptopenjdk14-openj9",
+        "count": "169"
+      }
+    ],
+    "adoptopenjdk14-openj9-jre": [
+      {
+        "cask": "adoptopenjdk14-openj9-jre",
+        "count": "32"
+      }
+    ],
+    "adoptopenjdk14-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk14-openj9-jre-large",
+        "count": "8"
+      }
+    ],
+    "adoptopenjdk14-openj9-large": [
+      {
+        "cask": "adoptopenjdk14-openj9-large",
+        "count": "22"
+      }
+    ],
+    "adoptopenjdk8": [
+      {
+        "cask": "adoptopenjdk8",
+        "count": "101,659"
+      }
+    ],
+    "adoptopenjdk8-jre": [
+      {
+        "cask": "adoptopenjdk8-jre",
+        "count": "974"
+      }
+    ],
+    "adoptopenjdk8-openj9": [
+      {
+        "cask": "adoptopenjdk8-openj9",
+        "count": "507"
+      }
+    ],
+    "adoptopenjdk8-openj9-jre": [
+      {
+        "cask": "adoptopenjdk8-openj9-jre",
+        "count": "49"
+      }
+    ],
+    "adoptopenjdk8-openj9-jre-large": [
+      {
+        "cask": "adoptopenjdk8-openj9-jre-large",
+        "count": "9"
+      }
+    ],
+    "adoptopenjdk8-openj9-large": [
+      {
+        "cask": "adoptopenjdk8-openj9-large",
+        "count": "45"
+      }
+    ],
+    "adoptopenjdk9": [
+      {
+        "cask": "adoptopenjdk9",
+        "count": "1,380"
+      }
+    ],
+    "adsr-sample-manager": [
+      {
+        "cask": "adsr-sample-manager",
+        "count": "1"
+      }
+    ],
+    "adtpro": [
+      {
+        "cask": "adtpro",
+        "count": "1"
+      }
+    ],
+    "advancedrestclient": [
+      {
+        "cask": "advancedrestclient",
+        "count": "139"
+      }
+    ],
+    "adventure": [
+      {
+        "cask": "adventure",
+        "count": "52"
+      }
+    ],
+    "adware-removal-tool": [
+      {
+        "cask": "adware-removal-tool",
+        "count": "24"
+      }
+    ],
+    "aegisub": [
+      {
+        "cask": "aegisub",
+        "count": "215"
+      }
+    ],
+    "aerial": [
+      {
+        "cask": "aerial",
+        "count": "3,620"
+      }
+    ],
+    "aether": [
+      {
+        "cask": "aether",
+        "count": "14"
+      }
+    ],
+    "aexol-remote-mouse": [
+      {
+        "cask": "aexol-remote-mouse",
+        "count": "11"
+      }
+    ],
+    "affinity-designer-beta": [
+      {
+        "cask": "affinity-designer-beta",
+        "count": "42"
+      }
+    ],
+    "affinity-photo-beta": [
+      {
+        "cask": "affinity-photo-beta",
+        "count": "67"
+      }
+    ],
+    "after-dark-classic": [
+      {
+        "cask": "after-dark-classic",
+        "count": "29"
+      }
+    ],
+    "agenda": [
+      {
+        "cask": "agenda",
+        "count": "205"
+      }
+    ],
+    "agfeo-dashboard": [
+      {
+        "cask": "agfeo-dashboard",
+        "count": "4"
+      }
+    ],
+    "aimersoft-video-converter-ultimate": [
+      {
+        "cask": "aimersoft-video-converter-ultimate",
+        "count": "7"
+      }
+    ],
+    "air-connect": [
+      {
+        "cask": "air-connect",
+        "count": "17"
+      }
+    ],
+    "air-video-server-hd": [
+      {
+        "cask": "air-video-server-hd",
+        "count": "25"
+      }
+    ],
+    "airbuddy": [
+      {
+        "cask": "airbuddy",
+        "count": "1"
+      }
+    ],
+    "aircall": [
+      {
+        "cask": "aircall",
+        "count": "16"
+      }
+    ],
+    "airdisplay": [
+      {
+        "cask": "airdisplay",
+        "count": "22"
+      }
+    ],
+    "airdroid": [
+      {
+        "cask": "airdroid",
+        "count": "177"
+      }
+    ],
+    "airflow": [
+      {
+        "cask": "airflow",
+        "count": "190"
+      }
+    ],
+    "airfoil": [
+      {
+        "cask": "airfoil",
+        "count": "140"
+      }
+    ],
+    "airmail-beta": [
+      {
+        "cask": "airmail-beta",
+        "count": "25"
+      }
+    ],
+    "airmedia": [
+      {
+        "cask": "airmedia",
+        "count": "124"
+      }
+    ],
+    "airparrot": [
+      {
+        "cask": "airparrot",
+        "count": "40"
+      }
+    ],
+    "airpass": [
+      {
+        "cask": "airpass",
+        "count": "18"
+      }
+    ],
+    "airqmon": [
+      {
+        "cask": "airqmon",
+        "count": "12"
+      }
+    ],
+    "airserver": [
+      {
+        "cask": "airserver",
+        "count": "312"
+      }
+    ],
+    "airtable": [
+      {
+        "cask": "airtable",
+        "count": "118"
+      }
+    ],
+    "airtame": [
+      {
+        "cask": "airtame",
+        "count": "117"
+      }
+    ],
+    "airtest-ide": [
+      {
+        "cask": "airtest-ide",
+        "count": "1"
+      }
+    ],
+    "airtool": [
+      {
+        "cask": "airtool",
+        "count": "45"
+      }
+    ],
+    "airtrash": [
+      {
+        "cask": "airtrash",
+        "count": "1"
+      }
+    ],
+    "airunlock": [
+      {
+        "cask": "airunlock",
+        "count": "8"
+      }
+    ],
+    "airy": [
+      {
+        "cask": "airy",
+        "count": "53"
+      }
+    ],
+    "aja-system-test": [
+      {
+        "cask": "aja-system-test",
+        "count": "39"
+      }
+    ],
+    "akai-professional-lpd8-editor": [
+      {
+        "cask": "akai-professional-lpd8-editor",
+        "count": "1"
+      }
+    ],
+    "alacritty": [
+      {
+        "cask": "alacritty",
+        "count": "9,508"
+      }
+    ],
+    "aladin": [
+      {
+        "cask": "aladin",
+        "count": "5"
+      }
+    ],
+    "alchemy": [
+      {
+        "cask": "alchemy",
+        "count": "17"
+      }
+    ],
+    "alephone": [
+      {
+        "cask": "alephone",
+        "count": "6"
+      }
+    ],
+    "aleth": [
+      {
+        "cask": "aleth",
+        "count": "3"
+      }
+    ],
+    "alfaview": [
+      {
+        "cask": "alfaview",
+        "count": "15"
+      }
+    ],
+    "alfred": [
+      {
+        "cask": "alfred",
+        "count": "9,719"
+      }
+    ],
+    "alfred-beta": [
+      {
+        "cask": "alfred-beta",
+        "count": "6"
+      }
+    ],
+    "alfred-snippetslab": [
+      {
+        "cask": "alfred-snippetslab",
+        "count": "1"
+      }
+    ],
+    "alfred-sound-bank": [
+      {
+        "cask": "alfred-sound-bank",
+        "count": "1"
+      }
+    ],
+    "alfred-things": [
+      {
+        "cask": "alfred-things",
+        "count": "1"
+      }
+    ],
+    "alfred2": [
+      {
+        "cask": "alfred2",
+        "count": "16"
+      }
+    ],
+    "alfred3": [
+      {
+        "cask": "alfred3",
+        "count": "137"
+      }
+    ],
+    "algodoo": [
+      {
+        "cask": "algodoo",
+        "count": "16"
+      }
+    ],
+    "alifix": [
+      {
+        "cask": "alifix",
+        "count": "5"
+      }
+    ],
+    "alimail": [
+      {
+        "cask": "alimail",
+        "count": "1"
+      }
+    ],
+    "alinof-timer": [
+      {
+        "cask": "alinof-timer",
+        "count": "33"
+      }
+    ],
+    "alisma": [
+      {
+        "cask": "alisma",
+        "count": "2"
+      }
+    ],
+    "aliwangwang": [
+      {
+        "cask": "aliwangwang",
+        "count": "364"
+      }
+    ],
+    "aliworkbench": [
+      {
+        "cask": "aliworkbench",
+        "count": "19"
+      }
+    ],
+    "all-in-one-messenger": [
+      {
+        "cask": "all-in-one-messenger",
+        "count": "36"
+      }
+    ],
+    "alloy": [
+      {
+        "cask": "alloy",
+        "count": "10"
+      }
+    ],
+    "alt-c": [
+      {
+        "cask": "alt-c",
+        "count": "28"
+      }
+    ],
+    "alt-tab": [
+      {
+        "cask": "alt-tab",
+        "count": "1,256"
+      }
+    ],
+    "altair-graphql-client": [
+      {
+        "cask": "altair-graphql-client",
+        "count": "818"
+      }
+    ],
+    "altdeploy": [
+      {
+        "cask": "altdeploy",
+        "count": "47"
+      }
+    ],
+    "alternote": [
+      {
+        "cask": "alternote",
+        "count": "8"
+      }
+    ],
+    "altserver": [
+      {
+        "cask": "altserver",
+        "count": "148"
+      }
+    ],
+    "alva": [
+      {
+        "cask": "alva",
+        "count": "18"
+      }
+    ],
+    "amadeus-pro": [
+      {
+        "cask": "amadeus-pro",
+        "count": "19"
+      }
+    ],
+    "amadine": [
+      {
+        "cask": "amadine",
+        "count": "5"
+      }
+    ],
+    "amazon-chime": [
+      {
+        "cask": "amazon-chime",
+        "count": "431"
+      }
+    ],
+    "amazon-music": [
+      {
+        "cask": "amazon-music",
+        "count": "529"
+      }
+    ],
+    "amazon-photos": [
+      {
+        "cask": "amazon-photos",
+        "count": "108"
+      }
+    ],
+    "amazon-workdocs": [
+      {
+        "cask": "amazon-workdocs",
+        "count": "31"
+      }
+    ],
+    "amazon-workspaces": [
+      {
+        "cask": "amazon-workspaces",
+        "count": "381"
+      }
+    ],
+    "amethyst": [
+      {
+        "cask": "amethyst",
+        "count": "4,138"
+      }
+    ],
+    "amitv87-pip": [
+      {
+        "cask": "amitv87-pip",
+        "count": "114"
+      }
+    ],
+    "amm": [
+      {
+        "cask": "amm",
+        "count": "9"
+      }
+    ],
+    "ammonite": [
+      {
+        "cask": "ammonite",
+        "count": "79"
+      }
+    ],
+    "amorphousdiskmark": [
+      {
+        "cask": "amorphousdiskmark",
+        "count": "72"
+      }
+    ],
+    "amphetamine-enhancer": [
+      {
+        "cask": "amphetamine-enhancer",
+        "count": "2"
+      }
+    ],
+    "ampps": [
+      {
+        "cask": "ampps",
+        "count": "46"
+      }
+    ],
+    "amule": [
+      {
+        "cask": "amule",
+        "count": "1"
+      }
+    ],
+    "anaconda": [
+      {
+        "cask": "anaconda",
+        "count": "10,358"
+      }
+    ],
+    "anaconda2": [
+      {
+        "cask": "anaconda2",
+        "count": "53"
+      }
+    ],
+    "ananas-analytics-desktop-edition": [
+      {
+        "cask": "ananas-analytics-desktop-edition",
+        "count": "6"
+      }
+    ],
+    "android-file-transfer": [
+      {
+        "cask": "android-file-transfer",
+        "count": "3,150"
+      }
+    ],
+    "android-messages": [
+      {
+        "cask": "android-messages",
+        "count": "165"
+      }
+    ],
+    "android-ndk": [
+      {
+        "cask": "android-ndk",
+        "count": "1,893"
+      }
+    ],
+    "android-ndk-16b": [
+      {
+        "cask": "android-ndk-16b",
+        "count": "5"
+      }
+    ],
+    "android-ndk-19b": [
+      {
+        "cask": "android-ndk-19b",
+        "count": "1"
+      }
+    ],
+    "android-ndk-for-unity@2018.2.18f1": [
+      {
+        "cask": "android-ndk-for-unity@2018.2.18f1",
+        "count": "2"
+      }
+    ],
+    "android-ndk-for-unity@2018.4.5f1": [
+      {
+        "cask": "android-ndk-for-unity@2018.4.5f1",
+        "count": "2"
+      }
+    ],
+    "android-ndk12": [
+      {
+        "cask": "android-ndk12",
+        "count": "1"
+      }
+    ],
+    "android-ndk14": [
+      {
+        "cask": "android-ndk14",
+        "count": "1"
+      }
+    ],
+    "android-ndk16": [
+      {
+        "cask": "android-ndk16",
+        "count": "1"
+      }
+    ],
+    "android-platform-tools": [
+      {
+        "cask": "android-platform-tools",
+        "count": "43,147"
+      }
+    ],
+    "android-sdk": [
+      {
+        "cask": "android-sdk",
+        "count": "14,751"
+      }
+    ],
+    "android-sdk-custom": [
+      {
+        "cask": "android-sdk-custom",
+        "count": "1"
+      }
+    ],
+    "android-studio": [
+      {
+        "cask": "android-studio",
+        "count": "7,233"
+      }
+    ],
+    "android-studio-custom": [
+      {
+        "cask": "android-studio-custom",
+        "count": "1"
+      }
+    ],
+    "android-studio-preview": [
+      {
+        "cask": "android-studio-preview",
+        "count": "159"
+      }
+    ],
+    "androidndk-15b-android": [
+      {
+        "cask": "androidndk-15b-android",
+        "count": "2"
+      }
+    ],
+    "androidtool": [
+      {
+        "cask": "androidtool",
+        "count": "420"
+      }
+    ],
+    "angband": [
+      {
+        "cask": "angband",
+        "count": "17"
+      }
+    ],
+    "angry-ip-scanner": [
+      {
+        "cask": "angry-ip-scanner",
+        "count": "717"
+      }
+    ],
+    "angular-console": [
+      {
+        "cask": "angular-console",
+        "count": "6"
+      }
+    ],
+    "anka-build": [
+      {
+        "cask": "anka-build",
+        "count": "1"
+      }
+    ],
+    "anka-flow": [
+      {
+        "cask": "anka-flow",
+        "count": "137"
+      }
+    ],
+    "anki": [
+      {
+        "cask": "anki",
+        "count": "1,875"
+      }
+    ],
+    "ankiapp-anki": [
+      {
+        "cask": "ankiapp-anki",
+        "count": "65"
+      }
+    ],
+    "anne-pro": [
+      {
+        "cask": "anne-pro",
+        "count": "2"
+      }
+    ],
+    "anonym": [
+      {
+        "cask": "anonym",
+        "count": "10"
+      }
+    ],
+    "anonymousvpn": [
+      {
+        "cask": "anonymousvpn",
+        "count": "18"
+      }
+    ],
+    "another-redis-desktop-manager": [
+      {
+        "cask": "another-redis-desktop-manager",
+        "count": "1,781"
+      }
+    ],
+    "ansible-dk": [
+      {
+        "cask": "ansible-dk",
+        "count": "41"
+      }
+    ],
+    "ansiterm2": [
+      {
+        "cask": "ansiterm2",
+        "count": "1"
+      }
+    ],
+    "antconc": [
+      {
+        "cask": "antconc",
+        "count": "15"
+      }
+    ],
+    "antsword-loader": [
+      {
+        "cask": "antsword-loader",
+        "count": "6"
+      }
+    ],
+    "anvil": [
+      {
+        "cask": "anvil",
+        "count": "26"
+      }
+    ],
+    "anybar": [
+      {
+        "cask": "anybar",
+        "count": "147"
+      }
+    ],
+    "anydesk": [
+      {
+        "cask": "anydesk",
+        "count": "1,518"
+      }
+    ],
+    "anydo": [
+      {
+        "cask": "anydo",
+        "count": "58"
+      }
+    ],
+    "anylist": [
+      {
+        "cask": "anylist",
+        "count": "46"
+      }
+    ],
+    "anylogic": [
+      {
+        "cask": "anylogic",
+        "count": "1"
+      }
+    ],
+    "anytrans": [
+      {
+        "cask": "anytrans",
+        "count": "18"
+      }
+    ],
+    "anytrans-for-android": [
+      {
+        "cask": "anytrans-for-android",
+        "count": "22"
+      }
+    ],
+    "anzeigenchef": [
+      {
+        "cask": "anzeigenchef",
+        "count": "2"
+      }
+    ],
+    "ao": [
+      {
+        "cask": "ao",
+        "count": "53"
+      }
+    ],
+    "apache-couchdb": [
+      {
+        "cask": "apache-couchdb",
+        "count": "68"
+      }
+    ],
+    "apache-directory-studio": [
+      {
+        "cask": "apache-directory-studio",
+        "count": "810"
+      }
+    ],
+    "ape": [
+      {
+        "cask": "ape",
+        "count": "1"
+      }
+    ],
+    "apfelstrudel": [
+      {
+        "cask": "apfelstrudel",
+        "count": "5"
+      }
+    ],
+    "apk-icon-editor": [
+      {
+        "cask": "apk-icon-editor",
+        "count": "11"
+      }
+    ],
+    "app-cleaner": [
+      {
+        "cask": "app-cleaner",
+        "count": "698"
+      }
+    ],
+    "app-tamer": [
+      {
+        "cask": "app-tamer",
+        "count": "37"
+      }
+    ],
+    "appcleaner": [
+      {
+        "cask": "appcleaner",
+        "count": "6,004"
+      }
+    ],
+    "appcode": [
+      {
+        "cask": "appcode",
+        "count": "368"
+      }
+    ],
+    "appcode-eap": [
+      {
+        "cask": "appcode-eap",
+        "count": "8"
+      }
+    ],
+    "appdelete": [
+      {
+        "cask": "appdelete",
+        "count": "67"
+      }
+    ],
+    "appearin": [
+      {
+        "cask": "appearin",
+        "count": "2"
+      }
+    ],
+    "appgate-sdp-client": [
+      {
+        "cask": "appgate-sdp-client",
+        "count": "60"
+      }
+    ],
+    "appgrid": [
+      {
+        "cask": "appgrid",
+        "count": "17"
+      }
+    ],
+    "appium": [
+      {
+        "cask": "appium",
+        "count": "284"
+      }
+    ],
+    "apple-brother-printer-drivers": [
+      {
+        "cask": "apple-brother-printer-drivers",
+        "count": "2"
+      }
+    ],
+    "apple-events": [
+      {
+        "cask": "apple-events",
+        "count": "19"
+      }
+    ],
+    "apple-hewlett-packard-printer-drivers": [
+      {
+        "cask": "apple-hewlett-packard-printer-drivers",
+        "count": "60"
+      }
+    ],
+    "apple-juice": [
+      {
+        "cask": "apple-juice",
+        "count": "112"
+      }
+    ],
+    "apple-yubikey-memento": [
+      {
+        "cask": "apple-yubikey-memento",
+        "count": "1"
+      }
+    ],
+    "apple2ix": [
+      {
+        "cask": "apple2ix",
+        "count": "2"
+      }
+    ],
+    "applejuice-core": [
+      {
+        "cask": "applejuice-core",
+        "count": "5"
+      }
+    ],
+    "applejuice-gui": [
+      {
+        "cask": "applejuice-gui",
+        "count": "2"
+      }
+    ],
+    "applepi-baker": [
+      {
+        "cask": "applepi-baker",
+        "count": "176"
+      }
+    ],
+    "apppolice": [
+      {
+        "cask": "apppolice",
+        "count": "72"
+      }
+    ],
+    "appshelf": [
+      {
+        "cask": "appshelf",
+        "count": "5"
+      }
+    ],
+    "appstore-quickview": [
+      {
+        "cask": "appstore-quickview",
+        "count": "9"
+      }
+    ],
+    "appstudio": [
+      {
+        "cask": "appstudio",
+        "count": "7"
+      }
+    ],
+    "apptivate": [
+      {
+        "cask": "apptivate",
+        "count": "37"
+      }
+    ],
+    "apptrap": [
+      {
+        "cask": "apptrap",
+        "count": "55"
+      }
+    ],
+    "appzapper": [
+      {
+        "cask": "appzapper",
+        "count": "219"
+      }
+    ],
+    "aptanastudio": [
+      {
+        "cask": "aptanastudio",
+        "count": "65"
+      }
+    ],
+    "aptible": [
+      {
+        "cask": "aptible",
+        "count": "376"
+      }
+    ],
+    "aqua-data-studio": [
+      {
+        "cask": "aqua-data-studio",
+        "count": "39"
+      }
+    ],
+    "aquamacs": [
+      {
+        "cask": "aquamacs",
+        "count": "200"
+      }
+    ],
+    "aquaskk": [
+      {
+        "cask": "aquaskk",
+        "count": "89"
+      }
+    ],
+    "aquaterm": [
+      {
+        "cask": "aquaterm",
+        "count": "709"
+      }
+    ],
+    "aquiline-check": [
+      {
+        "cask": "aquiline-check",
+        "count": "3"
+      }
+    ],
+    "araxis-merge": [
+      {
+        "cask": "araxis-merge",
+        "count": "186"
+      }
+    ],
+    "archi": [
+      {
+        "cask": "archi",
+        "count": "1"
+      }
+    ],
+    "archichect": [
+      {
+        "cask": "archichect",
+        "count": "4"
+      }
+    ],
+    "archipelago": [
+      {
+        "cask": "archipelago",
+        "count": "5"
+      }
+    ],
+    "archiver": [
+      {
+        "cask": "archiver",
+        "count": "96"
+      }
+    ],
+    "arduino": [
+      {
+        "cask": "arduino",
+        "count": "1,969"
+      }
+    ],
+    "arduino-nightly": [
+      {
+        "cask": "arduino-nightly",
+        "count": "8"
+      }
+    ],
+    "argos3-webviz": [
+      {
+        "cask": "argos3-webviz",
+        "count": "5"
+      }
+    ],
+    "argouml": [
+      {
+        "cask": "argouml",
+        "count": "45"
+      }
+    ],
+    "aria-maestosa": [
+      {
+        "cask": "aria-maestosa",
+        "count": "16"
+      }
+    ],
+    "aria2d": [
+      {
+        "cask": "aria2d",
+        "count": "108"
+      }
+    ],
+    "aria2gui": [
+      {
+        "cask": "aria2gui",
+        "count": "810"
+      }
+    ],
+    "ariang": [
+      {
+        "cask": "ariang",
+        "count": "63"
+      }
+    ],
+    "ark-desktop-wallet": [
+      {
+        "cask": "ark-desktop-wallet",
+        "count": "4"
+      }
+    ],
+    "armitage": [
+      {
+        "cask": "armitage",
+        "count": "184"
+      }
+    ],
+    "armory": [
+      {
+        "cask": "armory",
+        "count": "18"
+      }
+    ],
+    "arq": [
+      {
+        "cask": "arq",
+        "count": "372"
+      }
+    ],
+    "arq-cloud-backup": [
+      {
+        "cask": "arq-cloud-backup",
+        "count": "20"
+      }
+    ],
+    "arq-fix": [
+      {
+        "cask": "arq-fix",
+        "count": "1"
+      }
+    ],
+    "arq5": [
+      {
+        "cask": "arq5",
+        "count": "10"
+      }
+    ],
+    "arrayfire": [
+      {
+        "cask": "arrayfire",
+        "count": "34"
+      }
+    ],
+    "arrsync": [
+      {
+        "cask": "arrsync",
+        "count": "23"
+      }
+    ],
+    "art-directors-toolkit": [
+      {
+        "cask": "art-directors-toolkit",
+        "count": "5"
+      }
+    ],
+    "artisan": [
+      {
+        "cask": "artisan",
+        "count": "28"
+      }
+    ],
+    "artpip": [
+      {
+        "cask": "artpip",
+        "count": "17"
+      }
+    ],
+    "asc-timetables": [
+      {
+        "cask": "asc-timetables",
+        "count": "1"
+      }
+    ],
+    "ascension": [
+      {
+        "cask": "ascension",
+        "count": "16"
+      }
+    ],
+    "asciidocfx": [
+      {
+        "cask": "asciidocfx",
+        "count": "122"
+      }
+    ],
+    "asix-ax88179": [
+      {
+        "cask": "asix-ax88179",
+        "count": "49"
+      }
+    ],
+    "aspera-connect": [
+      {
+        "cask": "aspera-connect",
+        "count": "50"
+      }
+    ],
+    "asset-catalog-tinkerer": [
+      {
+        "cask": "asset-catalog-tinkerer",
+        "count": "247"
+      }
+    ],
+    "astah-professional": [
+      {
+        "cask": "astah-professional",
+        "count": "36"
+      }
+    ],
+    "astro-command-center": [
+      {
+        "cask": "astro-command-center",
+        "count": "14"
+      }
+    ],
+    "astropad": [
+      {
+        "cask": "astropad",
+        "count": "26"
+      }
+    ],
+    "astropad-studio": [
+      {
+        "cask": "astropad-studio",
+        "count": "5"
+      }
+    ],
+    "atext": [
+      {
+        "cask": "atext",
+        "count": "121"
+      }
+    ],
+    "atlantis": [
+      {
+        "cask": "atlantis",
+        "count": "15"
+      }
+    ],
+    "atlassian-companion": [
+      {
+        "cask": "atlassian-companion",
+        "count": "4"
+      }
+    ],
+    "atlauncher": [
+      {
+        "cask": "atlauncher",
+        "count": "20"
+      }
+    ],
+    "atok": [
+      {
+        "cask": "atok",
+        "count": "33"
+      }
+    ],
+    "atom": [
+      {
+        "cask": "atom",
+        "count": "14,629"
+      }
+    ],
+    "atom-beta": [
+      {
+        "cask": "atom-beta",
+        "count": "71"
+      }
+    ],
+    "atom-nightly": [
+      {
+        "cask": "atom-nightly",
+        "count": "38"
+      }
+    ],
+    "au-lab": [
+      {
+        "cask": "au-lab",
+        "count": "161"
+      }
+    ],
+    "audacity": [
+      {
+        "cask": "audacity",
+        "count": "28"
+      }
+    ],
+    "audio-hijack": [
+      {
+        "cask": "audio-hijack",
+        "count": "380"
+      }
+    ],
+    "audiobook-builder": [
+      {
+        "cask": "audiobook-builder",
+        "count": "27"
+      }
+    ],
+    "audiobookbinder": [
+      {
+        "cask": "audiobookbinder",
+        "count": "37"
+      }
+    ],
+    "audioscrobbler": [
+      {
+        "cask": "audioscrobbler",
+        "count": "6"
+      }
+    ],
+    "audioslicer": [
+      {
+        "cask": "audioslicer",
+        "count": "16"
+      }
+    ],
+    "audirvana": [
+      {
+        "cask": "audirvana",
+        "count": "66"
+      }
+    ],
+    "augur": [
+      {
+        "cask": "augur",
+        "count": "10"
+      }
+    ],
+    "aurora": [
+      {
+        "cask": "aurora",
+        "count": "17"
+      }
+    ],
+    "aurora-hdr": [
+      {
+        "cask": "aurora-hdr",
+        "count": "12"
+      }
+    ],
+    "auryo": [
+      {
+        "cask": "auryo",
+        "count": "16"
+      }
+    ],
+    "authy": [
+      {
+        "cask": "authy",
+        "count": "2,007"
+      }
+    ],
+    "autodesk-fusion360": [
+      {
+        "cask": "autodesk-fusion360",
+        "count": "363"
+      }
+    ],
+    "autodmg": [
+      {
+        "cask": "autodmg",
+        "count": "58"
+      }
+    ],
+    "autofirma": [
+      {
+        "cask": "autofirma",
+        "count": "29"
+      }
+    ],
+    "automute": [
+      {
+        "cask": "automute",
+        "count": "21"
+      }
+    ],
+    "autopkgr": [
+      {
+        "cask": "autopkgr",
+        "count": "49"
+      }
+    ],
+    "autovolume": [
+      {
+        "cask": "autovolume",
+        "count": "5"
+      }
+    ],
+    "autumn": [
+      {
+        "cask": "autumn",
+        "count": "6"
+      }
+    ],
+    "avast-secureline-vpn": [
+      {
+        "cask": "avast-secureline-vpn",
+        "count": "20"
+      }
+    ],
+    "avast-security": [
+      {
+        "cask": "avast-security",
+        "count": "313"
+      }
+    ],
+    "aveee_blender2.82": [
+      {
+        "cask": "aveee_blender2.82",
+        "count": "1"
+      }
+    ],
+    "aveee_renderman": [
+      {
+        "cask": "aveee_renderman",
+        "count": "2"
+      }
+    ],
+    "aveee_rmfh": [
+      {
+        "cask": "aveee_rmfh",
+        "count": "5"
+      }
+    ],
+    "aveee_slack": [
+      {
+        "cask": "aveee_slack",
+        "count": "1"
+      }
+    ],
+    "avg-antivirus": [
+      {
+        "cask": "avg-antivirus",
+        "count": "121"
+      }
+    ],
+    "aviatrix-vpn-client": [
+      {
+        "cask": "aviatrix-vpn-client",
+        "count": "146"
+      }
+    ],
+    "avibrazil-rdm": [
+      {
+        "cask": "avibrazil-rdm",
+        "count": "485"
+      }
+    ],
+    "avidcodecsle": [
+      {
+        "cask": "avidcodecsle",
+        "count": "17"
+      }
+    ],
+    "avidemux": [
+      {
+        "cask": "avidemux",
+        "count": "548"
+      }
+    ],
+    "avira": [
+      {
+        "cask": "avira",
+        "count": "17"
+      }
+    ],
+    "avira-antivirus": [
+      {
+        "cask": "avira-antivirus",
+        "count": "202"
+      }
+    ],
+    "avitools": [
+      {
+        "cask": "avitools",
+        "count": "11"
+      }
+    ],
+    "avocode": [
+      {
+        "cask": "avocode",
+        "count": "71"
+      }
+    ],
+    "avogadro": [
+      {
+        "cask": "avogadro",
+        "count": "73"
+      }
+    ],
+    "avogadro-graph": [
+      {
+        "cask": "avogadro-graph",
+        "count": "1"
+      }
+    ],
+    "awa": [
+      {
+        "cask": "awa",
+        "count": "5"
+      }
+    ],
+    "aware": [
+      {
+        "cask": "aware",
+        "count": "59"
+      }
+    ],
+    "awareness": [
+      {
+        "cask": "awareness",
+        "count": "35"
+      }
+    ],
+    "awips-python": [
+      {
+        "cask": "awips-python",
+        "count": "10"
+      }
+    ],
+    "aws-cli": [
+      {
+        "cask": "aws-cli",
+        "count": "2"
+      }
+    ],
+    "aws-vault": [
+      {
+        "cask": "aws-vault",
+        "count": "4,719"
+      }
+    ],
+    "awsaml": [
+      {
+        "cask": "awsaml",
+        "count": "51"
+      }
+    ],
+    "awscli": [
+      {
+        "cask": "awscli",
+        "count": "2"
+      }
+    ],
+    "awscli-v2-unofficial": [
+      {
+        "cask": "awscli-v2-unofficial",
+        "count": "3"
+      }
+    ],
+    "awsx": [
+      {
+        "cask": "awsx",
+        "count": "6"
+      }
+    ],
+    "axe-edit-iii": [
+      {
+        "cask": "axe-edit-iii",
+        "count": "2"
+      }
+    ],
+    "axe-electrum": [
+      {
+        "cask": "axe-electrum",
+        "count": "2"
+      }
+    ],
+    "axure-rp": [
+      {
+        "cask": "axure-rp",
+        "count": "247"
+      }
+    ],
+    "azure-data-studio": [
+      {
+        "cask": "azure-data-studio",
+        "count": "1,014"
+      }
+    ],
+    "back-in-time": [
+      {
+        "cask": "back-in-time",
+        "count": "13"
+      }
+    ],
+    "backblaze": [
+      {
+        "cask": "backblaze",
+        "count": "511"
+      }
+    ],
+    "backblaze-downloader": [
+      {
+        "cask": "backblaze-downloader",
+        "count": "46"
+      }
+    ],
+    "background-music": [
+      {
+        "cask": "background-music",
+        "count": "6,369"
+      }
+    ],
+    "background-music-pre": [
+      {
+        "cask": "background-music-pre",
+        "count": "88"
+      }
+    ],
+    "backlog": [
+      {
+        "cask": "backlog",
+        "count": "7"
+      }
+    ],
+    "backupandsync": [
+      {
+        "cask": "backupandsync",
+        "count": "9"
+      }
+    ],
+    "backuploupe": [
+      {
+        "cask": "backuploupe",
+        "count": "50"
+      }
+    ],
+    "badlion-client": [
+      {
+        "cask": "badlion-client",
+        "count": "9"
+      }
+    ],
+    "baiducloud": [
+      {
+        "cask": "baiducloud",
+        "count": "158"
+      }
+    ],
+    "baiduhi": [
+      {
+        "cask": "baiduhi",
+        "count": "14"
+      }
+    ],
+    "baiduinput": [
+      {
+        "cask": "baiduinput",
+        "count": "97"
+      }
+    ],
+    "baidunetdisk": [
+      {
+        "cask": "baidunetdisk",
+        "count": "2,063"
+      }
+    ],
+    "baidunetdisk2.2.2": [
+      {
+        "cask": "baidunetdisk2.2.2",
+        "count": "1"
+      }
+    ],
+    "bailiff": [
+      {
+        "cask": "bailiff",
+        "count": "2"
+      }
+    ],
+    "balance-lock": [
+      {
+        "cask": "balance-lock",
+        "count": "18"
+      }
+    ],
+    "balenaetcher": [
+      {
+        "cask": "balenaetcher",
+        "count": "7,655"
+      }
+    ],
+    "ballast": [
+      {
+        "cask": "ballast",
+        "count": "83"
+      }
+    ],
+    "balsamiq-mockups": [
+      {
+        "cask": "balsamiq-mockups",
+        "count": "32"
+      }
+    ],
+    "balsamiq-wireframes": [
+      {
+        "cask": "balsamiq-wireframes",
+        "count": "184"
+      }
+    ],
+    "bandage": [
+      {
+        "cask": "bandage",
+        "count": "5"
+      }
+    ],
+    "bankid": [
+      {
+        "cask": "bankid",
+        "count": "38"
+      }
+    ],
+    "banking-4": [
+      {
+        "cask": "banking-4",
+        "count": "39"
+      }
+    ],
+    "banktivity": [
+      {
+        "cask": "banktivity",
+        "count": "64"
+      }
+    ],
+    "banshee": [
+      {
+        "cask": "banshee",
+        "count": "21"
+      }
+    ],
+    "baretorrent": [
+      {
+        "cask": "baretorrent",
+        "count": "58"
+      }
+    ],
+    "baritone": [
+      {
+        "cask": "baritone",
+        "count": "7"
+      }
+    ],
+    "barklyjava8": [
+      {
+        "cask": "barklyjava8",
+        "count": "49"
+      }
+    ],
+    "barmaid": [
+      {
+        "cask": "barmaid",
+        "count": "1"
+      }
+    ],
+    "barrier": [
+      {
+        "cask": "barrier",
+        "count": "1,083"
+      }
+    ],
+    "bartender": [
+      {
+        "cask": "bartender",
+        "count": "1,868"
+      }
+    ],
+    "bartender-beta": [
+      {
+        "cask": "bartender-beta",
+        "count": "1"
+      }
+    ],
+    "barxtemp": [
+      {
+        "cask": "barxtemp",
+        "count": "21"
+      }
+    ],
+    "base": [
+      {
+        "cask": "base",
+        "count": "38"
+      }
+    ],
+    "basecamp": [
+      {
+        "cask": "basecamp",
+        "count": "199"
+      }
+    ],
+    "basictex": [
+      {
+        "cask": "basictex",
+        "count": "5,971"
+      }
+    ],
+    "basler-pylon": [
+      {
+        "cask": "basler-pylon",
+        "count": "1"
+      }
+    ],
+    "batchmod": [
+      {
+        "cask": "batchmod",
+        "count": "43"
+      }
+    ],
+    "bathyscaphe": [
+      {
+        "cask": "bathyscaphe",
+        "count": "65"
+      }
+    ],
+    "battery-guardian": [
+      {
+        "cask": "battery-guardian",
+        "count": "18"
+      }
+    ],
+    "battery-report": [
+      {
+        "cask": "battery-report",
+        "count": "26"
+      }
+    ],
+    "battle-net": [
+      {
+        "cask": "battle-net",
+        "count": "810"
+      }
+    ],
+    "battle-net-installer": [
+      {
+        "cask": "battle-net-installer",
+        "count": "1"
+      }
+    ],
+    "battlescribe": [
+      {
+        "cask": "battlescribe",
+        "count": "11"
+      }
+    ],
+    "baudline": [
+      {
+        "cask": "baudline",
+        "count": "14"
+      }
+    ],
+    "bbc-iplayer-downloads": [
+      {
+        "cask": "bbc-iplayer-downloads",
+        "count": "30"
+      }
+    ],
+    "bbedit": [
+      {
+        "cask": "bbedit",
+        "count": "941"
+      }
+    ],
+    "bdash": [
+      {
+        "cask": "bdash",
+        "count": "10"
+      }
+    ],
+    "bdinfo": [
+      {
+        "cask": "bdinfo",
+        "count": "5"
+      }
+    ],
+    "beacon-finder": [
+      {
+        "cask": "beacon-finder",
+        "count": "2"
+      }
+    ],
+    "beacon-scanner": [
+      {
+        "cask": "beacon-scanner",
+        "count": "18"
+      }
+    ],
+    "beagleim": [
+      {
+        "cask": "beagleim",
+        "count": "37"
+      }
+    ],
+    "beagleim-beta": [
+      {
+        "cask": "beagleim-beta",
+        "count": "4"
+      }
+    ],
+    "beaker-browser": [
+      {
+        "cask": "beaker-browser",
+        "count": "83"
+      }
+    ],
+    "beamer": [
+      {
+        "cask": "beamer",
+        "count": "123"
+      }
+    ],
+    "bean": [
+      {
+        "cask": "bean",
+        "count": "18"
+      }
+    ],
+    "beardedspice": [
+      {
+        "cask": "beardedspice",
+        "count": "325"
+      }
+    ],
+    "bearychat": [
+      {
+        "cask": "bearychat",
+        "count": "3"
+      }
+    ],
+    "beatport-pro": [
+      {
+        "cask": "beatport-pro",
+        "count": "17"
+      }
+    ],
+    "beatunes": [
+      {
+        "cask": "beatunes",
+        "count": "11"
+      }
+    ],
+    "beautune": [
+      {
+        "cask": "beautune",
+        "count": "1"
+      }
+    ],
+    "bee": [
+      {
+        "cask": "bee",
+        "count": "21"
+      }
+    ],
+    "beekeeper-studio": [
+      {
+        "cask": "beekeeper-studio",
+        "count": "2"
+      }
+    ],
+    "beersmith": [
+      {
+        "cask": "beersmith",
+        "count": "8"
+      }
+    ],
+    "behringer-x32-edit": [
+      {
+        "cask": "behringer-x32-edit",
+        "count": "3"
+      }
+    ],
+    "beoplay-software-update": [
+      {
+        "cask": "beoplay-software-update",
+        "count": "10"
+      }
+    ],
+    "bestres": [
+      {
+        "cask": "bestres",
+        "count": "22"
+      }
+    ],
+    "betaflight-configurator": [
+      {
+        "cask": "betaflight-configurator",
+        "count": "35"
+      }
+    ],
+    "better-window-manager": [
+      {
+        "cask": "better-window-manager",
+        "count": "22"
+      }
+    ],
+    "bettertouchtool": [
+      {
+        "cask": "bettertouchtool",
+        "count": "2,882"
+      }
+    ],
+    "bettertouchtool-2428": [
+      {
+        "cask": "bettertouchtool-2428",
+        "count": "1"
+      }
+    ],
+    "betterzip": [
+      {
+        "cask": "betterzip",
+        "count": "1,608"
+      }
+    ],
+    "betterzip-beta": [
+      {
+        "cask": "betterzip-beta",
+        "count": "2"
+      }
+    ],
+    "betterzipql": [
+      {
+        "cask": "betterzipql",
+        "count": "2"
+      }
+    ],
+    "between": [
+      {
+        "cask": "between",
+        "count": "12"
+      }
+    ],
+    "betwixt": [
+      {
+        "cask": "betwixt",
+        "count": "8"
+      }
+    ],
+    "beyond-compare": [
+      {
+        "cask": "beyond-compare",
+        "count": "1,234"
+      }
+    ],
+    "beyond-compare-beta": [
+      {
+        "cask": "beyond-compare-beta",
+        "count": "1"
+      }
+    ],
+    "bforartists": [
+      {
+        "cask": "bforartists",
+        "count": "2"
+      }
+    ],
+    "bfxr": [
+      {
+        "cask": "bfxr",
+        "count": "22"
+      }
+    ],
+    "bibdesk": [
+      {
+        "cask": "bibdesk",
+        "count": "454"
+      }
+    ],
+    "big-mean-folder-machine": [
+      {
+        "cask": "big-mean-folder-machine",
+        "count": "8"
+      }
+    ],
+    "bilibili": [
+      {
+        "cask": "bilibili",
+        "count": "196"
+      }
+    ],
+    "bilimini": [
+      {
+        "cask": "bilimini",
+        "count": "11"
+      }
+    ],
+    "binary-ninja": [
+      {
+        "cask": "binary-ninja",
+        "count": "29"
+      }
+    ],
+    "bino": [
+      {
+        "cask": "bino",
+        "count": "16"
+      }
+    ],
+    "biopassfido": [
+      {
+        "cask": "biopassfido",
+        "count": "1"
+      }
+    ],
+    "birdfont": [
+      {
+        "cask": "birdfont",
+        "count": "50"
+      }
+    ],
+    "biscuit": [
+      {
+        "cask": "biscuit",
+        "count": "98"
+      }
+    ],
+    "bisq": [
+      {
+        "cask": "bisq",
+        "count": "46"
+      }
+    ],
+    "bit-slicer": [
+      {
+        "cask": "bit-slicer",
+        "count": "33"
+      }
+    ],
+    "bitbar": [
+      {
+        "cask": "bitbar",
+        "count": "1,886"
+      }
+    ],
+    "bitcoin-core": [
+      {
+        "cask": "bitcoin-core",
+        "count": "115"
+      }
+    ],
+    "bitmessage": [
+      {
+        "cask": "bitmessage",
+        "count": "22"
+      }
+    ],
+    "bitrix24": [
+      {
+        "cask": "bitrix24",
+        "count": "19"
+      }
+    ],
+    "bitwarden": [
+      {
+        "cask": "bitwarden",
+        "count": "1,897"
+      }
+    ],
+    "bitwig-studio": [
+      {
+        "cask": "bitwig-studio",
+        "count": "22"
+      }
+    ],
+    "blackhole": [
+      {
+        "cask": "blackhole",
+        "count": "4,221"
+      }
+    ],
+    "blackvue-viewer": [
+      {
+        "cask": "blackvue-viewer",
+        "count": "7"
+      }
+    ],
+    "blank-screensaver": [
+      {
+        "cask": "blank-screensaver",
+        "count": "30"
+      }
+    ],
+    "blankscreen": [
+      {
+        "cask": "blankscreen",
+        "count": "1"
+      }
+    ],
+    "blender": [
+      {
+        "cask": "blender",
+        "count": "2,718"
+      }
+    ],
+    "blheli-configurator": [
+      {
+        "cask": "blheli-configurator",
+        "count": "12"
+      }
+    ],
+    "blink1control": [
+      {
+        "cask": "blink1control",
+        "count": "9"
+      }
+    ],
+    "blisk": [
+      {
+        "cask": "blisk",
+        "count": "105"
+      }
+    ],
+    "blitz": [
+      {
+        "cask": "blitz",
+        "count": "29"
+      }
+    ],
+    "blobby-volley2": [
+      {
+        "cask": "blobby-volley2",
+        "count": "21"
+      }
+    ],
+    "blockblock": [
+      {
+        "cask": "blockblock",
+        "count": "211"
+      }
+    ],
+    "blocks-code": [
+      {
+        "cask": "blocks-code",
+        "count": "3"
+      }
+    ],
+    "blockstack": [
+      {
+        "cask": "blockstack",
+        "count": "11"
+      }
+    ],
+    "blocs": [
+      {
+        "cask": "blocs",
+        "count": "18"
+      }
+    ],
+    "bloodhound": [
+      {
+        "cask": "bloodhound",
+        "count": "64"
+      }
+    ],
+    "bloomrpc": [
+      {
+        "cask": "bloomrpc",
+        "count": "3,306"
+      }
+    ],
+    "blowhole": [
+      {
+        "cask": "blowhole",
+        "count": "1"
+      }
+    ],
+    "blu-ray-player": [
+      {
+        "cask": "blu-ray-player",
+        "count": "18"
+      }
+    ],
+    "blu-ray-player-pro": [
+      {
+        "cask": "blu-ray-player-pro",
+        "count": "24"
+      }
+    ],
+    "blue-jeans": [
+      {
+        "cask": "blue-jeans",
+        "count": "2,746"
+      }
+    ],
+    "blue-jeans-browser-plugin": [
+      {
+        "cask": "blue-jeans-browser-plugin",
+        "count": "23"
+      }
+    ],
+    "bluefish": [
+      {
+        "cask": "bluefish",
+        "count": "45"
+      }
+    ],
+    "bluegriffon": [
+      {
+        "cask": "bluegriffon",
+        "count": "39"
+      }
+    ],
+    "blueharvest": [
+      {
+        "cask": "blueharvest",
+        "count": "34"
+      }
+    ],
+    "bluej": [
+      {
+        "cask": "bluej",
+        "count": "53"
+      }
+    ],
+    "bluesense": [
+      {
+        "cask": "bluesense",
+        "count": "5"
+      }
+    ],
+    "bluestacks": [
+      {
+        "cask": "bluestacks",
+        "count": "693"
+      }
+    ],
+    "bmw-vagrant": [
+      {
+        "cask": "bmw-vagrant",
+        "count": "20"
+      }
+    ],
+    "bob": [
+      {
+        "cask": "bob",
+        "count": "965"
+      }
+    ],
+    "boinc": [
+      {
+        "cask": "boinc",
+        "count": "310"
+      }
+    ],
+    "bolts": [
+      {
+        "cask": "bolts",
+        "count": "10"
+      }
+    ],
+    "bonitastudiocommunity": [
+      {
+        "cask": "bonitastudiocommunity",
+        "count": "10"
+      }
+    ],
+    "bonjeff": [
+      {
+        "cask": "bonjeff",
+        "count": "10"
+      }
+    ],
+    "bonjour-browser": [
+      {
+        "cask": "bonjour-browser",
+        "count": "72"
+      }
+    ],
+    "bookends": [
+      {
+        "cask": "bookends",
+        "count": "46"
+      }
+    ],
+    "bookmacster": [
+      {
+        "cask": "bookmacster",
+        "count": "23"
+      }
+    ],
+    "boom": [
+      {
+        "cask": "boom",
+        "count": "77"
+      }
+    ],
+    "boom-3d": [
+      {
+        "cask": "boom-3d",
+        "count": "232"
+      }
+    ],
+    "boonzi": [
+      {
+        "cask": "boonzi",
+        "count": "3"
+      }
+    ],
+    "boostnote": [
+      {
+        "cask": "boostnote",
+        "count": "995"
+      }
+    ],
+    "bootchamp": [
+      {
+        "cask": "bootchamp",
+        "count": "19"
+      }
+    ],
+    "bootstrap-studio": [
+      {
+        "cask": "bootstrap-studio",
+        "count": "34"
+      }
+    ],
+    "bootxchanger": [
+      {
+        "cask": "bootxchanger",
+        "count": "12"
+      }
+    ],
+    "borgbackup": [
+      {
+        "cask": "borgbackup",
+        "count": "597"
+      }
+    ],
+    "bose-soundtouch": [
+      {
+        "cask": "bose-soundtouch",
+        "count": "7"
+      }
+    ],
+    "bose-updater": [
+      {
+        "cask": "bose-updater",
+        "count": "36"
+      }
+    ],
+    "bossa": [
+      {
+        "cask": "bossa",
+        "count": "32"
+      }
+    ],
+    "bot-framework-emulator": [
+      {
+        "cask": "bot-framework-emulator",
+        "count": "56"
+      }
+    ],
+    "bowtie": [
+      {
+        "cask": "bowtie",
+        "count": "45"
+      }
+    ],
+    "box-drive": [
+      {
+        "cask": "box-drive",
+        "count": "282"
+      }
+    ],
+    "box-edit": [
+      {
+        "cask": "box-edit",
+        "count": "19"
+      }
+    ],
+    "box-sync": [
+      {
+        "cask": "box-sync",
+        "count": "188"
+      }
+    ],
+    "boxcryptor": [
+      {
+        "cask": "boxcryptor",
+        "count": "136"
+      }
+    ],
+    "boxer": [
+      {
+        "cask": "boxer",
+        "count": "68"
+      }
+    ],
+    "boxofsnoo-fairmount": [
+      {
+        "cask": "boxofsnoo-fairmount",
+        "count": "8"
+      }
+    ],
+    "boxy-suite": [
+      {
+        "cask": "boxy-suite",
+        "count": "13"
+      }
+    ],
+    "brackets": [
+      {
+        "cask": "brackets",
+        "count": "1,030"
+      }
+    ],
+    "bragi-updater": [
+      {
+        "cask": "bragi-updater",
+        "count": "1"
+      }
+    ],
+    "brain-workshop": [
+      {
+        "cask": "brain-workshop",
+        "count": "16"
+      }
+    ],
+    "brainfm": [
+      {
+        "cask": "brainfm",
+        "count": "16"
+      }
+    ],
+    "brave": [
+      {
+        "cask": "brave",
+        "count": "1"
+      }
+    ],
+    "brave-browser": [
+      {
+        "cask": "brave-browser",
+        "count": "6,838"
+      }
+    ],
+    "brave-browser-beta": [
+      {
+        "cask": "brave-browser-beta",
+        "count": "320"
+      }
+    ],
+    "brave-browser-dev": [
+      {
+        "cask": "brave-browser-dev",
+        "count": "80"
+      }
+    ],
+    "brave-browser-nightly": [
+      {
+        "cask": "brave-browser-nightly",
+        "count": "37"
+      }
+    ],
+    "breakaway": [
+      {
+        "cask": "breakaway",
+        "count": "4"
+      }
+    ],
+    "breaktimer": [
+      {
+        "cask": "breaktimer",
+        "count": "16"
+      }
+    ],
+    "breeze": [
+      {
+        "cask": "breeze",
+        "count": "1"
+      }
+    ],
+    "brewservicesmenubar": [
+      {
+        "cask": "brewservicesmenubar",
+        "count": "151"
+      }
+    ],
+    "brewtarget": [
+      {
+        "cask": "brewtarget",
+        "count": "13"
+      }
+    ],
+    "bria": [
+      {
+        "cask": "bria",
+        "count": "40"
+      }
+    ],
+    "bricklink-studio": [
+      {
+        "cask": "bricklink-studio",
+        "count": "42"
+      }
+    ],
+    "bricksmith": [
+      {
+        "cask": "bricksmith",
+        "count": "26"
+      }
+    ],
+    "brightness": [
+      {
+        "cask": "brightness",
+        "count": "42"
+      }
+    ],
+    "brightness-sync": [
+      {
+        "cask": "brightness-sync",
+        "count": "25"
+      }
+    ],
+    "brisk": [
+      {
+        "cask": "brisk",
+        "count": "9"
+      }
+    ],
+    "brisync": [
+      {
+        "cask": "brisync",
+        "count": "34"
+      }
+    ],
+    "brl-cad-mged": [
+      {
+        "cask": "brl-cad-mged",
+        "count": "21"
+      }
+    ],
+    "brogue": [
+      {
+        "cask": "brogue",
+        "count": "26"
+      }
+    ],
+    "brook": [
+      {
+        "cask": "brook",
+        "count": "108"
+      }
+    ],
+    "brooklyn": [
+      {
+        "cask": "brooklyn",
+        "count": "1,242"
+      }
+    ],
+    "brother-p-touch-editor": [
+      {
+        "cask": "brother-p-touch-editor",
+        "count": "10"
+      }
+    ],
+    "brother-p-touch-update-software": [
+      {
+        "cask": "brother-p-touch-update-software",
+        "count": "9"
+      }
+    ],
+    "browserosaurus": [
+      {
+        "cask": "browserosaurus",
+        "count": "158"
+      }
+    ],
+    "browserstacklocal": [
+      {
+        "cask": "browserstacklocal",
+        "count": "101"
+      }
+    ],
+    "bsm": [
+      {
+        "cask": "bsm",
+        "count": "3"
+      }
+    ],
+    "btcpayserver-vault": [
+      {
+        "cask": "btcpayserver-vault",
+        "count": "4"
+      }
+    ],
+    "bubo": [
+      {
+        "cask": "bubo",
+        "count": "3"
+      }
+    ],
+    "buckshot": [
+      {
+        "cask": "buckshot",
+        "count": "1"
+      }
+    ],
+    "buildsettingextractor": [
+      {
+        "cask": "buildsettingextractor",
+        "count": "5"
+      }
+    ],
+    "bunch": [
+      {
+        "cask": "bunch",
+        "count": "27"
+      }
+    ],
+    "bunqcommunity-bunq": [
+      {
+        "cask": "bunqcommunity-bunq",
+        "count": "33"
+      }
+    ],
+    "burn": [
+      {
+        "cask": "burn",
+        "count": "333"
+      }
+    ],
+    "burp-suite": [
+      {
+        "cask": "burp-suite",
+        "count": "445"
+      }
+    ],
+    "busycal": [
+      {
+        "cask": "busycal",
+        "count": "74"
+      }
+    ],
+    "busycontacts": [
+      {
+        "cask": "busycontacts",
+        "count": "22"
+      }
+    ],
+    "butler": [
+      {
+        "cask": "butler",
+        "count": "22"
+      }
+    ],
+    "butt": [
+      {
+        "cask": "butt",
+        "count": "75"
+      }
+    ],
+    "butter": [
+      {
+        "cask": "butter",
+        "count": "4"
+      }
+    ],
+    "buttercup": [
+      {
+        "cask": "buttercup",
+        "count": "189"
+      }
+    ],
+    "bwana": [
+      {
+        "cask": "bwana",
+        "count": "11"
+      }
+    ],
+    "bzflag": [
+      {
+        "cask": "bzflag",
+        "count": "63"
+      }
+    ],
+    "c0re100-qbittorrent": [
+      {
+        "cask": "c0re100-qbittorrent",
+        "count": "179"
+      }
+    ],
+    "cabal": [
+      {
+        "cask": "cabal",
+        "count": "179"
+      }
+    ],
+    "cacher": [
+      {
+        "cask": "cacher",
+        "count": "81"
+      }
+    ],
+    "caffeine": [
+      {
+        "cask": "caffeine",
+        "count": "3,476"
+      }
+    ],
+    "cajviewer": [
+      {
+        "cask": "cajviewer",
+        "count": "66"
+      }
+    ],
+    "cakebrew": [
+      {
+        "cask": "cakebrew",
+        "count": "2,459"
+      }
+    ],
+    "calcservice": [
+      {
+        "cask": "calcservice",
+        "count": "4"
+      }
+    ],
+    "caldigit-docking-utility": [
+      {
+        "cask": "caldigit-docking-utility",
+        "count": "28"
+      }
+    ],
+    "caldigit-thunderbolt-charging": [
+      {
+        "cask": "caldigit-thunderbolt-charging",
+        "count": "21"
+      }
+    ],
+    "calendar-366": [
+      {
+        "cask": "calendar-366",
+        "count": "7"
+      }
+    ],
+    "calibre": [
+      {
+        "cask": "calibre",
+        "count": "7,354"
+      }
+    ],
+    "callersbane": [
+      {
+        "cask": "callersbane",
+        "count": "1"
+      }
+    ],
+    "camed": [
+      {
+        "cask": "camed",
+        "count": "6"
+      }
+    ],
+    "camera-live": [
+      {
+        "cask": "camera-live",
+        "count": "84"
+      }
+    ],
+    "camerabag-photo": [
+      {
+        "cask": "camerabag-photo",
+        "count": "6"
+      }
+    ],
+    "camtasia": [
+      {
+        "cask": "camtasia",
+        "count": "116"
+      }
+    ],
+    "camtwist": [
+      {
+        "cask": "camtwist",
+        "count": "1"
+      }
+    ],
+    "camtwiststudio": [
+      {
+        "cask": "camtwiststudio",
+        "count": "1"
+      }
+    ],
+    "camunda-modeler": [
+      {
+        "cask": "camunda-modeler",
+        "count": "226"
+      }
+    ],
+    "canary": [
+      {
+        "cask": "canary",
+        "count": "84"
+      }
+    ],
+    "candybar": [
+      {
+        "cask": "candybar",
+        "count": "9"
+      }
+    ],
+    "canoe": [
+      {
+        "cask": "canoe",
+        "count": "1"
+      }
+    ],
+    "canon-captureontouch-utility": [
+      {
+        "cask": "canon-captureontouch-utility",
+        "count": "3"
+      }
+    ],
+    "canon-eos-utility": [
+      {
+        "cask": "canon-eos-utility",
+        "count": "67"
+      }
+    ],
+    "canon-ijscanner1": [
+      {
+        "cask": "canon-ijscanner1",
+        "count": "2"
+      }
+    ],
+    "canon-ijscanner13f": [
+      {
+        "cask": "canon-ijscanner13f",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner14f": [
+      {
+        "cask": "canon-ijscanner14f",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner3": [
+      {
+        "cask": "canon-ijscanner3",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner5": [
+      {
+        "cask": "canon-ijscanner5",
+        "count": "1"
+      }
+    ],
+    "canon-ijscanner6": [
+      {
+        "cask": "canon-ijscanner6",
+        "count": "1"
+      }
+    ],
+    "canon-imageformula-driver": [
+      {
+        "cask": "canon-imageformula-driver",
+        "count": "2"
+      }
+    ],
+    "canon-lide-90": [
+      {
+        "cask": "canon-lide-90",
+        "count": "7"
+      }
+    ],
+    "canon-pixma-scanner-driver-ica": [
+      {
+        "cask": "canon-pixma-scanner-driver-ica",
+        "count": "16"
+      }
+    ],
+    "canon-printer-driver": [
+      {
+        "cask": "canon-printer-driver",
+        "count": "1"
+      }
+    ],
+    "canon-scanner-driver": [
+      {
+        "cask": "canon-scanner-driver",
+        "count": "1"
+      }
+    ],
+    "canon-ufrii-lt-printer-driver": [
+      {
+        "cask": "canon-ufrii-lt-printer-driver",
+        "count": "1"
+      }
+    ],
+    "cantata": [
+      {
+        "cask": "cantata",
+        "count": "73"
+      }
+    ],
+    "caprine": [
+      {
+        "cask": "caprine",
+        "count": "797"
+      }
+    ],
+    "captain": [
+      {
+        "cask": "captain",
+        "count": "45"
+      }
+    ],
+    "captin": [
+      {
+        "cask": "captin",
+        "count": "59"
+      }
+    ],
+    "caption": [
+      {
+        "cask": "caption",
+        "count": "47"
+      }
+    ],
+    "capto": [
+      {
+        "cask": "capto",
+        "count": "32"
+      }
+    ],
+    "capture-one": [
+      {
+        "cask": "capture-one",
+        "count": "43"
+      }
+    ],
+    "carbon-copy-cloner": [
+      {
+        "cask": "carbon-copy-cloner",
+        "count": "663"
+      }
+    ],
+    "cardhop": [
+      {
+        "cask": "cardhop",
+        "count": "47"
+      }
+    ],
+    "caret": [
+      {
+        "cask": "caret",
+        "count": "31"
+      }
+    ],
+    "cask": [
+      {
+        "cask": "cask",
+        "count": "3"
+      }
+    ],
+    "catalina-cache-cleaner": [
+      {
+        "cask": "catalina-cache-cleaner",
+        "count": "31"
+      }
+    ],
+    "catch": [
+      {
+        "cask": "catch",
+        "count": "29"
+      }
+    ],
+    "cathode": [
+      {
+        "cask": "cathode",
+        "count": "24"
+      }
+    ],
+    "catlight": [
+      {
+        "cask": "catlight",
+        "count": "22"
+      }
+    ],
+    "cave-story": [
+      {
+        "cask": "cave-story",
+        "count": "25"
+      }
+    ],
+    "cbz-manager": [
+      {
+        "cask": "cbz-manager",
+        "count": "22"
+      }
+    ],
+    "ccleaner": [
+      {
+        "cask": "ccleaner",
+        "count": "852"
+      }
+    ],
+    "ccmenu": [
+      {
+        "cask": "ccmenu",
+        "count": "103"
+      }
+    ],
+    "cctalk": [
+      {
+        "cask": "cctalk",
+        "count": "14"
+      }
+    ],
+    "cd-to": [
+      {
+        "cask": "cd-to",
+        "count": "92"
+      }
+    ],
+    "celestia": [
+      {
+        "cask": "celestia",
+        "count": "1"
+      }
+    ],
+    "celldesigner": [
+      {
+        "cask": "celldesigner",
+        "count": "2"
+      }
+    ],
+    "cellery": [
+      {
+        "cask": "cellery",
+        "count": "2"
+      }
+    ],
+    "cellprofiler": [
+      {
+        "cask": "cellprofiler",
+        "count": "5"
+      }
+    ],
+    "cemu": [
+      {
+        "cask": "cemu",
+        "count": "17"
+      }
+    ],
+    "cerebro": [
+      {
+        "cask": "cerebro",
+        "count": "58"
+      }
+    ],
+    "cert-quicklook": [
+      {
+        "cask": "cert-quicklook",
+        "count": "1"
+      }
+    ],
+    "cevelop": [
+      {
+        "cask": "cevelop",
+        "count": "27"
+      }
+    ],
+    "cg-bazelisk": [
+      {
+        "cask": "cg-bazelisk",
+        "count": "2"
+      }
+    ],
+    "chai": [
+      {
+        "cask": "chai",
+        "count": "26"
+      }
+    ],
+    "chalk": [
+      {
+        "cask": "chalk",
+        "count": "34"
+      }
+    ],
+    "chameleon-ssd-optimizer": [
+      {
+        "cask": "chameleon-ssd-optimizer",
+        "count": "30"
+      }
+    ],
+    "charger-information": [
+      {
+        "cask": "charger-information",
+        "count": "1"
+      }
+    ],
+    "charles": [
+      {
+        "cask": "charles",
+        "count": "1,961"
+      }
+    ],
+    "charles-applejava": [
+      {
+        "cask": "charles-applejava",
+        "count": "4"
+      }
+    ],
+    "charles-beta": [
+      {
+        "cask": "charles-beta",
+        "count": "6"
+      }
+    ],
+    "charles3": [
+      {
+        "cask": "charles3",
+        "count": "3"
+      }
+    ],
+    "charlessoft-timetracker": [
+      {
+        "cask": "charlessoft-timetracker",
+        "count": "12"
+      }
+    ],
+    "chatmate-for-facebook": [
+      {
+        "cask": "chatmate-for-facebook",
+        "count": "32"
+      }
+    ],
+    "chatmate-for-whatsapp": [
+      {
+        "cask": "chatmate-for-whatsapp",
+        "count": "82"
+      }
+    ],
+    "chatology": [
+      {
+        "cask": "chatology",
+        "count": "12"
+      }
+    ],
+    "chatty": [
+      {
+        "cask": "chatty",
+        "count": "35"
+      }
+    ],
+    "chatwork": [
+      {
+        "cask": "chatwork",
+        "count": "103"
+      }
+    ],
+    "cheatsheet": [
+      {
+        "cask": "cheatsheet",
+        "count": "2,427"
+      }
+    ],
+    "checkpoint": [
+      {
+        "cask": "checkpoint",
+        "count": "1"
+      }
+    ],
+    "checkra1n": [
+      {
+        "cask": "checkra1n",
+        "count": "424"
+      }
+    ],
+    "checksum-validator": [
+      {
+        "cask": "checksum-validator",
+        "count": "1"
+      }
+    ],
+    "cheetah3d": [
+      {
+        "cask": "cheetah3d",
+        "count": "6"
+      }
+    ],
+    "chef-infra-client": [
+      {
+        "cask": "chef-infra-client",
+        "count": "39"
+      }
+    ],
+    "chef-workstation": [
+      {
+        "cask": "chef-workstation",
+        "count": "732"
+      }
+    ],
+    "chefdk": [
+      {
+        "cask": "chefdk",
+        "count": "810"
+      }
+    ],
+    "chemdoodle": [
+      {
+        "cask": "chemdoodle",
+        "count": "6"
+      }
+    ],
+    "chessx": [
+      {
+        "cask": "chessx",
+        "count": "49"
+      }
+    ],
+    "chiaki": [
+      {
+        "cask": "chiaki",
+        "count": "10"
+      }
+    ],
+    "chicken": [
+      {
+        "cask": "chicken",
+        "count": "59"
+      }
+    ],
+    "chirp-daily": [
+      {
+        "cask": "chirp-daily",
+        "count": "36"
+      }
+    ],
+    "chocolat": [
+      {
+        "cask": "chocolat",
+        "count": "16"
+      }
+    ],
+    "choosy": [
+      {
+        "cask": "choosy",
+        "count": "299"
+      }
+    ],
+    "chrome-devtools": [
+      {
+        "cask": "chrome-devtools",
+        "count": "146"
+      }
+    ],
+    "chrome-remote-desktop-host": [
+      {
+        "cask": "chrome-remote-desktop-host",
+        "count": "270"
+      }
+    ],
+    "chromedriver": [
+      {
+        "cask": "chromedriver",
+        "count": "42,473"
+      }
+    ],
+    "chromedriver-beta": [
+      {
+        "cask": "chromedriver-beta",
+        "count": "108"
+      }
+    ],
+    "chromedriver79": [
+      {
+        "cask": "chromedriver79",
+        "count": "1"
+      }
+    ],
+    "chromedriver80": [
+      {
+        "cask": "chromedriver80",
+        "count": "2"
+      }
+    ],
+    "chromium": [
+      {
+        "cask": "chromium",
+        "count": "6,420"
+      }
+    ],
+    "chromium-portia": [
+      {
+        "cask": "chromium-portia",
+        "count": "3"
+      }
+    ],
+    "chronicle": [
+      {
+        "cask": "chronicle",
+        "count": "6"
+      }
+    ],
+    "chronoagent": [
+      {
+        "cask": "chronoagent",
+        "count": "8"
+      }
+    ],
+    "chronos": [
+      {
+        "cask": "chronos",
+        "count": "10"
+      }
+    ],
+    "chronosync": [
+      {
+        "cask": "chronosync",
+        "count": "55"
+      }
+    ],
+    "chronycontrol": [
+      {
+        "cask": "chronycontrol",
+        "count": "16"
+      }
+    ],
+    "chrysalis": [
+      {
+        "cask": "chrysalis",
+        "count": "55"
+      }
+    ],
+    "cinch": [
+      {
+        "cask": "cinch",
+        "count": "35"
+      }
+    ],
+    "cinder": [
+      {
+        "cask": "cinder",
+        "count": "15"
+      }
+    ],
+    "cinebench": [
+      {
+        "cask": "cinebench",
+        "count": "222"
+      }
+    ],
+    "cineplay": [
+      {
+        "cask": "cineplay",
+        "count": "1"
+      }
+    ],
+    "circuit": [
+      {
+        "cask": "circuit",
+        "count": "7"
+      }
+    ],
+    "cirrus": [
+      {
+        "cask": "cirrus",
+        "count": "5"
+      }
+    ],
+    "cisco-proximity": [
+      {
+        "cask": "cisco-proximity",
+        "count": "2,230"
+      }
+    ],
+    "cisdem-data-recovery": [
+      {
+        "cask": "cisdem-data-recovery",
+        "count": "22"
+      }
+    ],
+    "cisdem-document-reader": [
+      {
+        "cask": "cisdem-document-reader",
+        "count": "10"
+      }
+    ],
+    "cisdem-pdf-converter-ocr": [
+      {
+        "cask": "cisdem-pdf-converter-ocr",
+        "count": "17"
+      }
+    ],
+    "cisdem-pdfmanagerultimate": [
+      {
+        "cask": "cisdem-pdfmanagerultimate",
+        "count": "18"
+      }
+    ],
+    "cisdem-pdftoolkit": [
+      {
+        "cask": "cisdem-pdftoolkit",
+        "count": "13"
+      }
+    ],
+    "citra": [
+      {
+        "cask": "citra",
+        "count": "79"
+      }
+    ],
+    "citrix-workspace": [
+      {
+        "cask": "citrix-workspace",
+        "count": "4"
+      }
+    ],
+    "cityofzion-neon": [
+      {
+        "cask": "cityofzion-neon",
+        "count": "24"
+      }
+    ],
+    "ck550-macos": [
+      {
+        "cask": "ck550-macos",
+        "count": "3"
+      }
+    ],
+    "ckan": [
+      {
+        "cask": "ckan",
+        "count": "30"
+      }
+    ],
+    "ckb-next": [
+      {
+        "cask": "ckb-next",
+        "count": "31"
+      }
+    ],
+    "clamxav": [
+      {
+        "cask": "clamxav",
+        "count": "132"
+      }
+    ],
+    "clashx": [
+      {
+        "cask": "clashx",
+        "count": "1,614"
+      }
+    ],
+    "clashxr": [
+      {
+        "cask": "clashxr",
+        "count": "1"
+      }
+    ],
+    "classroom-assistant": [
+      {
+        "cask": "classroom-assistant",
+        "count": "8"
+      }
+    ],
+    "clean-me": [
+      {
+        "cask": "clean-me",
+        "count": "604"
+      }
+    ],
+    "cleanapp": [
+      {
+        "cask": "cleanapp",
+        "count": "19"
+      }
+    ],
+    "cleanmymac": [
+      {
+        "cask": "cleanmymac",
+        "count": "1,979"
+      }
+    ],
+    "cleanmymac3": [
+      {
+        "cask": "cleanmymac3",
+        "count": "47"
+      }
+    ],
+    "cleanshot": [
+      {
+        "cask": "cleanshot",
+        "count": "24"
+      }
+    ],
+    "cleartext": [
+      {
+        "cask": "cleartext",
+        "count": "7"
+      }
+    ],
+    "clementine": [
+      {
+        "cask": "clementine",
+        "count": "291"
+      }
+    ],
+    "clickcharts": [
+      {
+        "cask": "clickcharts",
+        "count": "2"
+      }
+    ],
+    "clickup": [
+      {
+        "cask": "clickup",
+        "count": "98"
+      }
+    ],
+    "clion": [
+      {
+        "cask": "clion",
+        "count": "1,284"
+      }
+    ],
+    "clip-studio-paint": [
+      {
+        "cask": "clip-studio-paint",
+        "count": "55"
+      }
+    ],
+    "clipbuddy": [
+      {
+        "cask": "clipbuddy",
+        "count": "1"
+      }
+    ],
+    "clipgrab": [
+      {
+        "cask": "clipgrab",
+        "count": "202"
+      }
+    ],
+    "clipy": [
+      {
+        "cask": "clipy",
+        "count": "1,720"
+      }
+    ],
+    "cliqz": [
+      {
+        "cask": "cliqz",
+        "count": "27"
+      }
+    ],
+    "clix": [
+      {
+        "cask": "clix",
+        "count": "8"
+      }
+    ],
+    "cljstyle": [
+      {
+        "cask": "cljstyle",
+        "count": "13"
+      }
+    ],
+    "clock": [
+      {
+        "cask": "clock",
+        "count": "23"
+      }
+    ],
+    "clock-bar": [
+      {
+        "cask": "clock-bar",
+        "count": "270"
+      }
+    ],
+    "clock-signal": [
+      {
+        "cask": "clock-signal",
+        "count": "1"
+      }
+    ],
+    "clockify": [
+      {
+        "cask": "clockify",
+        "count": "197"
+      }
+    ],
+    "clocksaver": [
+      {
+        "cask": "clocksaver",
+        "count": "175"
+      }
+    ],
+    "clone-hero": [
+      {
+        "cask": "clone-hero",
+        "count": "14"
+      }
+    ],
+    "clonk": [
+      {
+        "cask": "clonk",
+        "count": "17"
+      }
+    ],
+    "cloud-pbx": [
+      {
+        "cask": "cloud-pbx",
+        "count": "1"
+      }
+    ],
+    "cloudapp": [
+      {
+        "cask": "cloudapp",
+        "count": "241"
+      }
+    ],
+    "cloudcompare": [
+      {
+        "cask": "cloudcompare",
+        "count": "39"
+      }
+    ],
+    "cloudmounter": [
+      {
+        "cask": "cloudmounter",
+        "count": "51"
+      }
+    ],
+    "cloudtv": [
+      {
+        "cask": "cloudtv",
+        "count": "19"
+      }
+    ],
+    "cloudup": [
+      {
+        "cask": "cloudup",
+        "count": "4"
+      }
+    ],
+    "cloudytabs": [
+      {
+        "cask": "cloudytabs",
+        "count": "53"
+      }
+    ],
+    "clover-configurator": [
+      {
+        "cask": "clover-configurator",
+        "count": "495"
+      }
+    ],
+    "cluster": [
+      {
+        "cask": "cluster",
+        "count": "1"
+      }
+    ],
+    "cmake": [
+      {
+        "cask": "cmake",
+        "count": "1,707"
+      }
+    ],
+    "cmake315": [
+      {
+        "cask": "cmake315",
+        "count": "11"
+      }
+    ],
+    "cmc-menulet": [
+      {
+        "cask": "cmc-menulet",
+        "count": "2"
+      }
+    ],
+    "cmd-eikana": [
+      {
+        "cask": "cmd-eikana",
+        "count": "82"
+      }
+    ],
+    "cmdtap": [
+      {
+        "cask": "cmdtap",
+        "count": "4"
+      }
+    ],
+    "cmpxat": [
+      {
+        "cask": "cmpxat",
+        "count": "1"
+      }
+    ],
+    "cn-wps": [
+      {
+        "cask": "cn-wps",
+        "count": "4"
+      }
+    ],
+    "cncjs": [
+      {
+        "cask": "cncjs",
+        "count": "14"
+      }
+    ],
+    "cncnet": [
+      {
+        "cask": "cncnet",
+        "count": "22"
+      }
+    ],
+    "coccinellida": [
+      {
+        "cask": "coccinellida",
+        "count": "12"
+      }
+    ],
+    "coccoc": [
+      {
+        "cask": "coccoc",
+        "count": "8"
+      }
+    ],
+    "cockatrice": [
+      {
+        "cask": "cockatrice",
+        "count": "53"
+      }
+    ],
+    "cocktail": [
+      {
+        "cask": "cocktail",
+        "count": "104"
+      }
+    ],
+    "cocoapods": [
+      {
+        "cask": "cocoapods",
+        "count": "285"
+      }
+    ],
+    "cocoapods-app": [
+      {
+        "cask": "cocoapods-app",
+        "count": "1"
+      }
+    ],
+    "cocoarestclient": [
+      {
+        "cask": "cocoarestclient",
+        "count": "80"
+      }
+    ],
+    "cocoaspell": [
+      {
+        "cask": "cocoaspell",
+        "count": "95"
+      }
+    ],
+    "coconutbattery": [
+      {
+        "cask": "coconutbattery",
+        "count": "1,657"
+      }
+    ],
+    "cocoscreator": [
+      {
+        "cask": "cocoscreator",
+        "count": "132"
+      }
+    ],
+    "coda": [
+      {
+        "cask": "coda",
+        "count": "133"
+      }
+    ],
+    "code-notes": [
+      {
+        "cask": "code-notes",
+        "count": "18"
+      }
+    ],
+    "code42-crashplan": [
+      {
+        "cask": "code42-crashplan",
+        "count": "1,733"
+      }
+    ],
+    "codeexpander": [
+      {
+        "cask": "codeexpander",
+        "count": "5"
+      }
+    ],
+    "codekit": [
+      {
+        "cask": "codekit",
+        "count": "100"
+      }
+    ],
+    "codelite": [
+      {
+        "cask": "codelite",
+        "count": "113"
+      }
+    ],
+    "coderunner": [
+      {
+        "cask": "coderunner",
+        "count": "225"
+      }
+    ],
+    "cold-turkey-blocker": [
+      {
+        "cask": "cold-turkey-blocker",
+        "count": "50"
+      }
+    ],
+    "collabshot": [
+      {
+        "cask": "collabshot",
+        "count": "1"
+      }
+    ],
+    "colloquy": [
+      {
+        "cask": "colloquy",
+        "count": "127"
+      }
+    ],
+    "color-oracle": [
+      {
+        "cask": "color-oracle",
+        "count": "29"
+      }
+    ],
+    "colormunki-photo": [
+      {
+        "cask": "colormunki-photo",
+        "count": "1"
+      }
+    ],
+    "colorpicker-developer": [
+      {
+        "cask": "colorpicker-developer",
+        "count": "80"
+      }
+    ],
+    "colorpicker-materialdesign": [
+      {
+        "cask": "colorpicker-materialdesign",
+        "count": "17"
+      }
+    ],
+    "colorpicker-propicker": [
+      {
+        "cask": "colorpicker-propicker",
+        "count": "34"
+      }
+    ],
+    "colorpicker-rcwebcolorpicker": [
+      {
+        "cask": "colorpicker-rcwebcolorpicker",
+        "count": "1"
+      }
+    ],
+    "colorpicker-skalacolor": [
+      {
+        "cask": "colorpicker-skalacolor",
+        "count": "70"
+      }
+    ],
+    "colors": [
+      {
+        "cask": "colors",
+        "count": "2"
+      }
+    ],
+    "colorsnapper": [
+      {
+        "cask": "colorsnapper",
+        "count": "49"
+      }
+    ],
+    "colortester": [
+      {
+        "cask": "colortester",
+        "count": "6"
+      }
+    ],
+    "colour-contrast-analyser": [
+      {
+        "cask": "colour-contrast-analyser",
+        "count": "22"
+      }
+    ],
+    "combine-pdfs": [
+      {
+        "cask": "combine-pdfs",
+        "count": "41"
+      }
+    ],
+    "comictagger": [
+      {
+        "cask": "comictagger",
+        "count": "30"
+      }
+    ],
+    "comma-chameleon": [
+      {
+        "cask": "comma-chameleon",
+        "count": "3"
+      }
+    ],
+    "command-tab-plus": [
+      {
+        "cask": "command-tab-plus",
+        "count": "37"
+      }
+    ],
+    "commander-one": [
+      {
+        "cask": "commander-one",
+        "count": "407"
+      }
+    ],
+    "commandpost": [
+      {
+        "cask": "commandpost",
+        "count": "1"
+      }
+    ],
+    "commandq": [
+      {
+        "cask": "commandq",
+        "count": "9"
+      }
+    ],
+    "comparemerge": [
+      {
+        "cask": "comparemerge",
+        "count": "62"
+      }
+    ],
+    "composercat": [
+      {
+        "cask": "composercat",
+        "count": "8"
+      }
+    ],
+    "compositor": [
+      {
+        "cask": "compositor",
+        "count": "15"
+      }
+    ],
+    "concept2-utility": [
+      {
+        "cask": "concept2-utility",
+        "count": "2"
+      }
+    ],
+    "confcrypt": [
+      {
+        "cask": "confcrypt",
+        "count": "3"
+      }
+    ],
+    "conferences": [
+      {
+        "cask": "conferences",
+        "count": "9"
+      }
+    ],
+    "confluent-hub-client": [
+      {
+        "cask": "confluent-hub-client",
+        "count": "582"
+      }
+    ],
+    "connectiq": [
+      {
+        "cask": "connectiq",
+        "count": "13"
+      }
+    ],
+    "connectmenow": [
+      {
+        "cask": "connectmenow",
+        "count": "18"
+      }
+    ],
+    "consolation3": [
+      {
+        "cask": "consolation3",
+        "count": "6"
+      }
+    ],
+    "console": [
+      {
+        "cask": "console",
+        "count": "26"
+      }
+    ],
+    "container-ps": [
+      {
+        "cask": "container-ps",
+        "count": "2"
+      }
+    ],
+    "content-manager-assistant": [
+      {
+        "cask": "content-manager-assistant",
+        "count": "3"
+      }
+    ],
+    "contexts": [
+      {
+        "cask": "contexts",
+        "count": "283"
+      }
+    ],
+    "continuity-activation-tool": [
+      {
+        "cask": "continuity-activation-tool",
+        "count": "2"
+      }
+    ],
+    "contraste": [
+      {
+        "cask": "contraste",
+        "count": "10"
+      }
+    ],
+    "controllermate": [
+      {
+        "cask": "controllermate",
+        "count": "56"
+      }
+    ],
+    "controlplane": [
+      {
+        "cask": "controlplane",
+        "count": "97"
+      }
+    ],
+    "cookie": [
+      {
+        "cask": "cookie",
+        "count": "27"
+      }
+    ],
+    "cool-retro-term": [
+      {
+        "cask": "cool-retro-term",
+        "count": "1,071"
+      }
+    ],
+    "coolterm": [
+      {
+        "cask": "coolterm",
+        "count": "187"
+      }
+    ],
+    "cooviewer": [
+      {
+        "cask": "cooviewer",
+        "count": "1"
+      }
+    ],
+    "copyclip": [
+      {
+        "cask": "copyclip",
+        "count": "182"
+      }
+    ],
+    "copyq": [
+      {
+        "cask": "copyq",
+        "count": "811"
+      }
+    ],
+    "copytranslator": [
+      {
+        "cask": "copytranslator",
+        "count": "1"
+      }
+    ],
+    "coqide": [
+      {
+        "cask": "coqide",
+        "count": "189"
+      }
+    ],
+    "cord": [
+      {
+        "cask": "cord",
+        "count": "172"
+      }
+    ],
+    "core-data-editor": [
+      {
+        "cask": "core-data-editor",
+        "count": "8"
+      }
+    ],
+    "corelocationcli": [
+      {
+        "cask": "corelocationcli",
+        "count": "112"
+      }
+    ],
+    "cornercal": [
+      {
+        "cask": "cornercal",
+        "count": "18"
+      }
+    ],
+    "cornerstone": [
+      {
+        "cask": "cornerstone",
+        "count": "42"
+      }
+    ],
+    "corona-tracker": [
+      {
+        "cask": "corona-tracker",
+        "count": "933"
+      }
+    ],
+    "coronasdk": [
+      {
+        "cask": "coronasdk",
+        "count": "12"
+      }
+    ],
+    "corretto": [
+      {
+        "cask": "corretto",
+        "count": "1,027"
+      }
+    ],
+    "corretto8": [
+      {
+        "cask": "corretto8",
+        "count": "995"
+      }
+    ],
+    "corsair-icue": [
+      {
+        "cask": "corsair-icue",
+        "count": "53"
+      }
+    ],
+    "coteditor": [
+      {
+        "cask": "coteditor",
+        "count": "669"
+      }
+    ],
+    "couchbase-server-community": [
+      {
+        "cask": "couchbase-server-community",
+        "count": "53"
+      }
+    ],
+    "couchbase-server-enterprise": [
+      {
+        "cask": "couchbase-server-enterprise",
+        "count": "11"
+      }
+    ],
+    "couchpotato": [
+      {
+        "cask": "couchpotato",
+        "count": "31"
+      }
+    ],
+    "couleurs": [
+      {
+        "cask": "couleurs",
+        "count": "27"
+      }
+    ],
+    "coverload": [
+      {
+        "cask": "coverload",
+        "count": "9"
+      }
+    ],
+    "coyim": [
+      {
+        "cask": "coyim",
+        "count": "4"
+      }
+    ],
+    "cozy-drive": [
+      {
+        "cask": "cozy-drive",
+        "count": "12"
+      }
+    ],
+    "cpuinfo": [
+      {
+        "cask": "cpuinfo",
+        "count": "123"
+      }
+    ],
+    "cr": [
+      {
+        "cask": "cr",
+        "count": "4"
+      }
+    ],
+    "cracked": [
+      {
+        "cask": "cracked",
+        "count": "1"
+      }
+    ],
+    "craftmanager": [
+      {
+        "cask": "craftmanager",
+        "count": "58"
+      }
+    ],
+    "craftos-pc": [
+      {
+        "cask": "craftos-pc",
+        "count": "2"
+      }
+    ],
+    "create-recovery-partition-installer": [
+      {
+        "cask": "create-recovery-partition-installer",
+        "count": "23"
+      }
+    ],
+    "createuserpkg": [
+      {
+        "cask": "createuserpkg",
+        "count": "10"
+      }
+    ],
+    "creepy": [
+      {
+        "cask": "creepy",
+        "count": "10"
+      }
+    ],
+    "crescendo": [
+      {
+        "cask": "crescendo",
+        "count": "2"
+      }
+    ],
+    "cricut-design-space": [
+      {
+        "cask": "cricut-design-space",
+        "count": "13"
+      }
+    ],
+    "criptext": [
+      {
+        "cask": "criptext",
+        "count": "5"
+      }
+    ],
+    "cronnix": [
+      {
+        "cask": "cronnix",
+        "count": "86"
+      }
+    ],
+    "crossover": [
+      {
+        "cask": "crossover",
+        "count": "300"
+      }
+    ],
+    "crosspack-avr": [
+      {
+        "cask": "crosspack-avr",
+        "count": "167"
+      }
+    ],
+    "crunch": [
+      {
+        "cask": "crunch",
+        "count": "66"
+      }
+    ],
+    "crushftp": [
+      {
+        "cask": "crushftp",
+        "count": "41"
+      }
+    ],
+    "crypt": [
+      {
+        "cask": "crypt",
+        "count": "79"
+      }
+    ],
+    "crypter": [
+      {
+        "cask": "crypter",
+        "count": "11"
+      }
+    ],
+    "cryptomator": [
+      {
+        "cask": "cryptomator",
+        "count": "563"
+      }
+    ],
+    "cryptr": [
+      {
+        "cask": "cryptr",
+        "count": "88"
+      }
+    ],
+    "crystal": [
+      {
+        "cask": "crystal",
+        "count": "6"
+      }
+    ],
+    "crystalmaker": [
+      {
+        "cask": "crystalmaker",
+        "count": "6"
+      }
+    ],
+    "crystax-ndk": [
+      {
+        "cask": "crystax-ndk",
+        "count": "8"
+      }
+    ],
+    "cscreen": [
+      {
+        "cask": "cscreen",
+        "count": "1,767"
+      }
+    ],
+    "cube": [
+      {
+        "cask": "cube",
+        "count": "1"
+      }
+    ],
+    "cubicsdr": [
+      {
+        "cask": "cubicsdr",
+        "count": "143"
+      }
+    ],
+    "cuda": [
+      {
+        "cask": "cuda",
+        "count": "1"
+      }
+    ],
+    "cuda-z": [
+      {
+        "cask": "cuda-z",
+        "count": "155"
+      }
+    ],
+    "cumulus": [
+      {
+        "cask": "cumulus",
+        "count": "8"
+      }
+    ],
+    "cura-lulzbot": [
+      {
+        "cask": "cura-lulzbot",
+        "count": "21"
+      }
+    ],
+    "curecon-qt": [
+      {
+        "cask": "curecon-qt",
+        "count": "1"
+      }
+    ],
+    "curio": [
+      {
+        "cask": "curio",
+        "count": "6"
+      }
+    ],
+    "cursorcerer": [
+      {
+        "cask": "cursorcerer",
+        "count": "31"
+      }
+    ],
+    "cursorsense": [
+      {
+        "cask": "cursorsense",
+        "count": "29"
+      }
+    ],
+    "cutbox": [
+      {
+        "cask": "cutbox",
+        "count": "28"
+      }
+    ],
+    "cuteclips": [
+      {
+        "cask": "cuteclips",
+        "count": "1"
+      }
+    ],
+    "cutesdr": [
+      {
+        "cask": "cutesdr",
+        "count": "22"
+      }
+    ],
+    "cutter": [
+      {
+        "cask": "cutter",
+        "count": "511"
+      }
+    ],
+    "cyberduck": [
+      {
+        "cask": "cyberduck",
+        "count": "6,194"
+      }
+    ],
+    "cyberduck-custom": [
+      {
+        "cask": "cyberduck-custom",
+        "count": "1"
+      }
+    ],
+    "cyberghost-vpn": [
+      {
+        "cask": "cyberghost-vpn",
+        "count": "62"
+      }
+    ],
+    "cycling74-max": [
+      {
+        "cask": "cycling74-max",
+        "count": "51"
+      }
+    ],
+    "cydownload": [
+      {
+        "cask": "cydownload",
+        "count": "4"
+      }
+    ],
+    "cypress-desktop": [
+      {
+        "cask": "cypress-desktop",
+        "count": "1"
+      }
+    ],
+    "cytoscape": [
+      {
+        "cask": "cytoscape",
+        "count": "55"
+      }
+    ],
+    "d3visualizer": [
+      {
+        "cask": "d3visualizer",
+        "count": "1"
+      }
+    ],
+    "daedalus": [
+      {
+        "cask": "daedalus",
+        "count": "7"
+      }
+    ],
+    "daemon-tools": [
+      {
+        "cask": "daemon-tools",
+        "count": "43"
+      }
+    ],
+    "daily-english-listening": [
+      {
+        "cask": "daily-english-listening",
+        "count": "3"
+      }
+    ],
+    "daily-wall": [
+      {
+        "cask": "daily-wall",
+        "count": "1"
+      }
+    ],
+    "daisydisk": [
+      {
+        "cask": "daisydisk",
+        "count": "1,212"
+      }
+    ],
+    "dangerzone": [
+      {
+        "cask": "dangerzone",
+        "count": "3"
+      }
+    ],
+    "darkmode": [
+      {
+        "cask": "darkmode",
+        "count": "1"
+      }
+    ],
+    "darktable": [
+      {
+        "cask": "darktable",
+        "count": "1,138"
+      }
+    ],
+    "darktable-dev": [
+      {
+        "cask": "darktable-dev",
+        "count": "8"
+      }
+    ],
+    "darwindumper": [
+      {
+        "cask": "darwindumper",
+        "count": "8"
+      }
+    ],
+    "dash": [
+      {
+        "cask": "dash",
+        "count": "3,820"
+      }
+    ],
+    "dash-dash": [
+      {
+        "cask": "dash-dash",
+        "count": "4"
+      }
+    ],
+    "dash2": [
+      {
+        "cask": "dash2",
+        "count": "10"
+      }
+    ],
+    "dash3": [
+      {
+        "cask": "dash3",
+        "count": "23"
+      }
+    ],
+    "dash4": [
+      {
+        "cask": "dash4",
+        "count": "86"
+      }
+    ],
+    "dashcam-viewer": [
+      {
+        "cask": "dashcam-viewer",
+        "count": "6"
+      }
+    ],
+    "dashlane": [
+      {
+        "cask": "dashlane",
+        "count": "457"
+      }
+    ],
+    "dat": [
+      {
+        "cask": "dat",
+        "count": "20"
+      }
+    ],
+    "dat-weather-doe": [
+      {
+        "cask": "dat-weather-doe",
+        "count": "2"
+      }
+    ],
+    "data-integration": [
+      {
+        "cask": "data-integration",
+        "count": "137"
+      }
+    ],
+    "data-rescue": [
+      {
+        "cask": "data-rescue",
+        "count": "14"
+      }
+    ],
+    "data-science-studio": [
+      {
+        "cask": "data-science-studio",
+        "count": "57"
+      }
+    ],
+    "datacolor-spyder-elite": [
+      {
+        "cask": "datacolor-spyder-elite",
+        "count": "3"
+      }
+    ],
+    "datadog-agent": [
+      {
+        "cask": "datadog-agent",
+        "count": "674"
+      }
+    ],
+    "datagraph": [
+      {
+        "cask": "datagraph",
+        "count": "48"
+      }
+    ],
+    "datagrip": [
+      {
+        "cask": "datagrip",
+        "count": "1,687"
+      }
+    ],
+    "dataloader": [
+      {
+        "cask": "dataloader",
+        "count": "12"
+      }
+    ],
+    "datazenit": [
+      {
+        "cask": "datazenit",
+        "count": "4"
+      }
+    ],
+    "datovka": [
+      {
+        "cask": "datovka",
+        "count": "26"
+      }
+    ],
+    "datweatherdoe": [
+      {
+        "cask": "datweatherdoe",
+        "count": "35"
+      }
+    ],
+    "davmail": [
+      {
+        "cask": "davmail",
+        "count": "35"
+      }
+    ],
+    "dawnlabs-alchemy": [
+      {
+        "cask": "dawnlabs-alchemy",
+        "count": "1"
+      }
+    ],
+    "day-o": [
+      {
+        "cask": "day-o",
+        "count": "160"
+      }
+    ],
+    "db-browser-for-sqlite": [
+      {
+        "cask": "db-browser-for-sqlite",
+        "count": "8,942"
+      }
+    ],
+    "dbeaver-community": [
+      {
+        "cask": "dbeaver-community",
+        "count": "10,848"
+      }
+    ],
+    "dbeaver-enterprise": [
+      {
+        "cask": "dbeaver-enterprise",
+        "count": "119"
+      }
+    ],
+    "dbglass": [
+      {
+        "cask": "dbglass",
+        "count": "35"
+      }
+    ],
+    "dbkoda": [
+      {
+        "cask": "dbkoda",
+        "count": "29"
+      }
+    ],
+    "dbngin": [
+      {
+        "cask": "dbngin",
+        "count": "131"
+      }
+    ],
+    "dbschema": [
+      {
+        "cask": "dbschema",
+        "count": "49"
+      }
+    ],
+    "dbvisualizer": [
+      {
+        "cask": "dbvisualizer",
+        "count": "464"
+      }
+    ],
+    "dcommander": [
+      {
+        "cask": "dcommander",
+        "count": "27"
+      }
+    ],
+    "dcp-o-matic": [
+      {
+        "cask": "dcp-o-matic",
+        "count": "11"
+      }
+    ],
+    "dcp-o-matic-batch-converter": [
+      {
+        "cask": "dcp-o-matic-batch-converter",
+        "count": "5"
+      }
+    ],
+    "dcp-o-matic-encode-server": [
+      {
+        "cask": "dcp-o-matic-encode-server",
+        "count": "3"
+      }
+    ],
+    "dcp-o-matic-kdm-creator": [
+      {
+        "cask": "dcp-o-matic-kdm-creator",
+        "count": "3"
+      }
+    ],
+    "dcp-o-matic-player": [
+      {
+        "cask": "dcp-o-matic-player",
+        "count": "11"
+      }
+    ],
+    "dcv-viewer": [
+      {
+        "cask": "dcv-viewer",
+        "count": "5"
+      }
+    ],
+    "dd-utility": [
+      {
+        "cask": "dd-utility",
+        "count": "42"
+      }
+    ],
+    "deadbeef-devel": [
+      {
+        "cask": "deadbeef-devel",
+        "count": "41"
+      }
+    ],
+    "deadbolt": [
+      {
+        "cask": "deadbolt",
+        "count": "11"
+      }
+    ],
+    "deathtodsstore": [
+      {
+        "cask": "deathtodsstore",
+        "count": "10"
+      }
+    ],
+    "debookee": [
+      {
+        "cask": "debookee",
+        "count": "26"
+      }
+    ],
+    "deckset": [
+      {
+        "cask": "deckset",
+        "count": "111"
+      }
+    ],
+    "deco": [
+      {
+        "cask": "deco",
+        "count": "11"
+      }
+    ],
+    "decrediton": [
+      {
+        "cask": "decrediton",
+        "count": "5"
+      }
+    ],
+    "deeper": [
+      {
+        "cask": "deeper",
+        "count": "94"
+      }
+    ],
+    "deepgit": [
+      {
+        "cask": "deepgit",
+        "count": "36"
+      }
+    ],
+    "deepl": [
+      {
+        "cask": "deepl",
+        "count": "1,197"
+      }
+    ],
+    "deepstream": [
+      {
+        "cask": "deepstream",
+        "count": "5"
+      }
+    ],
+    "deeptools": [
+      {
+        "cask": "deeptools",
+        "count": "2"
+      }
+    ],
+    "deezer": [
+      {
+        "cask": "deezer",
+        "count": "389"
+      }
+    ],
+    "default-folder-x": [
+      {
+        "cask": "default-folder-x",
+        "count": "107"
+      }
+    ],
+    "deflemask": [
+      {
+        "cask": "deflemask",
+        "count": "1"
+      }
+    ],
+    "dejalu": [
+      {
+        "cask": "dejalu",
+        "count": "7"
+      }
+    ],
+    "delayedlauncher": [
+      {
+        "cask": "delayedlauncher",
+        "count": "5"
+      }
+    ],
+    "delibar": [
+      {
+        "cask": "delibar",
+        "count": "2"
+      }
+    ],
+    "delicious-library": [
+      {
+        "cask": "delicious-library",
+        "count": "6"
+      }
+    ],
+    "delighted": [
+      {
+        "cask": "delighted",
+        "count": "6"
+      }
+    ],
+    "delta": [
+      {
+        "cask": "delta",
+        "count": "12"
+      }
+    ],
+    "deltawalker": [
+      {
+        "cask": "deltawalker",
+        "count": "69"
+      }
+    ],
+    "deluge": [
+      {
+        "cask": "deluge",
+        "count": "766"
+      }
+    ],
+    "dendroscope": [
+      {
+        "cask": "dendroscope",
+        "count": "4"
+      }
+    ],
+    "denemo": [
+      {
+        "cask": "denemo",
+        "count": "11"
+      }
+    ],
+    "denpo": [
+      {
+        "cask": "denpo",
+        "count": "1"
+      }
+    ],
+    "denpo-cask": [
+      {
+        "cask": "denpo-cask",
+        "count": "1"
+      }
+    ],
+    "deploystudio": [
+      {
+        "cask": "deploystudio",
+        "count": "5"
+      }
+    ],
+    "deputy": [
+      {
+        "cask": "deputy",
+        "count": "2"
+      }
+    ],
+    "desktoputility": [
+      {
+        "cask": "desktoputility",
+        "count": "12"
+      }
+    ],
+    "desmume": [
+      {
+        "cask": "desmume",
+        "count": "46"
+      }
+    ],
+    "detectx-swift": [
+      {
+        "cask": "detectx-swift",
+        "count": "17"
+      }
+    ],
+    "detexify": [
+      {
+        "cask": "detexify",
+        "count": "141"
+      }
+    ],
+    "detox-instruments": [
+      {
+        "cask": "detox-instruments",
+        "count": "205"
+      }
+    ],
+    "devcolor": [
+      {
+        "cask": "devcolor",
+        "count": "1"
+      }
+    ],
+    "devdocs": [
+      {
+        "cask": "devdocs",
+        "count": "236"
+      }
+    ],
+    "devdocs-macos": [
+      {
+        "cask": "devdocs-macos",
+        "count": "51"
+      }
+    ],
+    "developerexcuses": [
+      {
+        "cask": "developerexcuses",
+        "count": "12"
+      }
+    ],
+    "devhub": [
+      {
+        "cask": "devhub",
+        "count": "24"
+      }
+    ],
+    "devolo-cockpit": [
+      {
+        "cask": "devolo-cockpit",
+        "count": "16"
+      }
+    ],
+    "devonagent": [
+      {
+        "cask": "devonagent",
+        "count": "43"
+      }
+    ],
+    "devonthink": [
+      {
+        "cask": "devonthink",
+        "count": "192"
+      }
+    ],
+    "devonthink-pro": [
+      {
+        "cask": "devonthink-pro",
+        "count": "4"
+      }
+    ],
+    "dexed": [
+      {
+        "cask": "dexed",
+        "count": "28"
+      }
+    ],
+    "dhs": [
+      {
+        "cask": "dhs",
+        "count": "47"
+      }
+    ],
+    "dia": [
+      {
+        "cask": "dia",
+        "count": "668"
+      }
+    ],
+    "dialpad": [
+      {
+        "cask": "dialpad",
+        "count": "31"
+      }
+    ],
+    "diashapes": [
+      {
+        "cask": "diashapes",
+        "count": "28"
+      }
+    ],
+    "dictater": [
+      {
+        "cask": "dictater",
+        "count": "5"
+      }
+    ],
+    "dictcc-en-de-dictionary-plugin": [
+      {
+        "cask": "dictcc-en-de-dictionary-plugin",
+        "count": "14"
+      }
+    ],
+    "dictionaries": [
+      {
+        "cask": "dictionaries",
+        "count": "51"
+      }
+    ],
+    "dictunifier": [
+      {
+        "cask": "dictunifier",
+        "count": "79"
+      }
+    ],
+    "difffork": [
+      {
+        "cask": "difffork",
+        "count": "11"
+      }
+    ],
+    "diffmerge": [
+      {
+        "cask": "diffmerge",
+        "count": "1,465"
+      }
+    ],
+    "digikam": [
+      {
+        "cask": "digikam",
+        "count": "215"
+      }
+    ],
+    "digital-paper-app": [
+      {
+        "cask": "digital-paper-app",
+        "count": "7"
+      }
+    ],
+    "dingtalk": [
+      {
+        "cask": "dingtalk",
+        "count": "796"
+      }
+    ],
+    "dintch": [
+      {
+        "cask": "dintch",
+        "count": "1"
+      }
+    ],
+    "disablemonitor": [
+      {
+        "cask": "disablemonitor",
+        "count": "53"
+      }
+    ],
+    "discord": [
+      {
+        "cask": "discord",
+        "count": "12,740"
+      }
+    ],
+    "discord-canary": [
+      {
+        "cask": "discord-canary",
+        "count": "54"
+      }
+    ],
+    "discord-ptb": [
+      {
+        "cask": "discord-ptb",
+        "count": "42"
+      }
+    ],
+    "discretescroll": [
+      {
+        "cask": "discretescroll",
+        "count": "20"
+      }
+    ],
+    "disk-arbitrator": [
+      {
+        "cask": "disk-arbitrator",
+        "count": "61"
+      }
+    ],
+    "disk-drill": [
+      {
+        "cask": "disk-drill",
+        "count": "282"
+      }
+    ],
+    "disk-inventory-x": [
+      {
+        "cask": "disk-inventory-x",
+        "count": "1,096"
+      }
+    ],
+    "diskcatalogmaker": [
+      {
+        "cask": "diskcatalogmaker",
+        "count": "20"
+      }
+    ],
+    "diskmaker-x": [
+      {
+        "cask": "diskmaker-x",
+        "count": "154"
+      }
+    ],
+    "diskwave": [
+      {
+        "cask": "diskwave",
+        "count": "77"
+      }
+    ],
+    "displaperture": [
+      {
+        "cask": "displaperture",
+        "count": "13"
+      }
+    ],
+    "displaycal": [
+      {
+        "cask": "displaycal",
+        "count": "108"
+      }
+    ],
+    "displaylink": [
+      {
+        "cask": "displaylink",
+        "count": "166"
+      }
+    ],
+    "dissenter-browser": [
+      {
+        "cask": "dissenter-browser",
+        "count": "8"
+      }
+    ],
+    "divvy": [
+      {
+        "cask": "divvy",
+        "count": "282"
+      }
+    ],
+    "djay-pro": [
+      {
+        "cask": "djay-pro",
+        "count": "31"
+      }
+    ],
+    "dji-assistant2-mavic": [
+      {
+        "cask": "dji-assistant2-mavic",
+        "count": "1"
+      }
+    ],
+    "djv": [
+      {
+        "cask": "djv",
+        "count": "31"
+      }
+    ],
+    "djview": [
+      {
+        "cask": "djview",
+        "count": "275"
+      }
+    ],
+    "dlan-cockpit": [
+      {
+        "cask": "dlan-cockpit",
+        "count": "5"
+      }
+    ],
+    "dmenu": [
+      {
+        "cask": "dmenu",
+        "count": "9"
+      }
+    ],
+    "dmenu-mac": [
+      {
+        "cask": "dmenu-mac",
+        "count": "17"
+      }
+    ],
+    "dmm-player": [
+      {
+        "cask": "dmm-player",
+        "count": "23"
+      }
+    ],
+    "dmm-player-for-chrome": [
+      {
+        "cask": "dmm-player-for-chrome",
+        "count": "3"
+      }
+    ],
+    "dnie": [
+      {
+        "cask": "dnie",
+        "count": "3"
+      }
+    ],
+    "do-not-disturb": [
+      {
+        "cask": "do-not-disturb",
+        "count": "72"
+      }
+    ],
+    "docear": [
+      {
+        "cask": "docear",
+        "count": "32"
+      }
+    ],
+    "dock-manager": [
+      {
+        "cask": "dock-manager",
+        "count": "3"
+      }
+    ],
+    "docker": [
+      {
+        "cask": "docker",
+        "count": "54,659"
+      }
+    ],
+    "docker-2_1": [
+      {
+        "cask": "docker-2_1",
+        "count": "9"
+      }
+    ],
+    "docker-desktop": [
+      {
+        "cask": "docker-desktop",
+        "count": "1"
+      }
+    ],
+    "docker-edge": [
+      {
+        "cask": "docker-edge",
+        "count": "495"
+      }
+    ],
+    "docker-toolbox": [
+      {
+        "cask": "docker-toolbox",
+        "count": "1,226"
+      }
+    ],
+    "dockey": [
+      {
+        "cask": "dockey",
+        "count": "24"
+      }
+    ],
+    "dockstation": [
+      {
+        "cask": "dockstation",
+        "count": "83"
+      }
+    ],
+    "dogecoin": [
+      {
+        "cask": "dogecoin",
+        "count": "12"
+      }
+    ],
+    "dolphin": [
+      {
+        "cask": "dolphin",
+        "count": "238"
+      }
+    ],
+    "dolphin-dev": [
+      {
+        "cask": "dolphin-dev",
+        "count": "32"
+      }
+    ],
+    "doly": [
+      {
+        "cask": "doly",
+        "count": "5"
+      }
+    ],
+    "domainbrain": [
+      {
+        "cask": "domainbrain",
+        "count": "2"
+      }
+    ],
+    "doomrl": [
+      {
+        "cask": "doomrl",
+        "count": "21"
+      }
+    ],
+    "doomsday-engine": [
+      {
+        "cask": "doomsday-engine",
+        "count": "6"
+      }
+    ],
+    "dosbox": [
+      {
+        "cask": "dosbox",
+        "count": "349"
+      }
+    ],
+    "dosbox-x": [
+      {
+        "cask": "dosbox-x",
+        "count": "93"
+      }
+    ],
+    "doteditor": [
+      {
+        "cask": "doteditor",
+        "count": "21"
+      }
+    ],
+    "dotnet": [
+      {
+        "cask": "dotnet",
+        "count": "2,208"
+      }
+    ],
+    "dotnet-preview": [
+      {
+        "cask": "dotnet-preview",
+        "count": "5"
+      }
+    ],
+    "dotnet-sdk": [
+      {
+        "cask": "dotnet-sdk",
+        "count": "4,652"
+      }
+    ],
+    "dotnet-sdk-2.1.400": [
+      {
+        "cask": "dotnet-sdk-2.1.400",
+        "count": "19"
+      }
+    ],
+    "dotnet-sdk-2.1.500": [
+      {
+        "cask": "dotnet-sdk-2.1.500",
+        "count": "7"
+      }
+    ],
+    "dotnet-sdk-2.1.800": [
+      {
+        "cask": "dotnet-sdk-2.1.800",
+        "count": "117"
+      }
+    ],
+    "dotnet-sdk-2.2.100": [
+      {
+        "cask": "dotnet-sdk-2.2.100",
+        "count": "142"
+      }
+    ],
+    "dotnet-sdk-2.2.200": [
+      {
+        "cask": "dotnet-sdk-2.2.200",
+        "count": "15"
+      }
+    ],
+    "dotnet-sdk-2.2.300": [
+      {
+        "cask": "dotnet-sdk-2.2.300",
+        "count": "20"
+      }
+    ],
+    "dotnet-sdk-2.2.400": [
+      {
+        "cask": "dotnet-sdk-2.2.400",
+        "count": "195"
+      }
+    ],
+    "dotnet-sdk-3.0.100": [
+      {
+        "cask": "dotnet-sdk-3.0.100",
+        "count": "38"
+      }
+    ],
+    "dotnet-sdk-3.1.100": [
+      {
+        "cask": "dotnet-sdk-3.1.100",
+        "count": "87"
+      }
+    ],
+    "dotnet-sdk-3.1.200": [
+      {
+        "cask": "dotnet-sdk-3.1.200",
+        "count": "62"
+      }
+    ],
+    "dotnet-sdk-latest": [
+      {
+        "cask": "dotnet-sdk-latest",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-pinned": [
+      {
+        "cask": "dotnet-sdk-pinned",
+        "count": "1"
+      }
+    ],
+    "dotnet-sdk-preview": [
+      {
+        "cask": "dotnet-sdk-preview",
+        "count": "26"
+      }
+    ],
+    "double-commander": [
+      {
+        "cask": "double-commander",
+        "count": "394"
+      }
+    ],
+    "double-commander-qt": [
+      {
+        "cask": "double-commander-qt",
+        "count": "1"
+      }
+    ],
+    "doubletwist": [
+      {
+        "cask": "doubletwist",
+        "count": "88"
+      }
+    ],
+    "downie": [
+      {
+        "cask": "downie",
+        "count": "651"
+      }
+    ],
+    "doxie": [
+      {
+        "cask": "doxie",
+        "count": "43"
+      }
+    ],
+    "doxygen": [
+      {
+        "cask": "doxygen",
+        "count": "130"
+      }
+    ],
+    "dozer": [
+      {
+        "cask": "dozer",
+        "count": "3,039"
+      }
+    ],
+    "dradio": [
+      {
+        "cask": "dradio",
+        "count": "7"
+      }
+    ],
+    "dragondisk-custom": [
+      {
+        "cask": "dragondisk-custom",
+        "count": "1"
+      }
+    ],
+    "dragonfly-reverb": [
+      {
+        "cask": "dragonfly-reverb",
+        "count": "4"
+      }
+    ],
+    "drake": [
+      {
+        "cask": "drake",
+        "count": "12"
+      }
+    ],
+    "drama": [
+      {
+        "cask": "drama",
+        "count": "14"
+      }
+    ],
+    "drawbot": [
+      {
+        "cask": "drawbot",
+        "count": "18"
+      }
+    ],
+    "drawio": [
+      {
+        "cask": "drawio",
+        "count": "3,081"
+      }
+    ],
+    "dremel-slicer": [
+      {
+        "cask": "dremel-slicer",
+        "count": "1"
+      }
+    ],
+    "drivedx": [
+      {
+        "cask": "drivedx",
+        "count": "137"
+      }
+    ],
+    "drivethrurpg": [
+      {
+        "cask": "drivethrurpg",
+        "count": "25"
+      }
+    ],
+    "drobo-dashboard": [
+      {
+        "cask": "drobo-dashboard",
+        "count": "34"
+      }
+    ],
+    "droidid": [
+      {
+        "cask": "droidid",
+        "count": "12"
+      }
+    ],
+    "drop-to-gif": [
+      {
+        "cask": "drop-to-gif",
+        "count": "44"
+      }
+    ],
+    "dropbox": [
+      {
+        "cask": "dropbox",
+        "count": "6,603"
+      }
+    ],
+    "dropbox-beta": [
+      {
+        "cask": "dropbox-beta",
+        "count": "63"
+      }
+    ],
+    "dropbox-encore": [
+      {
+        "cask": "dropbox-encore",
+        "count": "10"
+      }
+    ],
+    "dropdmg": [
+      {
+        "cask": "dropdmg",
+        "count": "9"
+      }
+    ],
+    "dropletmanager": [
+      {
+        "cask": "dropletmanager",
+        "count": "10"
+      }
+    ],
+    "droplr": [
+      {
+        "cask": "droplr",
+        "count": "69"
+      }
+    ],
+    "dropshare": [
+      {
+        "cask": "dropshare",
+        "count": "40"
+      }
+    ],
+    "duckietv": [
+      {
+        "cask": "duckietv",
+        "count": "10"
+      }
+    ],
+    "duefocus": [
+      {
+        "cask": "duefocus",
+        "count": "10"
+      }
+    ],
+    "duet": [
+      {
+        "cask": "duet",
+        "count": "811"
+      }
+    ],
+    "dukto": [
+      {
+        "cask": "dukto",
+        "count": "56"
+      }
+    ],
+    "dungeon-crawl-stone-soup-console": [
+      {
+        "cask": "dungeon-crawl-stone-soup-console",
+        "count": "43"
+      }
+    ],
+    "dungeon-crawl-stone-soup-tiles": [
+      {
+        "cask": "dungeon-crawl-stone-soup-tiles",
+        "count": "63"
+      }
+    ],
+    "duo-connect": [
+      {
+        "cask": "duo-connect",
+        "count": "25"
+      }
+    ],
+    "dupeguru": [
+      {
+        "cask": "dupeguru",
+        "count": "210"
+      }
+    ],
+    "duplicacy": [
+      {
+        "cask": "duplicacy",
+        "count": "32"
+      }
+    ],
+    "duplicacy-web-edition": [
+      {
+        "cask": "duplicacy-web-edition",
+        "count": "15"
+      }
+    ],
+    "duplicate-annihilator-for-photos": [
+      {
+        "cask": "duplicate-annihilator-for-photos",
+        "count": "12"
+      }
+    ],
+    "duplicati": [
+      {
+        "cask": "duplicati",
+        "count": "130"
+      }
+    ],
+    "dupscanub": [
+      {
+        "cask": "dupscanub",
+        "count": "4"
+      }
+    ],
+    "dust3d": [
+      {
+        "cask": "dust3d",
+        "count": "20"
+      }
+    ],
+    "dusty": [
+      {
+        "cask": "dusty",
+        "count": "4"
+      }
+    ],
+    "dvdstyler": [
+      {
+        "cask": "dvdstyler",
+        "count": "20"
+      }
+    ],
+    "dwarf-fortress": [
+      {
+        "cask": "dwarf-fortress",
+        "count": "241"
+      }
+    ],
+    "dwarf-fortress-lmp": [
+      {
+        "cask": "dwarf-fortress-lmp",
+        "count": "50"
+      }
+    ],
+    "dwgsee": [
+      {
+        "cask": "dwgsee",
+        "count": "34"
+      }
+    ],
+    "dwihn0r-keepassx": [
+      {
+        "cask": "dwihn0r-keepassx",
+        "count": "17"
+      }
+    ],
+    "dymo-label": [
+      {
+        "cask": "dymo-label",
+        "count": "27"
+      }
+    ],
+    "dyn-updater": [
+      {
+        "cask": "dyn-updater",
+        "count": "5"
+      }
+    ],
+    "dynalist": [
+      {
+        "cask": "dynalist",
+        "count": "82"
+      }
+    ],
+    "dynamic-dark-mode": [
+      {
+        "cask": "dynamic-dark-mode",
+        "count": "58"
+      }
+    ],
+    "dynamodb-local": [
+      {
+        "cask": "dynamodb-local",
+        "count": "325"
+      }
+    ],
+    "dynobase": [
+      {
+        "cask": "dynobase",
+        "count": "6"
+      }
+    ],
+    "dystextia": [
+      {
+        "cask": "dystextia",
+        "count": "4"
+      }
+    ],
+    "eaccess": [
+      {
+        "cask": "eaccess",
+        "count": "5"
+      }
+    ],
+    "eaccess-desktop": [
+      {
+        "cask": "eaccess-desktop",
+        "count": "4"
+      }
+    ],
+    "eagle": [
+      {
+        "cask": "eagle",
+        "count": "205"
+      }
+    ],
+    "eaglefiler": [
+      {
+        "cask": "eaglefiler",
+        "count": "30"
+      }
+    ],
+    "ealeksandrov-cd-to": [
+      {
+        "cask": "ealeksandrov-cd-to",
+        "count": "6"
+      }
+    ],
+    "easy-move-plus-resize": [
+      {
+        "cask": "easy-move-plus-resize",
+        "count": "252"
+      }
+    ],
+    "easyeda": [
+      {
+        "cask": "easyeda",
+        "count": "47"
+      }
+    ],
+    "easyfind": [
+      {
+        "cask": "easyfind",
+        "count": "309"
+      }
+    ],
+    "easytether": [
+      {
+        "cask": "easytether",
+        "count": "14"
+      }
+    ],
+    "ebibookreader": [
+      {
+        "cask": "ebibookreader",
+        "count": "7"
+      }
+    ],
+    "ebmac": [
+      {
+        "cask": "ebmac",
+        "count": "20"
+      }
+    ],
+    "eclipse-cpp": [
+      {
+        "cask": "eclipse-cpp",
+        "count": "304"
+      }
+    ],
+    "eclipse-dsl": [
+      {
+        "cask": "eclipse-dsl",
+        "count": "13"
+      }
+    ],
+    "eclipse-ide": [
+      {
+        "cask": "eclipse-ide",
+        "count": "1,253"
+      }
+    ],
+    "eclipse-installer": [
+      {
+        "cask": "eclipse-installer",
+        "count": "214"
+      }
+    ],
+    "eclipse-java": [
+      {
+        "cask": "eclipse-java",
+        "count": "1,749"
+      }
+    ],
+    "eclipse-java@4.10": [
+      {
+        "cask": "eclipse-java@4.10",
+        "count": "1"
+      }
+    ],
+    "eclipse-javascript": [
+      {
+        "cask": "eclipse-javascript",
+        "count": "50"
+      }
+    ],
+    "eclipse-jee": [
+      {
+        "cask": "eclipse-jee",
+        "count": "2,279"
+      }
+    ],
+    "eclipse-modeling": [
+      {
+        "cask": "eclipse-modeling",
+        "count": "91"
+      }
+    ],
+    "eclipse-php": [
+      {
+        "cask": "eclipse-php",
+        "count": "66"
+      }
+    ],
+    "eclipse-platform": [
+      {
+        "cask": "eclipse-platform",
+        "count": "64"
+      }
+    ],
+    "eclipse-rcp": [
+      {
+        "cask": "eclipse-rcp",
+        "count": "22"
+      }
+    ],
+    "eclipse-scout": [
+      {
+        "cask": "eclipse-scout",
+        "count": "1"
+      }
+    ],
+    "eclipse-testing": [
+      {
+        "cask": "eclipse-testing",
+        "count": "6"
+      }
+    ],
+    "eddie": [
+      {
+        "cask": "eddie",
+        "count": "30"
+      }
+    ],
+    "edex-ui": [
+      {
+        "cask": "edex-ui",
+        "count": "170"
+      }
+    ],
+    "edfbrowser": [
+      {
+        "cask": "edfbrowser",
+        "count": "51"
+      }
+    ],
+    "edison-mail": [
+      {
+        "cask": "edison-mail",
+        "count": "2"
+      }
+    ],
+    "editaro": [
+      {
+        "cask": "editaro",
+        "count": "5"
+      }
+    ],
+    "editready": [
+      {
+        "cask": "editready",
+        "count": "1"
+      }
+    ],
+    "edrawmax": [
+      {
+        "cask": "edrawmax",
+        "count": "64"
+      }
+    ],
+    "eggplant": [
+      {
+        "cask": "eggplant",
+        "count": "7"
+      }
+    ],
+    "eid-be": [
+      {
+        "cask": "eid-be",
+        "count": "7"
+      }
+    ],
+    "eid-be-viewer": [
+      {
+        "cask": "eid-be-viewer",
+        "count": "3"
+      }
+    ],
+    "eid-ee": [
+      {
+        "cask": "eid-ee",
+        "count": "1"
+      }
+    ],
+    "eim": [
+      {
+        "cask": "eim",
+        "count": "2"
+      }
+    ],
+    "eiskaltdcpp": [
+      {
+        "cask": "eiskaltdcpp",
+        "count": "46"
+      }
+    ],
+    "ejectionseat": [
+      {
+        "cask": "ejectionseat",
+        "count": "4"
+      }
+    ],
+    "ejector": [
+      {
+        "cask": "ejector",
+        "count": "10"
+      }
+    ],
+    "elan": [
+      {
+        "cask": "elan",
+        "count": "5"
+      }
+    ],
+    "elasticwolf": [
+      {
+        "cask": "elasticwolf",
+        "count": "8"
+      }
+    ],
+    "electerm": [
+      {
+        "cask": "electerm",
+        "count": "155"
+      }
+    ],
+    "electorrent": [
+      {
+        "cask": "electorrent",
+        "count": "91"
+      }
+    ],
+    "electric-sheep": [
+      {
+        "cask": "electric-sheep",
+        "count": "37"
+      }
+    ],
+    "electrocrud": [
+      {
+        "cask": "electrocrud",
+        "count": "21"
+      }
+    ],
+    "electron": [
+      {
+        "cask": "electron",
+        "count": "591"
+      }
+    ],
+    "electron-api-demos": [
+      {
+        "cask": "electron-api-demos",
+        "count": "13"
+      }
+    ],
+    "electron-beta": [
+      {
+        "cask": "electron-beta",
+        "count": "1"
+      }
+    ],
+    "electron-cash": [
+      {
+        "cask": "electron-cash",
+        "count": "27"
+      }
+    ],
+    "electron-fiddle": [
+      {
+        "cask": "electron-fiddle",
+        "count": "55"
+      }
+    ],
+    "electronic-wechat": [
+      {
+        "cask": "electronic-wechat",
+        "count": "20"
+      }
+    ],
+    "electronmail": [
+      {
+        "cask": "electronmail",
+        "count": "35"
+      }
+    ],
+    "electrum": [
+      {
+        "cask": "electrum",
+        "count": "285"
+      }
+    ],
+    "electrum-ltc": [
+      {
+        "cask": "electrum-ltc",
+        "count": "10"
+      }
+    ],
+    "electrumsv": [
+      {
+        "cask": "electrumsv",
+        "count": "3"
+      }
+    ],
+    "elektriktrick": [
+      {
+        "cask": "elektriktrick",
+        "count": "1"
+      }
+    ],
+    "elektron-overbridge": [
+      {
+        "cask": "elektron-overbridge",
+        "count": "8"
+      }
+    ],
+    "elektron-transfer": [
+      {
+        "cask": "elektron-transfer",
+        "count": "2"
+      }
+    ],
+    "elgato-control-center": [
+      {
+        "cask": "elgato-control-center",
+        "count": "9"
+      }
+    ],
+    "elgato-game-capture-hd": [
+      {
+        "cask": "elgato-game-capture-hd",
+        "count": "63"
+      }
+    ],
+    "elgato-stream-deck": [
+      {
+        "cask": "elgato-stream-deck",
+        "count": "40"
+      }
+    ],
+    "elgato-thunderbolt-dock": [
+      {
+        "cask": "elgato-thunderbolt-dock",
+        "count": "23"
+      }
+    ],
+    "elgato-video-capture": [
+      {
+        "cask": "elgato-video-capture",
+        "count": "8"
+      }
+    ],
+    "elmedia-player": [
+      {
+        "cask": "elmedia-player",
+        "count": "296"
+      }
+    ],
+    "eloston-chromium": [
+      {
+        "cask": "eloston-chromium",
+        "count": "1,292"
+      }
+    ],
+    "elpass": [
+      {
+        "cask": "elpass",
+        "count": "28"
+      }
+    ],
+    "emacs": [
+      {
+        "cask": "emacs",
+        "count": "13,189"
+      }
+    ],
+    "emacs-inlinepatched": [
+      {
+        "cask": "emacs-inlinepatched",
+        "count": "1"
+      }
+    ],
+    "emacs-mac": [
+      {
+        "cask": "emacs-mac",
+        "count": "768"
+      }
+    ],
+    "emacs-mac-spacemacs-icon": [
+      {
+        "cask": "emacs-mac-spacemacs-icon",
+        "count": "172"
+      }
+    ],
+    "emacs-nightly": [
+      {
+        "cask": "emacs-nightly",
+        "count": "68"
+      }
+    ],
+    "emacs-pretest": [
+      {
+        "cask": "emacs-pretest",
+        "count": "82"
+      }
+    ],
+    "emacsclient": [
+      {
+        "cask": "emacsclient",
+        "count": "135"
+      }
+    ],
+    "emailchemy": [
+      {
+        "cask": "emailchemy",
+        "count": "2"
+      }
+    ],
+    "emby-server": [
+      {
+        "cask": "emby-server",
+        "count": "76"
+      }
+    ],
+    "emclient": [
+      {
+        "cask": "emclient",
+        "count": "29"
+      }
+    ],
+    "eme": [
+      {
+        "cask": "eme",
+        "count": "2"
+      }
+    ],
+    "emojipedia": [
+      {
+        "cask": "emojipedia",
+        "count": "32"
+      }
+    ],
+    "empoche": [
+      {
+        "cask": "empoche",
+        "count": "5"
+      }
+    ],
+    "encryptme": [
+      {
+        "cask": "encryptme",
+        "count": "58"
+      }
+    ],
+    "encryptr": [
+      {
+        "cask": "encryptr",
+        "count": "6"
+      }
+    ],
+    "endless-sky": [
+      {
+        "cask": "endless-sky",
+        "count": "12"
+      }
+    ],
+    "endnote": [
+      {
+        "cask": "endnote",
+        "count": "67"
+      }
+    ],
+    "endpoint_security_vpn": [
+      {
+        "cask": "endpoint_security_vpn",
+        "count": "1"
+      }
+    ],
+    "endurance": [
+      {
+        "cask": "endurance",
+        "count": "35"
+      }
+    ],
+    "energybar": [
+      {
+        "cask": "energybar",
+        "count": "47"
+      }
+    ],
+    "enfusegui": [
+      {
+        "cask": "enfusegui",
+        "count": "10"
+      }
+    ],
+    "engine-prime": [
+      {
+        "cask": "engine-prime",
+        "count": "6"
+      }
+    ],
+    "english-persian-dictionary": [
+      {
+        "cask": "english-persian-dictionary",
+        "count": "1"
+      }
+    ],
+    "enjoyable": [
+      {
+        "cask": "enjoyable",
+        "count": "70"
+      }
+    ],
+    "enolsoft-chm-view": [
+      {
+        "cask": "enolsoft-chm-view",
+        "count": "30"
+      }
+    ],
+    "enpass": [
+      {
+        "cask": "enpass",
+        "count": "393"
+      }
+    ],
+    "entropy": [
+      {
+        "cask": "entropy",
+        "count": "14"
+      }
+    ],
+    "envkey": [
+      {
+        "cask": "envkey",
+        "count": "14"
+      }
+    ],
+    "enzymex": [
+      {
+        "cask": "enzymex",
+        "count": "2"
+      }
+    ],
+    "epi2me-cli": [
+      {
+        "cask": "epi2me-cli",
+        "count": "1"
+      }
+    ],
+    "epic": [
+      {
+        "cask": "epic",
+        "count": "76"
+      }
+    ],
+    "epic-games": [
+      {
+        "cask": "epic-games",
+        "count": "922"
+      }
+    ],
+    "epichrome": [
+      {
+        "cask": "epichrome",
+        "count": "57"
+      }
+    ],
+    "epoccam-drivers": [
+      {
+        "cask": "epoccam-drivers",
+        "count": "4"
+      }
+    ],
+    "epoch-flip-clock": [
+      {
+        "cask": "epoch-flip-clock",
+        "count": "12"
+      }
+    ],
+    "epub-services": [
+      {
+        "cask": "epub-services",
+        "count": "110"
+      }
+    ],
+    "epub-to-pdf": [
+      {
+        "cask": "epub-to-pdf",
+        "count": "42"
+      }
+    ],
+    "epubmdimporter": [
+      {
+        "cask": "epubmdimporter",
+        "count": "41"
+      }
+    ],
+    "epubquicklook": [
+      {
+        "cask": "epubquicklook",
+        "count": "261"
+      }
+    ],
+    "eqmac": [
+      {
+        "cask": "eqmac",
+        "count": "284"
+      }
+    ],
+    "eset-cyber-security-pro": [
+      {
+        "cask": "eset-cyber-security-pro",
+        "count": "30"
+      }
+    ],
+    "eset-endpoint-security": [
+      {
+        "cask": "eset-endpoint-security",
+        "count": "842"
+      }
+    ],
+    "eshelper": [
+      {
+        "cask": "eshelper",
+        "count": "1"
+      }
+    ],
+    "espresso": [
+      {
+        "cask": "espresso",
+        "count": "55"
+      }
+    ],
+    "etcher": [
+      {
+        "cask": "etcher",
+        "count": "1"
+      }
+    ],
+    "ethereum-wallet": [
+      {
+        "cask": "ethereum-wallet",
+        "count": "26"
+      }
+    ],
+    "etrecheckpro": [
+      {
+        "cask": "etrecheckpro",
+        "count": "122"
+      }
+    ],
+    "eudic": [
+      {
+        "cask": "eudic",
+        "count": "240"
+      }
+    ],
+    "eurkey": [
+      {
+        "cask": "eurkey",
+        "count": "10"
+      }
+    ],
+    "eve": [
+      {
+        "cask": "eve",
+        "count": "11"
+      }
+    ],
+    "eve-launcher": [
+      {
+        "cask": "eve-launcher",
+        "count": "42"
+      }
+    ],
+    "eventstore": [
+      {
+        "cask": "eventstore",
+        "count": "239"
+      }
+    ],
+    "evernote": [
+      {
+        "cask": "evernote",
+        "count": "2,241"
+      }
+    ],
+    "everweb": [
+      {
+        "cask": "everweb",
+        "count": "3"
+      }
+    ],
+    "evoluent-vertical-mouse-device-controller": [
+      {
+        "cask": "evoluent-vertical-mouse-device-controller",
+        "count": "1"
+      }
+    ],
+    "evolv-escribe-suite": [
+      {
+        "cask": "evolv-escribe-suite",
+        "count": "2"
+      }
+    ],
+    "evom": [
+      {
+        "cask": "evom",
+        "count": "2"
+      }
+    ],
+    "exactscan": [
+      {
+        "cask": "exactscan",
+        "count": "16"
+      }
+    ],
+    "exfalso": [
+      {
+        "cask": "exfalso",
+        "count": "14"
+      }
+    ],
+    "exifrenamer": [
+      {
+        "cask": "exifrenamer",
+        "count": "58"
+      }
+    ],
+    "exist-db": [
+      {
+        "cask": "exist-db",
+        "count": "28"
+      }
+    ],
+    "exmancmd": [
+      {
+        "cask": "exmancmd",
+        "count": "200"
+      }
+    ],
+    "exodus": [
+      {
+        "cask": "exodus",
+        "count": "182"
+      }
+    ],
+    "expandrive": [
+      {
+        "cask": "expandrive",
+        "count": "118"
+      }
+    ],
+    "explorer": [
+      {
+        "cask": "explorer",
+        "count": "7"
+      }
+    ],
+    "expo-xde": [
+      {
+        "cask": "expo-xde",
+        "count": "59"
+      }
+    ],
+    "expressions": [
+      {
+        "cask": "expressions",
+        "count": "38"
+      }
+    ],
+    "expressscribe": [
+      {
+        "cask": "expressscribe",
+        "count": "8"
+      }
+    ],
+    "expressvpn": [
+      {
+        "cask": "expressvpn",
+        "count": "730"
+      }
+    ],
+    "extraterm": [
+      {
+        "cask": "extraterm",
+        "count": "47"
+      }
+    ],
+    "ezip": [
+      {
+        "cask": "ezip",
+        "count": "480"
+      }
+    ],
+    "f-secure-anti-virus": [
+      {
+        "cask": "f-secure-anti-virus",
+        "count": "1"
+      }
+    ],
+    "facebook-ios-sdk": [
+      {
+        "cask": "facebook-ios-sdk",
+        "count": "27"
+      }
+    ],
+    "factor": [
+      {
+        "cask": "factor",
+        "count": "57"
+      }
+    ],
+    "fake": [
+      {
+        "cask": "fake",
+        "count": "19"
+      }
+    ],
+    "falcon-sql-client": [
+      {
+        "cask": "falcon-sql-client",
+        "count": "129"
+      }
+    ],
+    "family-tree-builder": [
+      {
+        "cask": "family-tree-builder",
+        "count": "8"
+      }
+    ],
+    "fanny": [
+      {
+        "cask": "fanny",
+        "count": "266"
+      }
+    ],
+    "fantastical": [
+      {
+        "cask": "fantastical",
+        "count": "996"
+      }
+    ],
+    "fantasy-grounds": [
+      {
+        "cask": "fantasy-grounds",
+        "count": "11"
+      }
+    ],
+    "fantasy-map-generator": [
+      {
+        "cask": "fantasy-map-generator",
+        "count": "10"
+      }
+    ],
+    "farrago": [
+      {
+        "cask": "farrago",
+        "count": "35"
+      }
+    ],
+    "fastlane": [
+      {
+        "cask": "fastlane",
+        "count": "6,197"
+      }
+    ],
+    "fastonosql": [
+      {
+        "cask": "fastonosql",
+        "count": "14"
+      }
+    ],
+    "fastrawviewer": [
+      {
+        "cask": "fastrawviewer",
+        "count": "16"
+      }
+    ],
+    "fastscripts": [
+      {
+        "cask": "fastscripts",
+        "count": "30"
+      }
+    ],
+    "fauxpas": [
+      {
+        "cask": "fauxpas",
+        "count": "79"
+      }
+    ],
+    "favro": [
+      {
+        "cask": "favro",
+        "count": "8"
+      }
+    ],
+    "faxbot": [
+      {
+        "cask": "faxbot",
+        "count": "5"
+      }
+    ],
+    "fb3100": [
+      {
+        "cask": "fb3100",
+        "count": "2"
+      }
+    ],
+    "fb3200": [
+      {
+        "cask": "fb3200",
+        "count": "2"
+      }
+    ],
+    "fb3300": [
+      {
+        "cask": "fb3300",
+        "count": "4"
+      }
+    ],
+    "fbreader": [
+      {
+        "cask": "fbreader",
+        "count": "108"
+      }
+    ],
+    "fbvc": [
+      {
+        "cask": "fbvc",
+        "count": "2"
+      }
+    ],
+    "fedora-media-writer": [
+      {
+        "cask": "fedora-media-writer",
+        "count": "54"
+      }
+    ],
+    "feed-the-beast": [
+      {
+        "cask": "feed-the-beast",
+        "count": "27"
+      }
+    ],
+    "feeder": [
+      {
+        "cask": "feeder",
+        "count": "2"
+      }
+    ],
+    "feeds": [
+      {
+        "cask": "feeds",
+        "count": "1"
+      }
+    ],
+    "feem": [
+      {
+        "cask": "feem",
+        "count": "18"
+      }
+    ],
+    "feishu": [
+      {
+        "cask": "feishu",
+        "count": "340"
+      }
+    ],
+    "fenix": [
+      {
+        "cask": "fenix",
+        "count": "9"
+      }
+    ],
+    "ferdi": [
+      {
+        "cask": "ferdi",
+        "count": "444"
+      }
+    ],
+    "ferdi-beta": [
+      {
+        "cask": "ferdi-beta",
+        "count": "16"
+      }
+    ],
+    "fetch": [
+      {
+        "cask": "fetch",
+        "count": "136"
+      }
+    ],
+    "ff-works": [
+      {
+        "cask": "ff-works",
+        "count": "42"
+      }
+    ],
+    "fiddler": [
+      {
+        "cask": "fiddler",
+        "count": "2"
+      }
+    ],
+    "figma": [
+      {
+        "cask": "figma",
+        "count": "1,888"
+      }
+    ],
+    "figmadaemon": [
+      {
+        "cask": "figmadaemon",
+        "count": "26"
+      }
+    ],
+    "figtree": [
+      {
+        "cask": "figtree",
+        "count": "49"
+      }
+    ],
+    "fiji": [
+      {
+        "cask": "fiji",
+        "count": "113"
+      }
+    ],
+    "file-juicer": [
+      {
+        "cask": "file-juicer",
+        "count": "15"
+      }
+    ],
+    "filebot": [
+      {
+        "cask": "filebot",
+        "count": "560"
+      }
+    ],
+    "filedrop": [
+      {
+        "cask": "filedrop",
+        "count": "22"
+      }
+    ],
+    "filemaker-pro-advanced": [
+      {
+        "cask": "filemaker-pro-advanced",
+        "count": "32"
+      }
+    ],
+    "filemon": [
+      {
+        "cask": "filemon",
+        "count": "23"
+      }
+    ],
+    "filepane": [
+      {
+        "cask": "filepane",
+        "count": "12"
+      }
+    ],
+    "filezilla": [
+      {
+        "cask": "filezilla",
+        "count": "7"
+      }
+    ],
+    "final-cut-library-manager": [
+      {
+        "cask": "final-cut-library-manager",
+        "count": "14"
+      }
+    ],
+    "find-any-file": [
+      {
+        "cask": "find-any-file",
+        "count": "48"
+      }
+    ],
+    "find-empty-folders": [
+      {
+        "cask": "find-empty-folders",
+        "count": "10"
+      }
+    ],
+    "findergo": [
+      {
+        "cask": "findergo",
+        "count": "67"
+      }
+    ],
+    "findings": [
+      {
+        "cask": "findings",
+        "count": "1"
+      }
+    ],
+    "finereader": [
+      {
+        "cask": "finereader",
+        "count": "45"
+      }
+    ],
+    "fing": [
+      {
+        "cask": "fing",
+        "count": "451"
+      }
+    ],
+    "finicky": [
+      {
+        "cask": "finicky",
+        "count": "287"
+      }
+    ],
+    "firealpaca": [
+      {
+        "cask": "firealpaca",
+        "count": "145"
+      }
+    ],
+    "firebase-admin": [
+      {
+        "cask": "firebase-admin",
+        "count": "47"
+      }
+    ],
+    "firebird-emu": [
+      {
+        "cask": "firebird-emu",
+        "count": "11"
+      }
+    ],
+    "firecamp": [
+      {
+        "cask": "firecamp",
+        "count": "341"
+      }
+    ],
+    "firefox": [
+      {
+        "cask": "firefox",
+        "count": "34,335"
+      }
+    ],
+    "firefox-35": [
+      {
+        "cask": "firefox-35",
+        "count": "1"
+      }
+    ],
+    "firefox-36": [
+      {
+        "cask": "firefox-36",
+        "count": "1"
+      }
+    ],
+    "firefox-37": [
+      {
+        "cask": "firefox-37",
+        "count": "1"
+      }
+    ],
+    "firefox-40": [
+      {
+        "cask": "firefox-40",
+        "count": "2"
+      }
+    ],
+    "firefox-45": [
+      {
+        "cask": "firefox-45",
+        "count": "36"
+      }
+    ],
+    "firefox-46": [
+      {
+        "cask": "firefox-46",
+        "count": "1"
+      }
+    ],
+    "firefox-beta": [
+      {
+        "cask": "firefox-beta",
+        "count": "145"
+      }
+    ],
+    "firefox-developer-edition": [
+      {
+        "cask": "firefox-developer-edition",
+        "count": "1,805"
+      }
+    ],
+    "firefox-esr": [
+      {
+        "cask": "firefox-esr",
+        "count": "190"
+      }
+    ],
+    "firefox-esr-52-2-1": [
+      {
+        "cask": "firefox-esr-52-2-1",
+        "count": "1"
+      }
+    ],
+    "firefox-esr52": [
+      {
+        "cask": "firefox-esr52",
+        "count": "1"
+      }
+    ],
+    "firefox-nightly": [
+      {
+        "cask": "firefox-nightly",
+        "count": "456"
+      }
+    ],
+    "firestorm": [
+      {
+        "cask": "firestorm",
+        "count": "27"
+      }
+    ],
+    "firestorm-opensim": [
+      {
+        "cask": "firestorm-opensim",
+        "count": "2"
+      }
+    ],
+    "fiscript": [
+      {
+        "cask": "fiscript",
+        "count": "72"
+      }
+    ],
+    "fission": [
+      {
+        "cask": "fission",
+        "count": "74"
+      }
+    ],
+    "fitbit-connect": [
+      {
+        "cask": "fitbit-connect",
+        "count": "17"
+      }
+    ],
+    "fitbit-os-simulator": [
+      {
+        "cask": "fitbit-os-simulator",
+        "count": "8"
+      }
+    ],
+    "fl-studio": [
+      {
+        "cask": "fl-studio",
+        "count": "84"
+      }
+    ],
+    "flame": [
+      {
+        "cask": "flame",
+        "count": "11"
+      }
+    ],
+    "flanders-ip-utility": [
+      {
+        "cask": "flanders-ip-utility",
+        "count": "3"
+      }
+    ],
+    "flash-decompiler-trillix": [
+      {
+        "cask": "flash-decompiler-trillix",
+        "count": "8"
+      }
+    ],
+    "flash-npapi": [
+      {
+        "cask": "flash-npapi",
+        "count": "3,210"
+      }
+    ],
+    "flash-player": [
+      {
+        "cask": "flash-player",
+        "count": "4,780"
+      }
+    ],
+    "flash-player-debugger": [
+      {
+        "cask": "flash-player-debugger",
+        "count": "14"
+      }
+    ],
+    "flash-player-debugger-npapi": [
+      {
+        "cask": "flash-player-debugger-npapi",
+        "count": "13"
+      }
+    ],
+    "flash-player-debugger-ppapi": [
+      {
+        "cask": "flash-player-debugger-ppapi",
+        "count": "9"
+      }
+    ],
+    "flash-ppapi": [
+      {
+        "cask": "flash-ppapi",
+        "count": "2,537"
+      }
+    ],
+    "flashforge-flashprint": [
+      {
+        "cask": "flashforge-flashprint",
+        "count": "4"
+      }
+    ],
+    "flashlighttool": [
+      {
+        "cask": "flashlighttool",
+        "count": "33"
+      }
+    ],
+    "flashprint": [
+      {
+        "cask": "flashprint",
+        "count": "1"
+      }
+    ],
+    "fldigi": [
+      {
+        "cask": "fldigi",
+        "count": "35"
+      }
+    ],
+    "flexiglass": [
+      {
+        "cask": "flexiglass",
+        "count": "23"
+      }
+    ],
+    "flic": [
+      {
+        "cask": "flic",
+        "count": "8"
+      }
+    ],
+    "flickr-uploadr": [
+      {
+        "cask": "flickr-uploadr",
+        "count": "4"
+      }
+    ],
+    "flightgear": [
+      {
+        "cask": "flightgear",
+        "count": "32"
+      }
+    ],
+    "flip4mac": [
+      {
+        "cask": "flip4mac",
+        "count": "30"
+      }
+    ],
+    "flipper": [
+      {
+        "cask": "flipper",
+        "count": "500"
+      }
+    ],
+    "fliqlo": [
+      {
+        "cask": "fliqlo",
+        "count": "537"
+      }
+    ],
+    "flirc": [
+      {
+        "cask": "flirc",
+        "count": "15"
+      }
+    ],
+    "flixtools": [
+      {
+        "cask": "flixtools",
+        "count": "53"
+      }
+    ],
+    "flock": [
+      {
+        "cask": "flock",
+        "count": "125"
+      }
+    ],
+    "flock-agent": [
+      {
+        "cask": "flock-agent",
+        "count": "8"
+      }
+    ],
+    "flotato": [
+      {
+        "cask": "flotato",
+        "count": "197"
+      }
+    ],
+    "flow": [
+      {
+        "cask": "flow",
+        "count": "11"
+      }
+    ],
+    "flowdock": [
+      {
+        "cask": "flowdock",
+        "count": "50"
+      }
+    ],
+    "flowsync": [
+      {
+        "cask": "flowsync",
+        "count": "16"
+      }
+    ],
+    "fluid": [
+      {
+        "cask": "fluid",
+        "count": "224"
+      }
+    ],
+    "flume": [
+      {
+        "cask": "flume",
+        "count": "212"
+      }
+    ],
+    "fluor": [
+      {
+        "cask": "fluor",
+        "count": "349"
+      }
+    ],
+    "flutter": [
+      {
+        "cask": "flutter",
+        "count": "155"
+      }
+    ],
+    "flux": [
+      {
+        "cask": "flux",
+        "count": "2,821"
+      }
+    ],
+    "fluxcenter": [
+      {
+        "cask": "fluxcenter",
+        "count": "2"
+      }
+    ],
+    "flvcd-bigrats": [
+      {
+        "cask": "flvcd-bigrats",
+        "count": "3"
+      }
+    ],
+    "fly": [
+      {
+        "cask": "fly",
+        "count": "821"
+      }
+    ],
+    "flycut": [
+      {
+        "cask": "flycut",
+        "count": "1,299"
+      }
+    ],
+    "fm3-edit": [
+      {
+        "cask": "fm3-edit",
+        "count": "1"
+      }
+    ],
+    "fman": [
+      {
+        "cask": "fman",
+        "count": "81"
+      }
+    ],
+    "fme-desktop": [
+      {
+        "cask": "fme-desktop",
+        "count": "2"
+      }
+    ],
+    "focus": [
+      {
+        "cask": "focus",
+        "count": "98"
+      }
+    ],
+    "focus-booster": [
+      {
+        "cask": "focus-booster",
+        "count": "22"
+      }
+    ],
+    "focusatwill": [
+      {
+        "cask": "focusatwill",
+        "count": "11"
+      }
+    ],
+    "focused": [
+      {
+        "cask": "focused",
+        "count": "14"
+      }
+    ],
+    "focusrite-control": [
+      {
+        "cask": "focusrite-control",
+        "count": "26"
+      }
+    ],
+    "focusrite-saffire-mixcontrol": [
+      {
+        "cask": "focusrite-saffire-mixcontrol",
+        "count": "7"
+      }
+    ],
+    "focuswriter": [
+      {
+        "cask": "focuswriter",
+        "count": "56"
+      }
+    ],
+    "fog": [
+      {
+        "cask": "fog",
+        "count": "23"
+      }
+    ],
+    "fogpad": [
+      {
+        "cask": "fogpad",
+        "count": "3"
+      }
+    ],
+    "folding-at-home": [
+      {
+        "cask": "folding-at-home",
+        "count": "1,206"
+      }
+    ],
+    "foldingtext": [
+      {
+        "cask": "foldingtext",
+        "count": "17"
+      }
+    ],
+    "foldit": [
+      {
+        "cask": "foldit",
+        "count": "43"
+      }
+    ],
+    "folx": [
+      {
+        "cask": "folx",
+        "count": "1,027"
+      }
+    ],
+    "font-3270": [
+      {
+        "cask": "font-3270",
+        "count": "58"
+      }
+    ],
+    "font-3270-nerd-font": [
+      {
+        "cask": "font-3270-nerd-font",
+        "count": "174"
+      }
+    ],
+    "font-3270-nerd-font-mono": [
+      {
+        "cask": "font-3270-nerd-font-mono",
+        "count": "76"
+      }
+    ],
+    "font-abeezee": [
+      {
+        "cask": "font-abeezee",
+        "count": "26"
+      }
+    ],
+    "font-abel": [
+      {
+        "cask": "font-abel",
+        "count": "24"
+      }
+    ],
+    "font-aboriginal-sans": [
+      {
+        "cask": "font-aboriginal-sans",
+        "count": "22"
+      }
+    ],
+    "font-aboriginal-serif": [
+      {
+        "cask": "font-aboriginal-serif",
+        "count": "22"
+      }
+    ],
+    "font-abril-fatface": [
+      {
+        "cask": "font-abril-fatface",
+        "count": "22"
+      }
+    ],
+    "font-academicons": [
+      {
+        "cask": "font-academicons",
+        "count": "22"
+      }
+    ],
+    "font-aclonica": [
+      {
+        "cask": "font-aclonica",
+        "count": "18"
+      }
+    ],
+    "font-acme": [
+      {
+        "cask": "font-acme",
+        "count": "26"
+      }
+    ],
+    "font-actor": [
+      {
+        "cask": "font-actor",
+        "count": "20"
+      }
+    ],
+    "font-adamina": [
+      {
+        "cask": "font-adamina",
+        "count": "21"
+      }
+    ],
+    "font-adinatha-tamil-brahmi": [
+      {
+        "cask": "font-adinatha-tamil-brahmi",
+        "count": "18"
+      }
+    ],
+    "font-advent-pro": [
+      {
+        "cask": "font-advent-pro",
+        "count": "24"
+      }
+    ],
+    "font-african-sans": [
+      {
+        "cask": "font-african-sans",
+        "count": "20"
+      }
+    ],
+    "font-african-serif": [
+      {
+        "cask": "font-african-serif",
+        "count": "20"
+      }
+    ],
+    "font-agave-nerd-font": [
+      {
+        "cask": "font-agave-nerd-font",
+        "count": "39"
+      }
+    ],
+    "font-aguafina-script": [
+      {
+        "cask": "font-aguafina-script",
+        "count": "19"
+      }
+    ],
+    "font-ahuramzda": [
+      {
+        "cask": "font-ahuramzda",
+        "count": "19"
+      }
+    ],
+    "font-aileron": [
+      {
+        "cask": "font-aileron",
+        "count": "22"
+      }
+    ],
+    "font-akronim": [
+      {
+        "cask": "font-akronim",
+        "count": "20"
+      }
+    ],
+    "font-aladin": [
+      {
+        "cask": "font-aladin",
+        "count": "18"
+      }
+    ],
+    "font-aldrich": [
+      {
+        "cask": "font-aldrich",
+        "count": "20"
+      }
+    ],
+    "font-alef": [
+      {
+        "cask": "font-alef",
+        "count": "20"
+      }
+    ],
+    "font-alegreya": [
+      {
+        "cask": "font-alegreya",
+        "count": "43"
+      }
+    ],
+    "font-alegreya-sans": [
+      {
+        "cask": "font-alegreya-sans",
+        "count": "37"
+      }
+    ],
+    "font-alex-brush": [
+      {
+        "cask": "font-alex-brush",
+        "count": "19"
+      }
+    ],
+    "font-alfa-slab-one": [
+      {
+        "cask": "font-alfa-slab-one",
+        "count": "22"
+      }
+    ],
+    "font-alice": [
+      {
+        "cask": "font-alice",
+        "count": "24"
+      }
+    ],
+    "font-alike": [
+      {
+        "cask": "font-alike",
+        "count": "19"
+      }
+    ],
+    "font-alike-angular": [
+      {
+        "cask": "font-alike-angular",
+        "count": "19"
+      }
+    ],
+    "font-allan": [
+      {
+        "cask": "font-allan",
+        "count": "21"
+      }
+    ],
+    "font-allerta": [
+      {
+        "cask": "font-allerta",
+        "count": "18"
+      }
+    ],
+    "font-allerta-stencil": [
+      {
+        "cask": "font-allerta-stencil",
+        "count": "20"
+      }
+    ],
+    "font-allura": [
+      {
+        "cask": "font-allura",
+        "count": "20"
+      }
+    ],
+    "font-almendra": [
+      {
+        "cask": "font-almendra",
+        "count": "21"
+      }
+    ],
+    "font-almendra-display": [
+      {
+        "cask": "font-almendra-display",
+        "count": "19"
+      }
+    ],
+    "font-almendra-sc": [
+      {
+        "cask": "font-almendra-sc",
+        "count": "21"
+      }
+    ],
+    "font-amarante": [
+      {
+        "cask": "font-amarante",
+        "count": "19"
+      }
+    ],
+    "font-amaranth": [
+      {
+        "cask": "font-amaranth",
+        "count": "21"
+      }
+    ],
+    "font-amatic-sc": [
+      {
+        "cask": "font-amatic-sc",
+        "count": "27"
+      }
+    ],
+    "font-amethysta": [
+      {
+        "cask": "font-amethysta",
+        "count": "19"
+      }
+    ],
+    "font-amiri": [
+      {
+        "cask": "font-amiri",
+        "count": "20"
+      }
+    ],
+    "font-anaheim": [
+      {
+        "cask": "font-anaheim",
+        "count": "19"
+      }
+    ],
+    "font-andada": [
+      {
+        "cask": "font-andada",
+        "count": "22"
+      }
+    ],
+    "font-andada-sc": [
+      {
+        "cask": "font-andada-sc",
+        "count": "21"
+      }
+    ],
+    "font-andagii": [
+      {
+        "cask": "font-andagii",
+        "count": "17"
+      }
+    ],
+    "font-andale-mono": [
+      {
+        "cask": "font-andale-mono",
+        "count": "38"
+      }
+    ],
+    "font-andika": [
+      {
+        "cask": "font-andika",
+        "count": "19"
+      }
+    ],
+    "font-andron-scriptor-web": [
+      {
+        "cask": "font-andron-scriptor-web",
+        "count": "17"
+      }
+    ],
+    "font-angkor": [
+      {
+        "cask": "font-angkor",
+        "count": "16"
+      }
+    ],
+    "font-anka-coder": [
+      {
+        "cask": "font-anka-coder",
+        "count": "25"
+      }
+    ],
+    "font-annie-use-your-telescope": [
+      {
+        "cask": "font-annie-use-your-telescope",
+        "count": "19"
+      }
+    ],
+    "font-anonymice-nerd-font": [
+      {
+        "cask": "font-anonymice-nerd-font",
+        "count": "37"
+      }
+    ],
+    "font-anonymice-powerline": [
+      {
+        "cask": "font-anonymice-powerline",
+        "count": "150"
+      }
+    ],
+    "font-anonymous-pro": [
+      {
+        "cask": "font-anonymous-pro",
+        "count": "162"
+      }
+    ],
+    "font-anonymouspro-nerd-font": [
+      {
+        "cask": "font-anonymouspro-nerd-font",
+        "count": "86"
+      }
+    ],
+    "font-anonymouspro-nerd-font-mono": [
+      {
+        "cask": "font-anonymouspro-nerd-font-mono",
+        "count": "82"
+      }
+    ],
+    "font-antic": [
+      {
+        "cask": "font-antic",
+        "count": "18"
+      }
+    ],
+    "font-antic-didone": [
+      {
+        "cask": "font-antic-didone",
+        "count": "17"
+      }
+    ],
+    "font-antic-slab": [
+      {
+        "cask": "font-antic-slab",
+        "count": "17"
+      }
+    ],
+    "font-antinoou": [
+      {
+        "cask": "font-antinoou",
+        "count": "18"
+      }
+    ],
+    "font-anton": [
+      {
+        "cask": "font-anton",
+        "count": "21"
+      }
+    ],
+    "font-arapey": [
+      {
+        "cask": "font-arapey",
+        "count": "19"
+      }
+    ],
+    "font-arbutus": [
+      {
+        "cask": "font-arbutus",
+        "count": "19"
+      }
+    ],
+    "font-arbutus-slab": [
+      {
+        "cask": "font-arbutus-slab",
+        "count": "18"
+      }
+    ],
+    "font-architects-daughter": [
+      {
+        "cask": "font-architects-daughter",
+        "count": "23"
+      }
+    ],
+    "font-architype-renner": [
+      {
+        "cask": "font-architype-renner",
+        "count": "18"
+      }
+    ],
+    "font-archivo-black": [
+      {
+        "cask": "font-archivo-black",
+        "count": "25"
+      }
+    ],
+    "font-archivo-narrow": [
+      {
+        "cask": "font-archivo-narrow",
+        "count": "24"
+      }
+    ],
+    "font-arial": [
+      {
+        "cask": "font-arial",
+        "count": "33"
+      }
+    ],
+    "font-arial-black": [
+      {
+        "cask": "font-arial-black",
+        "count": "21"
+      }
+    ],
+    "font-arimo": [
+      {
+        "cask": "font-arimo",
+        "count": "32"
+      }
+    ],
+    "font-arimo-nerd-font": [
+      {
+        "cask": "font-arimo-nerd-font",
+        "count": "91"
+      }
+    ],
+    "font-arimo-nerd-font-mono": [
+      {
+        "cask": "font-arimo-nerd-font-mono",
+        "count": "56"
+      }
+    ],
+    "font-arizonia": [
+      {
+        "cask": "font-arizonia",
+        "count": "18"
+      }
+    ],
+    "font-armata": [
+      {
+        "cask": "font-armata",
+        "count": "18"
+      }
+    ],
+    "font-artifika": [
+      {
+        "cask": "font-artifika",
+        "count": "19"
+      }
+    ],
+    "font-arvo": [
+      {
+        "cask": "font-arvo",
+        "count": "27"
+      }
+    ],
+    "font-asset": [
+      {
+        "cask": "font-asset",
+        "count": "16"
+      }
+    ],
+    "font-astloch": [
+      {
+        "cask": "font-astloch",
+        "count": "18"
+      }
+    ],
+    "font-asul": [
+      {
+        "cask": "font-asul",
+        "count": "19"
+      }
+    ],
+    "font-atomic-age": [
+      {
+        "cask": "font-atomic-age",
+        "count": "21"
+      }
+    ],
+    "font-aubrey": [
+      {
+        "cask": "font-aubrey",
+        "count": "16"
+      }
+    ],
+    "font-audiowide": [
+      {
+        "cask": "font-audiowide",
+        "count": "17"
+      }
+    ],
+    "font-aurulentsansmono-nerd-font": [
+      {
+        "cask": "font-aurulentsansmono-nerd-font",
+        "count": "97"
+      }
+    ],
+    "font-aurulentsansmono-nerd-font-mono": [
+      {
+        "cask": "font-aurulentsansmono-nerd-font-mono",
+        "count": "50"
+      }
+    ],
+    "font-autour-one": [
+      {
+        "cask": "font-autour-one",
+        "count": "15"
+      }
+    ],
+    "font-average": [
+      {
+        "cask": "font-average",
+        "count": "17"
+      }
+    ],
+    "font-average-mono": [
+      {
+        "cask": "font-average-mono",
+        "count": "24"
+      }
+    ],
+    "font-average-sans": [
+      {
+        "cask": "font-average-sans",
+        "count": "15"
+      }
+    ],
+    "font-averia-gruesa-libre": [
+      {
+        "cask": "font-averia-gruesa-libre",
+        "count": "18"
+      }
+    ],
+    "font-averia-libre": [
+      {
+        "cask": "font-averia-libre",
+        "count": "24"
+      }
+    ],
+    "font-averia-sans-libre": [
+      {
+        "cask": "font-averia-sans-libre",
+        "count": "18"
+      }
+    ],
+    "font-averia-serif-libre": [
+      {
+        "cask": "font-averia-serif-libre",
+        "count": "20"
+      }
+    ],
+    "font-awesome-5-pro": [
+      {
+        "cask": "font-awesome-5-pro",
+        "count": "12"
+      }
+    ],
+    "font-awesome-terminal-fonts": [
+      {
+        "cask": "font-awesome-terminal-fonts",
+        "count": "328"
+      }
+    ],
+    "font-b612": [
+      {
+        "cask": "font-b612",
+        "count": "26"
+      }
+    ],
+    "font-bad-script": [
+      {
+        "cask": "font-bad-script",
+        "count": "20"
+      }
+    ],
+    "font-bahnschrift": [
+      {
+        "cask": "font-bahnschrift",
+        "count": "22"
+      }
+    ],
+    "font-baloo": [
+      {
+        "cask": "font-baloo",
+        "count": "17"
+      }
+    ],
+    "font-balsamiq-sans": [
+      {
+        "cask": "font-balsamiq-sans",
+        "count": "4"
+      }
+    ],
+    "font-balthazar": [
+      {
+        "cask": "font-balthazar",
+        "count": "15"
+      }
+    ],
+    "font-bangers": [
+      {
+        "cask": "font-bangers",
+        "count": "15"
+      }
+    ],
+    "font-barlow": [
+      {
+        "cask": "font-barlow",
+        "count": "23"
+      }
+    ],
+    "font-basic": [
+      {
+        "cask": "font-basic",
+        "count": "13"
+      }
+    ],
+    "font-battambang": [
+      {
+        "cask": "font-battambang",
+        "count": "17"
+      }
+    ],
+    "font-baumans": [
+      {
+        "cask": "font-baumans",
+        "count": "15"
+      }
+    ],
+    "font-bayon": [
+      {
+        "cask": "font-bayon",
+        "count": "12"
+      }
+    ],
+    "font-beattingvile": [
+      {
+        "cask": "font-beattingvile",
+        "count": "2"
+      }
+    ],
+    "font-belgrano": [
+      {
+        "cask": "font-belgrano",
+        "count": "14"
+      }
+    ],
+    "font-belleza": [
+      {
+        "cask": "font-belleza",
+        "count": "14"
+      }
+    ],
+    "font-benchnine": [
+      {
+        "cask": "font-benchnine",
+        "count": "17"
+      }
+    ],
+    "font-bentham": [
+      {
+        "cask": "font-bentham",
+        "count": "15"
+      }
+    ],
+    "font-berkshire-swash": [
+      {
+        "cask": "font-berkshire-swash",
+        "count": "16"
+      }
+    ],
+    "font-bevan": [
+      {
+        "cask": "font-bevan",
+        "count": "14"
+      }
+    ],
+    "font-bigblue-terminal-nerd-font": [
+      {
+        "cask": "font-bigblue-terminal-nerd-font",
+        "count": "18"
+      }
+    ],
+    "font-bigelow-rules": [
+      {
+        "cask": "font-bigelow-rules",
+        "count": "14"
+      }
+    ],
+    "font-bigshot-one": [
+      {
+        "cask": "font-bigshot-one",
+        "count": "14"
+      }
+    ],
+    "font-bilbo": [
+      {
+        "cask": "font-bilbo",
+        "count": "14"
+      }
+    ],
+    "font-bilbo-swash-caps": [
+      {
+        "cask": "font-bilbo-swash-caps",
+        "count": "15"
+      }
+    ],
+    "font-bitstream-vera": [
+      {
+        "cask": "font-bitstream-vera",
+        "count": "40"
+      }
+    ],
+    "font-bitstreamverasansmono-nerd-font": [
+      {
+        "cask": "font-bitstreamverasansmono-nerd-font",
+        "count": "124"
+      }
+    ],
+    "font-bitstreamverasansmono-nerd-font-mono": [
+      {
+        "cask": "font-bitstreamverasansmono-nerd-font-mono",
+        "count": "65"
+      }
+    ],
+    "font-bitter": [
+      {
+        "cask": "font-bitter",
+        "count": "23"
+      }
+    ],
+    "font-black-ops-one": [
+      {
+        "cask": "font-black-ops-one",
+        "count": "14"
+      }
+    ],
+    "font-blackout": [
+      {
+        "cask": "font-blackout",
+        "count": "15"
+      }
+    ],
+    "font-blexmono-nerd-font": [
+      {
+        "cask": "font-blexmono-nerd-font",
+        "count": "40"
+      }
+    ],
+    "font-blokk-neue": [
+      {
+        "cask": "font-blokk-neue",
+        "count": "16"
+      }
+    ],
+    "font-bokor": [
+      {
+        "cask": "font-bokor",
+        "count": "13"
+      }
+    ],
+    "font-bonbon": [
+      {
+        "cask": "font-bonbon",
+        "count": "16"
+      }
+    ],
+    "font-boogaloo": [
+      {
+        "cask": "font-boogaloo",
+        "count": "14"
+      }
+    ],
+    "font-bowlby-one": [
+      {
+        "cask": "font-bowlby-one",
+        "count": "15"
+      }
+    ],
+    "font-bowlby-one-sc": [
+      {
+        "cask": "font-bowlby-one-sc",
+        "count": "16"
+      }
+    ],
+    "font-brawler": [
+      {
+        "cask": "font-brawler",
+        "count": "15"
+      }
+    ],
+    "font-bree-serif": [
+      {
+        "cask": "font-bree-serif",
+        "count": "21"
+      }
+    ],
+    "font-brill": [
+      {
+        "cask": "font-brill",
+        "count": "14"
+      }
+    ],
+    "font-bubblegum-sans": [
+      {
+        "cask": "font-bubblegum-sans",
+        "count": "16"
+      }
+    ],
+    "font-bubbler-one": [
+      {
+        "cask": "font-bubbler-one",
+        "count": "13"
+      }
+    ],
+    "font-buda": [
+      {
+        "cask": "font-buda",
+        "count": "14"
+      }
+    ],
+    "font-buenard": [
+      {
+        "cask": "font-buenard",
+        "count": "17"
+      }
+    ],
+    "font-bukyvede-bold": [
+      {
+        "cask": "font-bukyvede-bold",
+        "count": "11"
+      }
+    ],
+    "font-bukyvede-italic": [
+      {
+        "cask": "font-bukyvede-italic",
+        "count": "12"
+      }
+    ],
+    "font-bukyvede-regular": [
+      {
+        "cask": "font-bukyvede-regular",
+        "count": "12"
+      }
+    ],
+    "font-bungee": [
+      {
+        "cask": "font-bungee",
+        "count": "13"
+      }
+    ],
+    "font-butcherman": [
+      {
+        "cask": "font-butcherman",
+        "count": "13"
+      }
+    ],
+    "font-butterfly-kids": [
+      {
+        "cask": "font-butterfly-kids",
+        "count": "14"
+      }
+    ],
+    "font-cabin": [
+      {
+        "cask": "font-cabin",
+        "count": "23"
+      }
+    ],
+    "font-cabin-condensed": [
+      {
+        "cask": "font-cabin-condensed",
+        "count": "17"
+      }
+    ],
+    "font-cabin-sketch": [
+      {
+        "cask": "font-cabin-sketch",
+        "count": "17"
+      }
+    ],
+    "font-caesar-dressing": [
+      {
+        "cask": "font-caesar-dressing",
+        "count": "14"
+      }
+    ],
+    "font-cagliostro": [
+      {
+        "cask": "font-cagliostro",
+        "count": "15"
+      }
+    ],
+    "font-caladea": [
+      {
+        "cask": "font-caladea",
+        "count": "1"
+      }
+    ],
+    "font-calligraffitti": [
+      {
+        "cask": "font-calligraffitti",
+        "count": "15"
+      }
+    ],
+    "font-cambo": [
+      {
+        "cask": "font-cambo",
+        "count": "15"
+      }
+    ],
+    "font-camingocode": [
+      {
+        "cask": "font-camingocode",
+        "count": "43"
+      }
+    ],
+    "font-candal": [
+      {
+        "cask": "font-candal",
+        "count": "15"
+      }
+    ],
+    "font-cantarell": [
+      {
+        "cask": "font-cantarell",
+        "count": "24"
+      }
+    ],
+    "font-cantata-one": [
+      {
+        "cask": "font-cantata-one",
+        "count": "15"
+      }
+    ],
+    "font-cantora-one": [
+      {
+        "cask": "font-cantora-one",
+        "count": "15"
+      }
+    ],
+    "font-capriola": [
+      {
+        "cask": "font-capriola",
+        "count": "15"
+      }
+    ],
+    "font-cardo": [
+      {
+        "cask": "font-cardo",
+        "count": "22"
+      }
+    ],
+    "font-carlito": [
+      {
+        "cask": "font-carlito",
+        "count": "1"
+      }
+    ],
+    "font-carme": [
+      {
+        "cask": "font-carme",
+        "count": "15"
+      }
+    ],
+    "font-carrois-gothic": [
+      {
+        "cask": "font-carrois-gothic",
+        "count": "15"
+      }
+    ],
+    "font-carrois-gothic-sc": [
+      {
+        "cask": "font-carrois-gothic-sc",
+        "count": "16"
+      }
+    ],
+    "font-carter-one": [
+      {
+        "cask": "font-carter-one",
+        "count": "15"
+      }
+    ],
+    "font-cascadia": [
+      {
+        "cask": "font-cascadia",
+        "count": "565"
+      }
+    ],
+    "font-cascadia-mono": [
+      {
+        "cask": "font-cascadia-mono",
+        "count": "248"
+      }
+    ],
+    "font-cascadia-mono-pl": [
+      {
+        "cask": "font-cascadia-mono-pl",
+        "count": "121"
+      }
+    ],
+    "font-cascadia-nerd-font": [
+      {
+        "cask": "font-cascadia-nerd-font",
+        "count": "91"
+      }
+    ],
+    "font-cascadia-nerd-font-mono": [
+      {
+        "cask": "font-cascadia-nerd-font-mono",
+        "count": "67"
+      }
+    ],
+    "font-cascadia-pl": [
+      {
+        "cask": "font-cascadia-pl",
+        "count": "161"
+      }
+    ],
+    "font-cascadiacode-nerd-font": [
+      {
+        "cask": "font-cascadiacode-nerd-font",
+        "count": "2"
+      }
+    ],
+    "font-cascadiacode-nerd-font-mono": [
+      {
+        "cask": "font-cascadiacode-nerd-font-mono",
+        "count": "1"
+      }
+    ],
+    "font-caskaydiacove-nerd-font": [
+      {
+        "cask": "font-caskaydiacove-nerd-font",
+        "count": "51"
+      }
+    ],
+    "font-caudex": [
+      {
+        "cask": "font-caudex",
+        "count": "16"
+      }
+    ],
+    "font-cedarville-cursive": [
+      {
+        "cask": "font-cedarville-cursive",
+        "count": "14"
+      }
+    ],
+    "font-ceviche-one": [
+      {
+        "cask": "font-ceviche-one",
+        "count": "14"
+      }
+    ],
+    "font-chalet": [
+      {
+        "cask": "font-chalet",
+        "count": "1"
+      }
+    ],
+    "font-changa-one": [
+      {
+        "cask": "font-changa-one",
+        "count": "16"
+      }
+    ],
+    "font-chango": [
+      {
+        "cask": "font-chango",
+        "count": "17"
+      }
+    ],
+    "font-chapbook": [
+      {
+        "cask": "font-chapbook",
+        "count": "16"
+      }
+    ],
+    "font-charis-sil": [
+      {
+        "cask": "font-charis-sil",
+        "count": "23"
+      }
+    ],
+    "font-charter": [
+      {
+        "cask": "font-charter",
+        "count": "27"
+      }
+    ],
+    "font-chau-philomene-one": [
+      {
+        "cask": "font-chau-philomene-one",
+        "count": "16"
+      }
+    ],
+    "font-chela-one": [
+      {
+        "cask": "font-chela-one",
+        "count": "15"
+      }
+    ],
+    "font-chelsea-market": [
+      {
+        "cask": "font-chelsea-market",
+        "count": "16"
+      }
+    ],
+    "font-chenla": [
+      {
+        "cask": "font-chenla",
+        "count": "14"
+      }
+    ],
+    "font-cherry-cream-soda": [
+      {
+        "cask": "font-cherry-cream-soda",
+        "count": "16"
+      }
+    ],
+    "font-cherry-swash": [
+      {
+        "cask": "font-cherry-swash",
+        "count": "15"
+      }
+    ],
+    "font-chewy": [
+      {
+        "cask": "font-chewy",
+        "count": "15"
+      }
+    ],
+    "font-chicle": [
+      {
+        "cask": "font-chicle",
+        "count": "14"
+      }
+    ],
+    "font-chivo": [
+      {
+        "cask": "font-chivo",
+        "count": "20"
+      }
+    ],
+    "font-church-slavonic": [
+      {
+        "cask": "font-church-slavonic",
+        "count": "14"
+      }
+    ],
+    "font-cica": [
+      {
+        "cask": "font-cica",
+        "count": "131"
+      }
+    ],
+    "font-cinzel": [
+      {
+        "cask": "font-cinzel",
+        "count": "18"
+      }
+    ],
+    "font-cinzel-decorative": [
+      {
+        "cask": "font-cinzel-decorative",
+        "count": "17"
+      }
+    ],
+    "font-clear-sans": [
+      {
+        "cask": "font-clear-sans",
+        "count": "53"
+      }
+    ],
+    "font-clicker-script": [
+      {
+        "cask": "font-clicker-script",
+        "count": "15"
+      }
+    ],
+    "font-cochineal": [
+      {
+        "cask": "font-cochineal",
+        "count": "14"
+      }
+    ],
+    "font-coda": [
+      {
+        "cask": "font-coda",
+        "count": "18"
+      }
+    ],
+    "font-coda-caption": [
+      {
+        "cask": "font-coda-caption",
+        "count": "14"
+      }
+    ],
+    "font-code2002": [
+      {
+        "cask": "font-code2002",
+        "count": "15"
+      }
+    ],
+    "font-codenewroman-nerd-font": [
+      {
+        "cask": "font-codenewroman-nerd-font",
+        "count": "120"
+      }
+    ],
+    "font-codenewroman-nerd-font-mono": [
+      {
+        "cask": "font-codenewroman-nerd-font-mono",
+        "count": "66"
+      }
+    ],
+    "font-codystar": [
+      {
+        "cask": "font-codystar",
+        "count": "15"
+      }
+    ],
+    "font-combo": [
+      {
+        "cask": "font-combo",
+        "count": "15"
+      }
+    ],
+    "font-comfortaa": [
+      {
+        "cask": "font-comfortaa",
+        "count": "23"
+      }
+    ],
+    "font-comic-neue": [
+      {
+        "cask": "font-comic-neue",
+        "count": "30"
+      }
+    ],
+    "font-comic-sans-ms": [
+      {
+        "cask": "font-comic-sans-ms",
+        "count": "24"
+      }
+    ],
+    "font-coming-soon": [
+      {
+        "cask": "font-coming-soon",
+        "count": "15"
+      }
+    ],
+    "font-computer-modern": [
+      {
+        "cask": "font-computer-modern",
+        "count": "143"
+      }
+    ],
+    "font-conakry": [
+      {
+        "cask": "font-conakry",
+        "count": "13"
+      }
+    ],
+    "font-concert-one": [
+      {
+        "cask": "font-concert-one",
+        "count": "14"
+      }
+    ],
+    "font-condiment": [
+      {
+        "cask": "font-condiment",
+        "count": "13"
+      }
+    ],
+    "font-consolas-for-powerline": [
+      {
+        "cask": "font-consolas-for-powerline",
+        "count": "327"
+      }
+    ],
+    "font-constructium": [
+      {
+        "cask": "font-constructium",
+        "count": "14"
+      }
+    ],
+    "font-content": [
+      {
+        "cask": "font-content",
+        "count": "13"
+      }
+    ],
+    "font-contrail-one": [
+      {
+        "cask": "font-contrail-one",
+        "count": "15"
+      }
+    ],
+    "font-convergence": [
+      {
+        "cask": "font-convergence",
+        "count": "14"
+      }
+    ],
+    "font-cookie": [
+      {
+        "cask": "font-cookie",
+        "count": "17"
+      }
+    ],
+    "font-cooper-hewitt": [
+      {
+        "cask": "font-cooper-hewitt",
+        "count": "28"
+      }
+    ],
+    "font-copse": [
+      {
+        "cask": "font-copse",
+        "count": "14"
+      }
+    ],
+    "font-corben": [
+      {
+        "cask": "font-corben",
+        "count": "14"
+      }
+    ],
+    "font-cormorant": [
+      {
+        "cask": "font-cormorant",
+        "count": "19"
+      }
+    ],
+    "font-courgette": [
+      {
+        "cask": "font-courgette",
+        "count": "15"
+      }
+    ],
+    "font-courier-new": [
+      {
+        "cask": "font-courier-new",
+        "count": "22"
+      }
+    ],
+    "font-courier-prime": [
+      {
+        "cask": "font-courier-prime",
+        "count": "45"
+      }
+    ],
+    "font-courier-prime-code": [
+      {
+        "cask": "font-courier-prime-code",
+        "count": "45"
+      }
+    ],
+    "font-courier-prime-medium-and-semi-bold": [
+      {
+        "cask": "font-courier-prime-medium-and-semi-bold",
+        "count": "24"
+      }
+    ],
+    "font-courier-prime-sans": [
+      {
+        "cask": "font-courier-prime-sans",
+        "count": "32"
+      }
+    ],
+    "font-cousine": [
+      {
+        "cask": "font-cousine",
+        "count": "35"
+      }
+    ],
+    "font-cousine-nerd-font": [
+      {
+        "cask": "font-cousine-nerd-font",
+        "count": "104"
+      }
+    ],
+    "font-cousine-nerd-font-mono": [
+      {
+        "cask": "font-cousine-nerd-font-mono",
+        "count": "63"
+      }
+    ],
+    "font-coustard": [
+      {
+        "cask": "font-coustard",
+        "count": "14"
+      }
+    ],
+    "font-covered-by-your-grace": [
+      {
+        "cask": "font-covered-by-your-grace",
+        "count": "15"
+      }
+    ],
+    "font-cozette": [
+      {
+        "cask": "font-cozette",
+        "count": "26"
+      }
+    ],
+    "font-crafty-girls": [
+      {
+        "cask": "font-crafty-girls",
+        "count": "15"
+      }
+    ],
+    "font-creepster": [
+      {
+        "cask": "font-creepster",
+        "count": "13"
+      }
+    ],
+    "font-crete-round": [
+      {
+        "cask": "font-crete-round",
+        "count": "13"
+      }
+    ],
+    "font-crimson-pro": [
+      {
+        "cask": "font-crimson-pro",
+        "count": "6"
+      }
+    ],
+    "font-crimson-text": [
+      {
+        "cask": "font-crimson-text",
+        "count": "32"
+      }
+    ],
+    "font-croissant-one": [
+      {
+        "cask": "font-croissant-one",
+        "count": "15"
+      }
+    ],
+    "font-crushed": [
+      {
+        "cask": "font-crushed",
+        "count": "14"
+      }
+    ],
+    "font-cuprum": [
+      {
+        "cask": "font-cuprum",
+        "count": "15"
+      }
+    ],
+    "font-cutive": [
+      {
+        "cask": "font-cutive",
+        "count": "15"
+      }
+    ],
+    "font-cutive-mono": [
+      {
+        "cask": "font-cutive-mono",
+        "count": "30"
+      }
+    ],
+    "font-d2coding": [
+      {
+        "cask": "font-d2coding",
+        "count": "189"
+      }
+    ],
+    "font-daddytimemono-nerd-font": [
+      {
+        "cask": "font-daddytimemono-nerd-font",
+        "count": "29"
+      }
+    ],
+    "font-damion": [
+      {
+        "cask": "font-damion",
+        "count": "14"
+      }
+    ],
+    "font-dancing-script": [
+      {
+        "cask": "font-dancing-script",
+        "count": "18"
+      }
+    ],
+    "font-dashicons": [
+      {
+        "cask": "font-dashicons",
+        "count": "42"
+      }
+    ],
+    "font-david-clm": [
+      {
+        "cask": "font-david-clm",
+        "count": "13"
+      }
+    ],
+    "font-davidodio-archivo": [
+      {
+        "cask": "font-davidodio-archivo",
+        "count": "1"
+      }
+    ],
+    "font-dawning-of-a-new-day": [
+      {
+        "cask": "font-dawning-of-a-new-day",
+        "count": "15"
+      }
+    ],
+    "font-days-one": [
+      {
+        "cask": "font-days-one",
+        "count": "15"
+      }
+    ],
+    "font-dejavu": [
+      {
+        "cask": "font-dejavu",
+        "count": "67"
+      }
+    ],
+    "font-dejavu-sans": [
+      {
+        "cask": "font-dejavu-sans",
+        "count": "228"
+      }
+    ],
+    "font-dejavu-sans-mono-for-powerline": [
+      {
+        "cask": "font-dejavu-sans-mono-for-powerline",
+        "count": "266"
+      }
+    ],
+    "font-dejavusansmono-nerd-font": [
+      {
+        "cask": "font-dejavusansmono-nerd-font",
+        "count": "260"
+      }
+    ],
+    "font-dejavusansmono-nerd-font-mono": [
+      {
+        "cask": "font-dejavusansmono-nerd-font-mono",
+        "count": "118"
+      }
+    ],
+    "font-delius": [
+      {
+        "cask": "font-delius",
+        "count": "15"
+      }
+    ],
+    "font-delius-swash-caps": [
+      {
+        "cask": "font-delius-swash-caps",
+        "count": "15"
+      }
+    ],
+    "font-delius-unicase": [
+      {
+        "cask": "font-delius-unicase",
+        "count": "15"
+      }
+    ],
+    "font-della-respira": [
+      {
+        "cask": "font-della-respira",
+        "count": "16"
+      }
+    ],
+    "font-denk-one": [
+      {
+        "cask": "font-denk-one",
+        "count": "16"
+      }
+    ],
+    "font-devicons": [
+      {
+        "cask": "font-devicons",
+        "count": "71"
+      }
+    ],
+    "font-devonshire": [
+      {
+        "cask": "font-devonshire",
+        "count": "15"
+      }
+    ],
+    "font-dhyana": [
+      {
+        "cask": "font-dhyana",
+        "count": "14"
+      }
+    ],
+    "font-didact-gothic": [
+      {
+        "cask": "font-didact-gothic",
+        "count": "16"
+      }
+    ],
+    "font-digohweli-old-do": [
+      {
+        "cask": "font-digohweli-old-do",
+        "count": "15"
+      }
+    ],
+    "font-diplomata": [
+      {
+        "cask": "font-diplomata",
+        "count": "15"
+      }
+    ],
+    "font-diplomata-sc": [
+      {
+        "cask": "font-diplomata-sc",
+        "count": "16"
+      }
+    ],
+    "font-domine": [
+      {
+        "cask": "font-domine",
+        "count": "18"
+      }
+    ],
+    "font-donegal-one": [
+      {
+        "cask": "font-donegal-one",
+        "count": "16"
+      }
+    ],
+    "font-doppio-one": [
+      {
+        "cask": "font-doppio-one",
+        "count": "15"
+      }
+    ],
+    "font-dorsa": [
+      {
+        "cask": "font-dorsa",
+        "count": "15"
+      }
+    ],
+    "font-dosis": [
+      {
+        "cask": "font-dosis",
+        "count": "27"
+      }
+    ],
+    "font-doulos-sil": [
+      {
+        "cask": "font-doulos-sil",
+        "count": "19"
+      }
+    ],
+    "font-droid-sans-mono-for-powerline": [
+      {
+        "cask": "font-droid-sans-mono-for-powerline",
+        "count": "236"
+      }
+    ],
+    "font-droidsansmono-nerd-font": [
+      {
+        "cask": "font-droidsansmono-nerd-font",
+        "count": "230"
+      }
+    ],
+    "font-droidsansmono-nerd-font-mono": [
+      {
+        "cask": "font-droidsansmono-nerd-font-mono",
+        "count": "86"
+      }
+    ],
+    "font-duru-sans": [
+      {
+        "cask": "font-duru-sans",
+        "count": "16"
+      }
+    ],
+    "font-dynalight": [
+      {
+        "cask": "font-dynalight",
+        "count": "17"
+      }
+    ],
+    "font-eagle-lake": [
+      {
+        "cask": "font-eagle-lake",
+        "count": "15"
+      }
+    ],
+    "font-eater": [
+      {
+        "cask": "font-eater",
+        "count": "14"
+      }
+    ],
+    "font-eb-garamond": [
+      {
+        "cask": "font-eb-garamond",
+        "count": "58"
+      }
+    ],
+    "font-economica": [
+      {
+        "cask": "font-economica",
+        "count": "17"
+      }
+    ],
+    "font-edlo": [
+      {
+        "cask": "font-edlo",
+        "count": "15"
+      }
+    ],
+    "font-eeyek-unicode": [
+      {
+        "cask": "font-eeyek-unicode",
+        "count": "3"
+      }
+    ],
+    "font-electrolize": [
+      {
+        "cask": "font-electrolize",
+        "count": "15"
+      }
+    ],
+    "font-elsie": [
+      {
+        "cask": "font-elsie",
+        "count": "15"
+      }
+    ],
+    "font-elsie-swash-caps": [
+      {
+        "cask": "font-elsie-swash-caps",
+        "count": "15"
+      }
+    ],
+    "font-emilys-candy": [
+      {
+        "cask": "font-emilys-candy",
+        "count": "15"
+      }
+    ],
+    "font-encodesans": [
+      {
+        "cask": "font-encodesans",
+        "count": "17"
+      }
+    ],
+    "font-encodesans-condensed": [
+      {
+        "cask": "font-encodesans-condensed",
+        "count": "18"
+      }
+    ],
+    "font-encodesans-expanded": [
+      {
+        "cask": "font-encodesans-expanded",
+        "count": "15"
+      }
+    ],
+    "font-encodesans-semicondensed": [
+      {
+        "cask": "font-encodesans-semicondensed",
+        "count": "16"
+      }
+    ],
+    "font-encodesans-semiexpanded": [
+      {
+        "cask": "font-encodesans-semiexpanded",
+        "count": "17"
+      }
+    ],
+    "font-engagement": [
+      {
+        "cask": "font-engagement",
+        "count": "15"
+      }
+    ],
+    "font-englebert": [
+      {
+        "cask": "font-englebert",
+        "count": "15"
+      }
+    ],
+    "font-enriqueta": [
+      {
+        "cask": "font-enriqueta",
+        "count": "16"
+      }
+    ],
+    "font-envy-code-r": [
+      {
+        "cask": "font-envy-code-r",
+        "count": "58"
+      }
+    ],
+    "font-erica-one": [
+      {
+        "cask": "font-erica-one",
+        "count": "16"
+      }
+    ],
+    "font-esteban": [
+      {
+        "cask": "font-esteban",
+        "count": "15"
+      }
+    ],
+    "font-et-book": [
+      {
+        "cask": "font-et-book",
+        "count": "38"
+      }
+    ],
+    "font-euphoria-script": [
+      {
+        "cask": "font-euphoria-script",
+        "count": "16"
+      }
+    ],
+    "font-everson-mono": [
+      {
+        "cask": "font-everson-mono",
+        "count": "29"
+      }
+    ],
+    "font-ewert": [
+      {
+        "cask": "font-ewert",
+        "count": "15"
+      }
+    ],
+    "font-exo": [
+      {
+        "cask": "font-exo",
+        "count": "21"
+      }
+    ],
+    "font-exo2": [
+      {
+        "cask": "font-exo2",
+        "count": "24"
+      }
+    ],
+    "font-ezra-sil": [
+      {
+        "cask": "font-ezra-sil",
+        "count": "17"
+      }
+    ],
+    "font-fairfax": [
+      {
+        "cask": "font-fairfax",
+        "count": "16"
+      }
+    ],
+    "font-fandol": [
+      {
+        "cask": "font-fandol",
+        "count": "17"
+      }
+    ],
+    "font-fantasque-sans-mono": [
+      {
+        "cask": "font-fantasque-sans-mono",
+        "count": "363"
+      }
+    ],
+    "font-fantasque-sans-mono-noligatures": [
+      {
+        "cask": "font-fantasque-sans-mono-noligatures",
+        "count": "1"
+      }
+    ],
+    "font-fantasque-sans-mono-noloopk": [
+      {
+        "cask": "font-fantasque-sans-mono-noloopk",
+        "count": "19"
+      }
+    ],
+    "font-fantasque-sans-mono-noloopk-noligatures": [
+      {
+        "cask": "font-fantasque-sans-mono-noloopk-noligatures",
+        "count": "1"
+      }
+    ],
+    "font-fantasquesansmono-nerd-font": [
+      {
+        "cask": "font-fantasquesansmono-nerd-font",
+        "count": "145"
+      }
+    ],
+    "font-fantasquesansmono-nerd-font-mono": [
+      {
+        "cask": "font-fantasquesansmono-nerd-font-mono",
+        "count": "95"
+      }
+    ],
+    "font-fanwood-text": [
+      {
+        "cask": "font-fanwood-text",
+        "count": "19"
+      }
+    ],
+    "font-fascinate": [
+      {
+        "cask": "font-fascinate",
+        "count": "16"
+      }
+    ],
+    "font-fascinate-inline": [
+      {
+        "cask": "font-fascinate-inline",
+        "count": "15"
+      }
+    ],
+    "font-faster-one": [
+      {
+        "cask": "font-faster-one",
+        "count": "14"
+      }
+    ],
+    "font-fasthand": [
+      {
+        "cask": "font-fasthand",
+        "count": "14"
+      }
+    ],
+    "font-fauna-one": [
+      {
+        "cask": "font-fauna-one",
+        "count": "18"
+      }
+    ],
+    "font-federant": [
+      {
+        "cask": "font-federant",
+        "count": "15"
+      }
+    ],
+    "font-federo": [
+      {
+        "cask": "font-federo",
+        "count": "15"
+      }
+    ],
+    "font-felipa": [
+      {
+        "cask": "font-felipa",
+        "count": "15"
+      }
+    ],
+    "font-fenix": [
+      {
+        "cask": "font-fenix",
+        "count": "17"
+      }
+    ],
+    "font-finger-paint": [
+      {
+        "cask": "font-finger-paint",
+        "count": "19"
+      }
+    ],
+    "font-fira-code": [
+      {
+        "cask": "font-fira-code",
+        "count": "11,930"
+      }
+    ],
+    "font-fira-mono": [
+      {
+        "cask": "font-fira-mono",
+        "count": "614"
+      }
+    ],
+    "font-fira-mono-for-powerline": [
+      {
+        "cask": "font-fira-mono-for-powerline",
+        "count": "592"
+      }
+    ],
+    "font-fira-sans": [
+      {
+        "cask": "font-fira-sans",
+        "count": "436"
+      }
+    ],
+    "font-firacode-nerd-font": [
+      {
+        "cask": "font-firacode-nerd-font",
+        "count": "1,940"
+      }
+    ],
+    "font-firacode-nerd-font-mono": [
+      {
+        "cask": "font-firacode-nerd-font-mono",
+        "count": "579"
+      }
+    ],
+    "font-firamono-nerd-font": [
+      {
+        "cask": "font-firamono-nerd-font",
+        "count": "328"
+      }
+    ],
+    "font-firamono-nerd-font-mono": [
+      {
+        "cask": "font-firamono-nerd-font-mono",
+        "count": "133"
+      }
+    ],
+    "font-fjalla-one": [
+      {
+        "cask": "font-fjalla-one",
+        "count": "18"
+      }
+    ],
+    "font-fjord-one": [
+      {
+        "cask": "font-fjord-one",
+        "count": "16"
+      }
+    ],
+    "font-flamenco": [
+      {
+        "cask": "font-flamenco",
+        "count": "15"
+      }
+    ],
+    "font-flavors": [
+      {
+        "cask": "font-flavors",
+        "count": "15"
+      }
+    ],
+    "font-fondamento": [
+      {
+        "cask": "font-fondamento",
+        "count": "15"
+      }
+    ],
+    "font-fontawesome": [
+      {
+        "cask": "font-fontawesome",
+        "count": "615"
+      }
+    ],
+    "font-fontdiner-swanky": [
+      {
+        "cask": "font-fontdiner-swanky",
+        "count": "15"
+      }
+    ],
+    "font-forum": [
+      {
+        "cask": "font-forum",
+        "count": "17"
+      }
+    ],
+    "font-foundation-icons": [
+      {
+        "cask": "font-foundation-icons",
+        "count": "19"
+      }
+    ],
+    "font-foundry-sterling": [
+      {
+        "cask": "font-foundry-sterling",
+        "count": "15"
+      }
+    ],
+    "font-francois-one": [
+      {
+        "cask": "font-francois-one",
+        "count": "16"
+      }
+    ],
+    "font-freckle-face": [
+      {
+        "cask": "font-freckle-face",
+        "count": "14"
+      }
+    ],
+    "font-fredericka-the-great": [
+      {
+        "cask": "font-fredericka-the-great",
+        "count": "15"
+      }
+    ],
+    "font-fredoka-one": [
+      {
+        "cask": "font-fredoka-one",
+        "count": "16"
+      }
+    ],
+    "font-freehand": [
+      {
+        "cask": "font-freehand",
+        "count": "15"
+      }
+    ],
+    "font-freesans": [
+      {
+        "cask": "font-freesans",
+        "count": "31"
+      }
+    ],
+    "font-fresca": [
+      {
+        "cask": "font-fresca",
+        "count": "16"
+      }
+    ],
+    "font-frijole": [
+      {
+        "cask": "font-frijole",
+        "count": "15"
+      }
+    ],
+    "font-fruktur": [
+      {
+        "cask": "font-fruktur",
+        "count": "13"
+      }
+    ],
+    "font-fzshusong-z01": [
+      {
+        "cask": "font-fzshusong-z01",
+        "count": "19"
+      }
+    ],
+    "font-fzshusong-z01s": [
+      {
+        "cask": "font-fzshusong-z01s",
+        "count": "3"
+      }
+    ],
+    "font-gabriela": [
+      {
+        "cask": "font-gabriela",
+        "count": "14"
+      }
+    ],
+    "font-gafata": [
+      {
+        "cask": "font-gafata",
+        "count": "14"
+      }
+    ],
+    "font-galdeano": [
+      {
+        "cask": "font-galdeano",
+        "count": "14"
+      }
+    ],
+    "font-galindo": [
+      {
+        "cask": "font-galindo",
+        "count": "14"
+      }
+    ],
+    "font-gandhi-sans": [
+      {
+        "cask": "font-gandhi-sans",
+        "count": "15"
+      }
+    ],
+    "font-genjyuugothic": [
+      {
+        "cask": "font-genjyuugothic",
+        "count": "12"
+      }
+    ],
+    "font-genjyuugothic-x": [
+      {
+        "cask": "font-genjyuugothic-x",
+        "count": "9"
+      }
+    ],
+    "font-genryumin": [
+      {
+        "cask": "font-genryumin",
+        "count": "3"
+      }
+    ],
+    "font-gensekigothic": [
+      {
+        "cask": "font-gensekigothic",
+        "count": "2"
+      }
+    ],
+    "font-gensenrounded": [
+      {
+        "cask": "font-gensenrounded",
+        "count": "4"
+      }
+    ],
+    "font-genshingothic": [
+      {
+        "cask": "font-genshingothic",
+        "count": "16"
+      }
+    ],
+    "font-gentium-basic": [
+      {
+        "cask": "font-gentium-basic",
+        "count": "22"
+      }
+    ],
+    "font-gentium-book-basic": [
+      {
+        "cask": "font-gentium-book-basic",
+        "count": "26"
+      }
+    ],
+    "font-gentium-plus": [
+      {
+        "cask": "font-gentium-plus",
+        "count": "26"
+      }
+    ],
+    "font-genwanmin": [
+      {
+        "cask": "font-genwanmin",
+        "count": "3"
+      }
+    ],
+    "font-genyogothic": [
+      {
+        "cask": "font-genyogothic",
+        "count": "3"
+      }
+    ],
+    "font-genyomin": [
+      {
+        "cask": "font-genyomin",
+        "count": "3"
+      }
+    ],
+    "font-geo": [
+      {
+        "cask": "font-geo",
+        "count": "14"
+      }
+    ],
+    "font-georgia": [
+      {
+        "cask": "font-georgia",
+        "count": "15"
+      }
+    ],
+    "font-geostar": [
+      {
+        "cask": "font-geostar",
+        "count": "13"
+      }
+    ],
+    "font-geostar-fill": [
+      {
+        "cask": "font-geostar-fill",
+        "count": "13"
+      }
+    ],
+    "font-germania-one": [
+      {
+        "cask": "font-germania-one",
+        "count": "13"
+      }
+    ],
+    "font-gfs-didot": [
+      {
+        "cask": "font-gfs-didot",
+        "count": "18"
+      }
+    ],
+    "font-gfs-neohellenic": [
+      {
+        "cask": "font-gfs-neohellenic",
+        "count": "12"
+      }
+    ],
+    "font-gidole": [
+      {
+        "cask": "font-gidole",
+        "count": "17"
+      }
+    ],
+    "font-gilbert": [
+      {
+        "cask": "font-gilbert",
+        "count": "13"
+      }
+    ],
+    "font-gilda-display": [
+      {
+        "cask": "font-gilda-display",
+        "count": "13"
+      }
+    ],
+    "font-give-you-glory": [
+      {
+        "cask": "font-give-you-glory",
+        "count": "13"
+      }
+    ],
+    "font-glass-antiqua": [
+      {
+        "cask": "font-glass-antiqua",
+        "count": "13"
+      }
+    ],
+    "font-glegoo": [
+      {
+        "cask": "font-glegoo",
+        "count": "14"
+      }
+    ],
+    "font-gloria-hallelujah": [
+      {
+        "cask": "font-gloria-hallelujah",
+        "count": "14"
+      }
+    ],
+    "font-gnu-unifont": [
+      {
+        "cask": "font-gnu-unifont",
+        "count": "40"
+      }
+    ],
+    "font-go": [
+      {
+        "cask": "font-go",
+        "count": "51"
+      }
+    ],
+    "font-go-medium": [
+      {
+        "cask": "font-go-medium",
+        "count": "10"
+      }
+    ],
+    "font-go-mono": [
+      {
+        "cask": "font-go-mono",
+        "count": "36"
+      }
+    ],
+    "font-go-mono-nerd-font": [
+      {
+        "cask": "font-go-mono-nerd-font",
+        "count": "91"
+      }
+    ],
+    "font-go-mono-nerd-font-mono": [
+      {
+        "cask": "font-go-mono-nerd-font-mono",
+        "count": "74"
+      }
+    ],
+    "font-goblin-one": [
+      {
+        "cask": "font-goblin-one",
+        "count": "13"
+      }
+    ],
+    "font-gochi-hand": [
+      {
+        "cask": "font-gochi-hand",
+        "count": "14"
+      }
+    ],
+    "font-gohu-nerd-font": [
+      {
+        "cask": "font-gohu-nerd-font",
+        "count": "51"
+      }
+    ],
+    "font-gohu-nerd-font-mono": [
+      {
+        "cask": "font-gohu-nerd-font-mono",
+        "count": "57"
+      }
+    ],
+    "font-gohufont-nerd-font": [
+      {
+        "cask": "font-gohufont-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-gomono-nerd-font": [
+      {
+        "cask": "font-gomono-nerd-font",
+        "count": "34"
+      }
+    ],
+    "font-gorditas": [
+      {
+        "cask": "font-gorditas",
+        "count": "12"
+      }
+    ],
+    "font-goudy-bookletter1911": [
+      {
+        "cask": "font-goudy-bookletter1911",
+        "count": "18"
+      }
+    ],
+    "font-graduate": [
+      {
+        "cask": "font-graduate",
+        "count": "12"
+      }
+    ],
+    "font-grand-hotel": [
+      {
+        "cask": "font-grand-hotel",
+        "count": "13"
+      }
+    ],
+    "font-gravitas-one": [
+      {
+        "cask": "font-gravitas-one",
+        "count": "14"
+      }
+    ],
+    "font-great-vibes": [
+      {
+        "cask": "font-great-vibes",
+        "count": "17"
+      }
+    ],
+    "font-griffy": [
+      {
+        "cask": "font-griffy",
+        "count": "14"
+      }
+    ],
+    "font-gruppo": [
+      {
+        "cask": "font-gruppo",
+        "count": "15"
+      }
+    ],
+    "font-gudea": [
+      {
+        "cask": "font-gudea",
+        "count": "15"
+      }
+    ],
+    "font-habibi": [
+      {
+        "cask": "font-habibi",
+        "count": "14"
+      }
+    ],
+    "font-hack": [
+      {
+        "cask": "font-hack",
+        "count": "809"
+      }
+    ],
+    "font-hack-nerd-font": [
+      {
+        "cask": "font-hack-nerd-font",
+        "count": "10,922"
+      }
+    ],
+    "font-hack-nerd-font-mono": [
+      {
+        "cask": "font-hack-nerd-font-mono",
+        "count": "281"
+      }
+    ],
+    "font-hackgen": [
+      {
+        "cask": "font-hackgen",
+        "count": "369"
+      }
+    ],
+    "font-halant": [
+      {
+        "cask": "font-halant",
+        "count": "14"
+      }
+    ],
+    "font-hammersmith-one": [
+      {
+        "cask": "font-hammersmith-one",
+        "count": "17"
+      }
+    ],
+    "font-han-nom-a": [
+      {
+        "cask": "font-han-nom-a",
+        "count": "15"
+      }
+    ],
+    "font-hanalei": [
+      {
+        "cask": "font-hanalei",
+        "count": "14"
+      }
+    ],
+    "font-hanalei-fill": [
+      {
+        "cask": "font-hanalei-fill",
+        "count": "14"
+      }
+    ],
+    "font-hanamina": [
+      {
+        "cask": "font-hanamina",
+        "count": "28"
+      }
+    ],
+    "font-handlee": [
+      {
+        "cask": "font-handlee",
+        "count": "21"
+      }
+    ],
+    "font-hanuman": [
+      {
+        "cask": "font-hanuman",
+        "count": "14"
+      }
+    ],
+    "font-happy-monkey": [
+      {
+        "cask": "font-happy-monkey",
+        "count": "15"
+      }
+    ],
+    "font-hasklig": [
+      {
+        "cask": "font-hasklig",
+        "count": "245"
+      }
+    ],
+    "font-hasklig-nerd-font": [
+      {
+        "cask": "font-hasklig-nerd-font",
+        "count": "138"
+      }
+    ],
+    "font-hasklig-nerd-font-mono": [
+      {
+        "cask": "font-hasklig-nerd-font-mono",
+        "count": "93"
+      }
+    ],
+    "font-hasklug-nerd-font": [
+      {
+        "cask": "font-hasklug-nerd-font",
+        "count": "44"
+      }
+    ],
+    "font-haskplex": [
+      {
+        "cask": "font-haskplex",
+        "count": "10"
+      }
+    ],
+    "font-haskplex-nerd": [
+      {
+        "cask": "font-haskplex-nerd",
+        "count": "12"
+      }
+    ],
+    "font-headland-one": [
+      {
+        "cask": "font-headland-one",
+        "count": "16"
+      }
+    ],
+    "font-heavydata-nerd-font": [
+      {
+        "cask": "font-heavydata-nerd-font",
+        "count": "86"
+      }
+    ],
+    "font-heavydata-nerd-font-mono": [
+      {
+        "cask": "font-heavydata-nerd-font-mono",
+        "count": "56"
+      }
+    ],
+    "font-henny-penny": [
+      {
+        "cask": "font-henny-penny",
+        "count": "16"
+      }
+    ],
+    "font-hermit": [
+      {
+        "cask": "font-hermit",
+        "count": "7"
+      }
+    ],
+    "font-hermit-nerd-font": [
+      {
+        "cask": "font-hermit-nerd-font",
+        "count": "66"
+      }
+    ],
+    "font-hermit-nerd-font-mono": [
+      {
+        "cask": "font-hermit-nerd-font-mono",
+        "count": "71"
+      }
+    ],
+    "font-herr-von-muellerhoff": [
+      {
+        "cask": "font-herr-von-muellerhoff",
+        "count": "15"
+      }
+    ],
+    "font-hind": [
+      {
+        "cask": "font-hind",
+        "count": "18"
+      }
+    ],
+    "font-holtwood-one-sc": [
+      {
+        "cask": "font-holtwood-one-sc",
+        "count": "16"
+      }
+    ],
+    "font-homemade-apple": [
+      {
+        "cask": "font-homemade-apple",
+        "count": "21"
+      }
+    ],
+    "font-homenaje": [
+      {
+        "cask": "font-homenaje",
+        "count": "14"
+      }
+    ],
+    "font-humor-sans": [
+      {
+        "cask": "font-humor-sans",
+        "count": "23"
+      }
+    ],
+    "font-hurmit-nerd-font": [
+      {
+        "cask": "font-hurmit-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-hyppolit": [
+      {
+        "cask": "font-hyppolit",
+        "count": "15"
+      }
+    ],
+    "font-ia-writer-duo": [
+      {
+        "cask": "font-ia-writer-duo",
+        "count": "51"
+      }
+    ],
+    "font-ia-writer-duospace": [
+      {
+        "cask": "font-ia-writer-duospace",
+        "count": "52"
+      }
+    ],
+    "font-ia-writer-mono": [
+      {
+        "cask": "font-ia-writer-mono",
+        "count": "75"
+      }
+    ],
+    "font-ia-writer-quattro": [
+      {
+        "cask": "font-ia-writer-quattro",
+        "count": "51"
+      }
+    ],
+    "font-ibm-plex": [
+      {
+        "cask": "font-ibm-plex",
+        "count": "415"
+      }
+    ],
+    "font-ibm-plex-nerd-font": [
+      {
+        "cask": "font-ibm-plex-nerd-font",
+        "count": "1"
+      }
+    ],
+    "font-ibmplexmono-nerd-font": [
+      {
+        "cask": "font-ibmplexmono-nerd-font",
+        "count": "27"
+      }
+    ],
+    "font-ibmplexmono-nerd-font-mono": [
+      {
+        "cask": "font-ibmplexmono-nerd-font-mono",
+        "count": "21"
+      }
+    ],
+    "font-iceberg": [
+      {
+        "cask": "font-iceberg",
+        "count": "17"
+      }
+    ],
+    "font-iceland": [
+      {
+        "cask": "font-iceland",
+        "count": "14"
+      }
+    ],
+    "font-icomoon": [
+      {
+        "cask": "font-icomoon",
+        "count": "17"
+      }
+    ],
+    "font-im-fell-types": [
+      {
+        "cask": "font-im-fell-types",
+        "count": "12"
+      }
+    ],
+    "font-impact": [
+      {
+        "cask": "font-impact",
+        "count": "17"
+      }
+    ],
+    "font-imprima": [
+      {
+        "cask": "font-imprima",
+        "count": "14"
+      }
+    ],
+    "font-imwriting-nerd-font": [
+      {
+        "cask": "font-imwriting-nerd-font",
+        "count": "19"
+      }
+    ],
+    "font-inconsolata": [
+      {
+        "cask": "font-inconsolata",
+        "count": "954"
+      }
+    ],
+    "font-inconsolata-dz-for-powerline": [
+      {
+        "cask": "font-inconsolata-dz-for-powerline",
+        "count": "163"
+      }
+    ],
+    "font-inconsolata-for-powerline": [
+      {
+        "cask": "font-inconsolata-for-powerline",
+        "count": "315"
+      }
+    ],
+    "font-inconsolata-for-powerline-bold": [
+      {
+        "cask": "font-inconsolata-for-powerline-bold",
+        "count": "112"
+      }
+    ],
+    "font-inconsolata-g": [
+      {
+        "cask": "font-inconsolata-g",
+        "count": "54"
+      }
+    ],
+    "font-inconsolata-g-for-powerline": [
+      {
+        "cask": "font-inconsolata-g-for-powerline",
+        "count": "156"
+      }
+    ],
+    "font-inconsolata-lgc": [
+      {
+        "cask": "font-inconsolata-lgc",
+        "count": "38"
+      }
+    ],
+    "font-inconsolata-nerd-font": [
+      {
+        "cask": "font-inconsolata-nerd-font",
+        "count": "353"
+      }
+    ],
+    "font-inconsolata-nerd-font-mono": [
+      {
+        "cask": "font-inconsolata-nerd-font-mono",
+        "count": "119"
+      }
+    ],
+    "font-inconsolatago-nerd-font": [
+      {
+        "cask": "font-inconsolatago-nerd-font",
+        "count": "131"
+      }
+    ],
+    "font-inconsolatago-nerd-font-mono": [
+      {
+        "cask": "font-inconsolatago-nerd-font-mono",
+        "count": "64"
+      }
+    ],
+    "font-inconsolatalgc-nerd-font": [
+      {
+        "cask": "font-inconsolatalgc-nerd-font",
+        "count": "104"
+      }
+    ],
+    "font-inconsolatalgc-nerd-font-mono": [
+      {
+        "cask": "font-inconsolatalgc-nerd-font-mono",
+        "count": "59"
+      }
+    ],
+    "font-inder": [
+      {
+        "cask": "font-inder",
+        "count": "10"
+      }
+    ],
+    "font-indie-flower": [
+      {
+        "cask": "font-indie-flower",
+        "count": "17"
+      }
+    ],
+    "font-inika": [
+      {
+        "cask": "font-inika",
+        "count": "13"
+      }
+    ],
+    "font-input": [
+      {
+        "cask": "font-input",
+        "count": "258"
+      }
+    ],
+    "font-input-custom": [
+      {
+        "cask": "font-input-custom",
+        "count": "1"
+      }
+    ],
+    "font-inria": [
+      {
+        "cask": "font-inria",
+        "count": "16"
+      }
+    ],
+    "font-inter": [
+      {
+        "cask": "font-inter",
+        "count": "154"
+      }
+    ],
+    "font-ionicons": [
+      {
+        "cask": "font-ionicons",
+        "count": "41"
+      }
+    ],
+    "font-iosevka": [
+      {
+        "cask": "font-iosevka",
+        "count": "1,267"
+      }
+    ],
+    "font-iosevka-beta": [
+      {
+        "cask": "font-iosevka-beta",
+        "count": "2"
+      }
+    ],
+    "font-iosevka-nerd-font": [
+      {
+        "cask": "font-iosevka-nerd-font",
+        "count": "362"
+      }
+    ],
+    "font-iosevka-nerd-font-mono": [
+      {
+        "cask": "font-iosevka-nerd-font-mono",
+        "count": "160"
+      }
+    ],
+    "font-iosevka-slab": [
+      {
+        "cask": "font-iosevka-slab",
+        "count": "844"
+      }
+    ],
+    "font-iosevka-slab-beta": [
+      {
+        "cask": "font-iosevka-slab-beta",
+        "count": "2"
+      }
+    ],
+    "font-iosevka-sparkle-beta": [
+      {
+        "cask": "font-iosevka-sparkle-beta",
+        "count": "2"
+      }
+    ],
+    "font-ipaexfont": [
+      {
+        "cask": "font-ipaexfont",
+        "count": "26"
+      }
+    ],
+    "font-ipafont": [
+      {
+        "cask": "font-ipafont",
+        "count": "32"
+      }
+    ],
+    "font-ipamjmincho": [
+      {
+        "cask": "font-ipamjmincho",
+        "count": "5"
+      }
+    ],
+    "font-iranian-sans": [
+      {
+        "cask": "font-iranian-sans",
+        "count": "11"
+      }
+    ],
+    "font-iranian-serif": [
+      {
+        "cask": "font-iranian-serif",
+        "count": "11"
+      }
+    ],
+    "font-irish-grover": [
+      {
+        "cask": "font-irish-grover",
+        "count": "11"
+      }
+    ],
+    "font-istok-web": [
+      {
+        "cask": "font-istok-web",
+        "count": "13"
+      }
+    ],
+    "font-italiana": [
+      {
+        "cask": "font-italiana",
+        "count": "11"
+      }
+    ],
+    "font-italianno": [
+      {
+        "cask": "font-italianno",
+        "count": "13"
+      }
+    ],
+    "font-jaapokki": [
+      {
+        "cask": "font-jaapokki",
+        "count": "12"
+      }
+    ],
+    "font-jacques-francois": [
+      {
+        "cask": "font-jacques-francois",
+        "count": "11"
+      }
+    ],
+    "font-jacques-francois-shadow": [
+      {
+        "cask": "font-jacques-francois-shadow",
+        "count": "12"
+      }
+    ],
+    "font-jetbrains-mono": [
+      {
+        "cask": "font-jetbrains-mono",
+        "count": "2,752"
+      }
+    ],
+    "font-jetbrains-mono-nl": [
+      {
+        "cask": "font-jetbrains-mono-nl",
+        "count": "1"
+      }
+    ],
+    "font-jetbrainsmono-nerd-font": [
+      {
+        "cask": "font-jetbrainsmono-nerd-font",
+        "count": "795"
+      }
+    ],
+    "font-jetbrainsmono-nerd-font-mono": [
+      {
+        "cask": "font-jetbrainsmono-nerd-font-mono",
+        "count": "278"
+      }
+    ],
+    "font-jf-open-huninn": [
+      {
+        "cask": "font-jf-open-huninn",
+        "count": "27"
+      }
+    ],
+    "font-jim-nightshade": [
+      {
+        "cask": "font-jim-nightshade",
+        "count": "13"
+      }
+    ],
+    "font-jockey-one": [
+      {
+        "cask": "font-jockey-one",
+        "count": "12"
+      }
+    ],
+    "font-jolly-lodger": [
+      {
+        "cask": "font-jolly-lodger",
+        "count": "12"
+      }
+    ],
+    "font-joscelyn": [
+      {
+        "cask": "font-joscelyn",
+        "count": "6"
+      }
+    ],
+    "font-josefin-sans": [
+      {
+        "cask": "font-josefin-sans",
+        "count": "26"
+      }
+    ],
+    "font-josefin-slab": [
+      {
+        "cask": "font-josefin-slab",
+        "count": "16"
+      }
+    ],
+    "font-joti-one": [
+      {
+        "cask": "font-joti-one",
+        "count": "12"
+      }
+    ],
+    "font-jsmath-cmbx10": [
+      {
+        "cask": "font-jsmath-cmbx10",
+        "count": "14"
+      }
+    ],
+    "font-judson": [
+      {
+        "cask": "font-judson",
+        "count": "11"
+      }
+    ],
+    "font-julee": [
+      {
+        "cask": "font-julee",
+        "count": "12"
+      }
+    ],
+    "font-julius-sans-one": [
+      {
+        "cask": "font-julius-sans-one",
+        "count": "14"
+      }
+    ],
+    "font-junction": [
+      {
+        "cask": "font-junction",
+        "count": "14"
+      }
+    ],
+    "font-junge": [
+      {
+        "cask": "font-junge",
+        "count": "13"
+      }
+    ],
+    "font-junicode": [
+      {
+        "cask": "font-junicode",
+        "count": "19"
+      }
+    ],
+    "font-jura": [
+      {
+        "cask": "font-jura",
+        "count": "14"
+      }
+    ],
+    "font-just-another-hand": [
+      {
+        "cask": "font-just-another-hand",
+        "count": "14"
+      }
+    ],
+    "font-kalam": [
+      {
+        "cask": "font-kalam",
+        "count": "20"
+      }
+    ],
+    "font-kameron": [
+      {
+        "cask": "font-kameron",
+        "count": "14"
+      }
+    ],
+    "font-karla": [
+      {
+        "cask": "font-karla",
+        "count": "25"
+      }
+    ],
+    "font-karma": [
+      {
+        "cask": "font-karma",
+        "count": "14"
+      }
+    ],
+    "font-kaushan-script": [
+      {
+        "cask": "font-kaushan-script",
+        "count": "15"
+      }
+    ],
+    "font-kawkab-mono": [
+      {
+        "cask": "font-kawkab-mono",
+        "count": "20"
+      }
+    ],
+    "font-khmer": [
+      {
+        "cask": "font-khmer",
+        "count": "14"
+      }
+    ],
+    "font-khmer-os-bundle": [
+      {
+        "cask": "font-khmer-os-bundle",
+        "count": "1"
+      }
+    ],
+    "font-khmeros-bundle": [
+      {
+        "cask": "font-khmeros-bundle",
+        "count": "1"
+      }
+    ],
+    "font-kite-one": [
+      {
+        "cask": "font-kite-one",
+        "count": "11"
+      }
+    ],
+    "font-koruri": [
+      {
+        "cask": "font-koruri",
+        "count": "1"
+      }
+    ],
+    "font-kranky": [
+      {
+        "cask": "font-kranky",
+        "count": "13"
+      }
+    ],
+    "font-kreon": [
+      {
+        "cask": "font-kreon",
+        "count": "13"
+      }
+    ],
+    "font-kristi": [
+      {
+        "cask": "font-kristi",
+        "count": "12"
+      }
+    ],
+    "font-krona-one": [
+      {
+        "cask": "font-krona-one",
+        "count": "15"
+      }
+    ],
+    "font-la-belle-aurore": [
+      {
+        "cask": "font-la-belle-aurore",
+        "count": "13"
+      }
+    ],
+    "font-laila": [
+      {
+        "cask": "font-laila",
+        "count": "14"
+      }
+    ],
+    "font-lancelot": [
+      {
+        "cask": "font-lancelot",
+        "count": "14"
+      }
+    ],
+    "font-langdon": [
+      {
+        "cask": "font-langdon",
+        "count": "12"
+      }
+    ],
+    "font-latin-modern": [
+      {
+        "cask": "font-latin-modern",
+        "count": "35"
+      }
+    ],
+    "font-latin-modern-math": [
+      {
+        "cask": "font-latin-modern-math",
+        "count": "27"
+      }
+    ],
+    "font-lato": [
+      {
+        "cask": "font-lato",
+        "count": "306"
+      }
+    ],
+    "font-league-gothic": [
+      {
+        "cask": "font-league-gothic",
+        "count": "29"
+      }
+    ],
+    "font-league-spartan": [
+      {
+        "cask": "font-league-spartan",
+        "count": "24"
+      }
+    ],
+    "font-leckerli-one": [
+      {
+        "cask": "font-leckerli-one",
+        "count": "13"
+      }
+    ],
+    "font-ledger": [
+      {
+        "cask": "font-ledger",
+        "count": "13"
+      }
+    ],
+    "font-lekton": [
+      {
+        "cask": "font-lekton",
+        "count": "15"
+      }
+    ],
+    "font-lekton-nerd-font": [
+      {
+        "cask": "font-lekton-nerd-font",
+        "count": "86"
+      }
+    ],
+    "font-lekton-nerd-font-mono": [
+      {
+        "cask": "font-lekton-nerd-font-mono",
+        "count": "50"
+      }
+    ],
+    "font-lemon": [
+      {
+        "cask": "font-lemon",
+        "count": "12"
+      }
+    ],
+    "font-lexend-deca": [
+      {
+        "cask": "font-lexend-deca",
+        "count": "4"
+      }
+    ],
+    "font-liberation-mono-for-powerline": [
+      {
+        "cask": "font-liberation-mono-for-powerline",
+        "count": "150"
+      }
+    ],
+    "font-liberation-nerd-font": [
+      {
+        "cask": "font-liberation-nerd-font",
+        "count": "26"
+      }
+    ],
+    "font-liberation-sans": [
+      {
+        "cask": "font-liberation-sans",
+        "count": "74"
+      }
+    ],
+    "font-liberationmono-nerd-font": [
+      {
+        "cask": "font-liberationmono-nerd-font",
+        "count": "69"
+      }
+    ],
+    "font-liberationmono-nerd-font-mono": [
+      {
+        "cask": "font-liberationmono-nerd-font-mono",
+        "count": "60"
+      }
+    ],
+    "font-libertinus": [
+      {
+        "cask": "font-libertinus",
+        "count": "35"
+      }
+    ],
+    "font-libre-baskerville": [
+      {
+        "cask": "font-libre-baskerville",
+        "count": "31"
+      }
+    ],
+    "font-libre-caslon-display": [
+      {
+        "cask": "font-libre-caslon-display",
+        "count": "14"
+      }
+    ],
+    "font-libre-caslon-text": [
+      {
+        "cask": "font-libre-caslon-text",
+        "count": "14"
+      }
+    ],
+    "font-libre-franklin": [
+      {
+        "cask": "font-libre-franklin",
+        "count": "27"
+      }
+    ],
+    "font-life-savers": [
+      {
+        "cask": "font-life-savers",
+        "count": "10"
+      }
+    ],
+    "font-ligature-symbols": [
+      {
+        "cask": "font-ligature-symbols",
+        "count": "11"
+      }
+    ],
+    "font-lilex": [
+      {
+        "cask": "font-lilex",
+        "count": "9"
+      }
+    ],
+    "font-lilita-one": [
+      {
+        "cask": "font-lilita-one",
+        "count": "10"
+      }
+    ],
+    "font-limelight": [
+      {
+        "cask": "font-limelight",
+        "count": "11"
+      }
+    ],
+    "font-linden-hill": [
+      {
+        "cask": "font-linden-hill",
+        "count": "19"
+      }
+    ],
+    "font-linux-biolinum": [
+      {
+        "cask": "font-linux-biolinum",
+        "count": "20"
+      }
+    ],
+    "font-linux-libertine": [
+      {
+        "cask": "font-linux-libertine",
+        "count": "56"
+      }
+    ],
+    "font-lobster": [
+      {
+        "cask": "font-lobster",
+        "count": "25"
+      }
+    ],
+    "font-lobster-two": [
+      {
+        "cask": "font-lobster-two",
+        "count": "17"
+      }
+    ],
+    "font-londrina-outline": [
+      {
+        "cask": "font-londrina-outline",
+        "count": "12"
+      }
+    ],
+    "font-londrina-shadow": [
+      {
+        "cask": "font-londrina-shadow",
+        "count": "10"
+      }
+    ],
+    "font-londrina-sketch": [
+      {
+        "cask": "font-londrina-sketch",
+        "count": "11"
+      }
+    ],
+    "font-londrina-solid": [
+      {
+        "cask": "font-londrina-solid",
+        "count": "10"
+      }
+    ],
+    "font-lora": [
+      {
+        "cask": "font-lora",
+        "count": "36"
+      }
+    ],
+    "font-love-ya-like-a-sister": [
+      {
+        "cask": "font-love-ya-like-a-sister",
+        "count": "10"
+      }
+    ],
+    "font-loved-by-the-king": [
+      {
+        "cask": "font-loved-by-the-king",
+        "count": "10"
+      }
+    ],
+    "font-lovers-quarrel": [
+      {
+        "cask": "font-lovers-quarrel",
+        "count": "12"
+      }
+    ],
+    "font-luckiest-guy": [
+      {
+        "cask": "font-luckiest-guy",
+        "count": "11"
+      }
+    ],
+    "font-luculent": [
+      {
+        "cask": "font-luculent",
+        "count": "10"
+      }
+    ],
+    "font-lusitana": [
+      {
+        "cask": "font-lusitana",
+        "count": "10"
+      }
+    ],
+    "font-lustria": [
+      {
+        "cask": "font-lustria",
+        "count": "11"
+      }
+    ],
+    "font-m-plus": [
+      {
+        "cask": "font-m-plus",
+        "count": "66"
+      }
+    ],
+    "font-macondo": [
+      {
+        "cask": "font-macondo",
+        "count": "10"
+      }
+    ],
+    "font-macondo-swash-caps": [
+      {
+        "cask": "font-macondo-swash-caps",
+        "count": "9"
+      }
+    ],
+    "font-magra": [
+      {
+        "cask": "font-magra",
+        "count": "9"
+      }
+    ],
+    "font-maiden-orange": [
+      {
+        "cask": "font-maiden-orange",
+        "count": "10"
+      }
+    ],
+    "font-mako": [
+      {
+        "cask": "font-mako",
+        "count": "11"
+      }
+    ],
+    "font-marcellus": [
+      {
+        "cask": "font-marcellus",
+        "count": "9"
+      }
+    ],
+    "font-marcellus-sc": [
+      {
+        "cask": "font-marcellus-sc",
+        "count": "10"
+      }
+    ],
+    "font-marck-script": [
+      {
+        "cask": "font-marck-script",
+        "count": "10"
+      }
+    ],
+    "font-margarine": [
+      {
+        "cask": "font-margarine",
+        "count": "8"
+      }
+    ],
+    "font-marko-one": [
+      {
+        "cask": "font-marko-one",
+        "count": "8"
+      }
+    ],
+    "font-marmelad": [
+      {
+        "cask": "font-marmelad",
+        "count": "9"
+      }
+    ],
+    "font-marvel": [
+      {
+        "cask": "font-marvel",
+        "count": "12"
+      }
+    ],
+    "font-masinahikan": [
+      {
+        "cask": "font-masinahikan",
+        "count": "8"
+      }
+    ],
+    "font-masinahikan-dene": [
+      {
+        "cask": "font-masinahikan-dene",
+        "count": "8"
+      }
+    ],
+    "font-mate": [
+      {
+        "cask": "font-mate",
+        "count": "9"
+      }
+    ],
+    "font-mate-sc": [
+      {
+        "cask": "font-mate-sc",
+        "count": "9"
+      }
+    ],
+    "font-material-icons": [
+      {
+        "cask": "font-material-icons",
+        "count": "63"
+      }
+    ],
+    "font-materialdesignicons-webfont": [
+      {
+        "cask": "font-materialdesignicons-webfont",
+        "count": "20"
+      }
+    ],
+    "font-maven-pro": [
+      {
+        "cask": "font-maven-pro",
+        "count": "12"
+      }
+    ],
+    "font-mclaren": [
+      {
+        "cask": "font-mclaren",
+        "count": "10"
+      }
+    ],
+    "font-meddon": [
+      {
+        "cask": "font-meddon",
+        "count": "10"
+      }
+    ],
+    "font-medievalsharp": [
+      {
+        "cask": "font-medievalsharp",
+        "count": "11"
+      }
+    ],
+    "font-medula-one": [
+      {
+        "cask": "font-medula-one",
+        "count": "9"
+      }
+    ],
+    "font-megrim": [
+      {
+        "cask": "font-megrim",
+        "count": "8"
+      }
+    ],
+    "font-meie-script": [
+      {
+        "cask": "font-meie-script",
+        "count": "8"
+      }
+    ],
+    "font-meltho": [
+      {
+        "cask": "font-meltho",
+        "count": "9"
+      }
+    ],
+    "font-menlo-for-powerline": [
+      {
+        "cask": "font-menlo-for-powerline",
+        "count": "516"
+      }
+    ],
+    "font-merienda": [
+      {
+        "cask": "font-merienda",
+        "count": "9"
+      }
+    ],
+    "font-merienda-one": [
+      {
+        "cask": "font-merienda-one",
+        "count": "7"
+      }
+    ],
+    "font-merriweather": [
+      {
+        "cask": "font-merriweather",
+        "count": "56"
+      }
+    ],
+    "font-merriweather-sans": [
+      {
+        "cask": "font-merriweather-sans",
+        "count": "19"
+      }
+    ],
+    "font-meslo-for-powerline": [
+      {
+        "cask": "font-meslo-for-powerline",
+        "count": "467"
+      }
+    ],
+    "font-meslo-lg": [
+      {
+        "cask": "font-meslo-lg",
+        "count": "124"
+      }
+    ],
+    "font-meslo-lgs-nf-bold": [
+      {
+        "cask": "font-meslo-lgs-nf-bold",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-bold-italic": [
+      {
+        "cask": "font-meslo-lgs-nf-bold-italic",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-italic": [
+      {
+        "cask": "font-meslo-lgs-nf-italic",
+        "count": "1"
+      }
+    ],
+    "font-meslo-lgs-nf-regular": [
+      {
+        "cask": "font-meslo-lgs-nf-regular",
+        "count": "1"
+      }
+    ],
+    "font-meslo-nerd-font": [
+      {
+        "cask": "font-meslo-nerd-font",
+        "count": "687"
+      }
+    ],
+    "font-meslo-nerd-font-mono": [
+      {
+        "cask": "font-meslo-nerd-font-mono",
+        "count": "218"
+      }
+    ],
+    "font-meslo-nerd-font-patched": [
+      {
+        "cask": "font-meslo-nerd-font-patched",
+        "count": "5"
+      }
+    ],
+    "font-meslolg-nerd-font": [
+      {
+        "cask": "font-meslolg-nerd-font",
+        "count": "167"
+      }
+    ],
+    "font-metal": [
+      {
+        "cask": "font-metal",
+        "count": "8"
+      }
+    ],
+    "font-metal-mania": [
+      {
+        "cask": "font-metal-mania",
+        "count": "9"
+      }
+    ],
+    "font-metamorphous": [
+      {
+        "cask": "font-metamorphous",
+        "count": "8"
+      }
+    ],
+    "font-metrophobic": [
+      {
+        "cask": "font-metrophobic",
+        "count": "8"
+      }
+    ],
+    "font-metropolis": [
+      {
+        "cask": "font-metropolis",
+        "count": "28"
+      }
+    ],
+    "font-miao-unicode": [
+      {
+        "cask": "font-miao-unicode",
+        "count": "7"
+      }
+    ],
+    "font-michroma": [
+      {
+        "cask": "font-michroma",
+        "count": "7"
+      }
+    ],
+    "font-microsoft-cleartype-family": [
+      {
+        "cask": "font-microsoft-cleartype-family",
+        "count": "2"
+      }
+    ],
+    "font-microsoft-office": [
+      {
+        "cask": "font-microsoft-office",
+        "count": "96"
+      }
+    ],
+    "font-migmix-1m": [
+      {
+        "cask": "font-migmix-1m",
+        "count": "14"
+      }
+    ],
+    "font-migmix-1p": [
+      {
+        "cask": "font-migmix-1p",
+        "count": "40"
+      }
+    ],
+    "font-migmix-2m": [
+      {
+        "cask": "font-migmix-2m",
+        "count": "13"
+      }
+    ],
+    "font-migmix-2p": [
+      {
+        "cask": "font-migmix-2p",
+        "count": "11"
+      }
+    ],
+    "font-migu-1c": [
+      {
+        "cask": "font-migu-1c",
+        "count": "15"
+      }
+    ],
+    "font-migu-1m": [
+      {
+        "cask": "font-migu-1m",
+        "count": "58"
+      }
+    ],
+    "font-migu-1p": [
+      {
+        "cask": "font-migu-1p",
+        "count": "16"
+      }
+    ],
+    "font-migu-2m": [
+      {
+        "cask": "font-migu-2m",
+        "count": "21"
+      }
+    ],
+    "font-milonga": [
+      {
+        "cask": "font-milonga",
+        "count": "10"
+      }
+    ],
+    "font-miltonian": [
+      {
+        "cask": "font-miltonian",
+        "count": "9"
+      }
+    ],
+    "font-miltonian-tattoo": [
+      {
+        "cask": "font-miltonian-tattoo",
+        "count": "9"
+      }
+    ],
+    "font-miniver": [
+      {
+        "cask": "font-miniver",
+        "count": "8"
+      }
+    ],
+    "font-miriam-mono-clm": [
+      {
+        "cask": "font-miriam-mono-clm",
+        "count": "15"
+      }
+    ],
+    "font-miss-fajardose": [
+      {
+        "cask": "font-miss-fajardose",
+        "count": "7"
+      }
+    ],
+    "font-modern-antiqua": [
+      {
+        "cask": "font-modern-antiqua",
+        "count": "8"
+      }
+    ],
+    "font-molle": [
+      {
+        "cask": "font-molle",
+        "count": "7"
+      }
+    ],
+    "font-monda": [
+      {
+        "cask": "font-monda",
+        "count": "6"
+      }
+    ],
+    "font-monofur-for-powerline": [
+      {
+        "cask": "font-monofur-for-powerline",
+        "count": "119"
+      }
+    ],
+    "font-monofur-nerd-font": [
+      {
+        "cask": "font-monofur-nerd-font",
+        "count": "123"
+      }
+    ],
+    "font-monofur-nerd-font-mono": [
+      {
+        "cask": "font-monofur-nerd-font-mono",
+        "count": "64"
+      }
+    ],
+    "font-monoid": [
+      {
+        "cask": "font-monoid",
+        "count": "164"
+      }
+    ],
+    "font-monoid-halfloose-large": [
+      {
+        "cask": "font-monoid-halfloose-large",
+        "count": "1"
+      }
+    ],
+    "font-monoid-halftight-large-dollar": [
+      {
+        "cask": "font-monoid-halftight-large-dollar",
+        "count": "1"
+      }
+    ],
+    "font-monoid-large": [
+      {
+        "cask": "font-monoid-large",
+        "count": "1"
+      }
+    ],
+    "font-monoid-large-dollar": [
+      {
+        "cask": "font-monoid-large-dollar",
+        "count": "1"
+      }
+    ],
+    "font-monoid-nerd-font": [
+      {
+        "cask": "font-monoid-nerd-font",
+        "count": "214"
+      }
+    ],
+    "font-monoid-nerd-font-mono": [
+      {
+        "cask": "font-monoid-nerd-font-mono",
+        "count": "78"
+      }
+    ],
+    "font-monoisome": [
+      {
+        "cask": "font-monoisome",
+        "count": "22"
+      }
+    ],
+    "font-mononoki": [
+      {
+        "cask": "font-mononoki",
+        "count": "77"
+      }
+    ],
+    "font-mononoki-nerd-font": [
+      {
+        "cask": "font-mononoki-nerd-font",
+        "count": "203"
+      }
+    ],
+    "font-mononoki-nerd-font-mono": [
+      {
+        "cask": "font-mononoki-nerd-font-mono",
+        "count": "87"
+      }
+    ],
+    "font-monoton": [
+      {
+        "cask": "font-monoton",
+        "count": "14"
+      }
+    ],
+    "font-monsieur-la-doulaise": [
+      {
+        "cask": "font-monsieur-la-doulaise",
+        "count": "7"
+      }
+    ],
+    "font-montaga": [
+      {
+        "cask": "font-montaga",
+        "count": "7"
+      }
+    ],
+    "font-montez": [
+      {
+        "cask": "font-montez",
+        "count": "7"
+      }
+    ],
+    "font-montserrat": [
+      {
+        "cask": "font-montserrat",
+        "count": "157"
+      }
+    ],
+    "font-montserrat-subrayada": [
+      {
+        "cask": "font-montserrat-subrayada",
+        "count": "11"
+      }
+    ],
+    "font-moul": [
+      {
+        "cask": "font-moul",
+        "count": "6"
+      }
+    ],
+    "font-mountains-of-christmas": [
+      {
+        "cask": "font-mountains-of-christmas",
+        "count": "7"
+      }
+    ],
+    "font-mouse-memoirs": [
+      {
+        "cask": "font-mouse-memoirs",
+        "count": "7"
+      }
+    ],
+    "font-mplus-1mn-nerd-font-mono": [
+      {
+        "cask": "font-mplus-1mn-nerd-font-mono",
+        "count": "7"
+      }
+    ],
+    "font-mplus-1mn-nerd-mono": [
+      {
+        "cask": "font-mplus-1mn-nerd-mono",
+        "count": "32"
+      }
+    ],
+    "font-mplus-nerd-font": [
+      {
+        "cask": "font-mplus-nerd-font",
+        "count": "101"
+      }
+    ],
+    "font-mplus-nerd-font-mono": [
+      {
+        "cask": "font-mplus-nerd-font-mono",
+        "count": "63"
+      }
+    ],
+    "font-mr-bedfort": [
+      {
+        "cask": "font-mr-bedfort",
+        "count": "7"
+      }
+    ],
+    "font-mr-dafoe": [
+      {
+        "cask": "font-mr-dafoe",
+        "count": "5"
+      }
+    ],
+    "font-mrs-saint-delafield": [
+      {
+        "cask": "font-mrs-saint-delafield",
+        "count": "6"
+      }
+    ],
+    "font-mrs-sheppards": [
+      {
+        "cask": "font-mrs-sheppards",
+        "count": "5"
+      }
+    ],
+    "font-mukti-narrow": [
+      {
+        "cask": "font-mukti-narrow",
+        "count": "5"
+      }
+    ],
+    "font-muli": [
+      {
+        "cask": "font-muli",
+        "count": "19"
+      }
+    ],
+    "font-museo": [
+      {
+        "cask": "font-museo",
+        "count": "11"
+      }
+    ],
+    "font-myrica": [
+      {
+        "cask": "font-myrica",
+        "count": "92"
+      }
+    ],
+    "font-myricam": [
+      {
+        "cask": "font-myricam",
+        "count": "61"
+      }
+    ],
+    "font-mystery-quest": [
+      {
+        "cask": "font-mystery-quest",
+        "count": "9"
+      }
+    ],
+    "font-n-gage": [
+      {
+        "cask": "font-n-gage",
+        "count": "7"
+      }
+    ],
+    "font-nanumgothic": [
+      {
+        "cask": "font-nanumgothic",
+        "count": "34"
+      }
+    ],
+    "font-nanumgothiccoding": [
+      {
+        "cask": "font-nanumgothiccoding",
+        "count": "26"
+      }
+    ],
+    "font-nanummyeongjo": [
+      {
+        "cask": "font-nanummyeongjo",
+        "count": "20"
+      }
+    ],
+    "font-nanumsquare": [
+      {
+        "cask": "font-nanumsquare",
+        "count": "1"
+      }
+    ],
+    "font-nanumsquare-round": [
+      {
+        "cask": "font-nanumsquare-round",
+        "count": "1"
+      }
+    ],
+    "font-national-park": [
+      {
+        "cask": "font-national-park",
+        "count": "19"
+      }
+    ],
+    "font-neodunggeunmo": [
+      {
+        "cask": "font-neodunggeunmo",
+        "count": "12"
+      }
+    ],
+    "font-neodunggeunmo-code": [
+      {
+        "cask": "font-neodunggeunmo-code",
+        "count": "15"
+      }
+    ],
+    "font-neucha": [
+      {
+        "cask": "font-neucha",
+        "count": "9"
+      }
+    ],
+    "font-neuton": [
+      {
+        "cask": "font-neuton",
+        "count": "8"
+      }
+    ],
+    "font-new-rocker": [
+      {
+        "cask": "font-new-rocker",
+        "count": "7"
+      }
+    ],
+    "font-new-york": [
+      {
+        "cask": "font-new-york",
+        "count": "5"
+      }
+    ],
+    "font-news-cycle": [
+      {
+        "cask": "font-news-cycle",
+        "count": "9"
+      }
+    ],
+    "font-niconne": [
+      {
+        "cask": "font-niconne",
+        "count": "8"
+      }
+    ],
+    "font-nimbus-sans-l": [
+      {
+        "cask": "font-nimbus-sans-l",
+        "count": "14"
+      }
+    ],
+    "font-nixie-one": [
+      {
+        "cask": "font-nixie-one",
+        "count": "28"
+      }
+    ],
+    "font-nobile": [
+      {
+        "cask": "font-nobile",
+        "count": "8"
+      }
+    ],
+    "font-nokora": [
+      {
+        "cask": "font-nokora",
+        "count": "8"
+      }
+    ],
+    "font-norican": [
+      {
+        "cask": "font-norican",
+        "count": "8"
+      }
+    ],
+    "font-nosifer": [
+      {
+        "cask": "font-nosifer",
+        "count": "8"
+      }
+    ],
+    "font-nothing-you-could-do": [
+      {
+        "cask": "font-nothing-you-could-do",
+        "count": "8"
+      }
+    ],
+    "font-noticia-text": [
+      {
+        "cask": "font-noticia-text",
+        "count": "7"
+      }
+    ],
+    "font-noto-color-emoji": [
+      {
+        "cask": "font-noto-color-emoji",
+        "count": "65"
+      }
+    ],
+    "font-noto-emoji": [
+      {
+        "cask": "font-noto-emoji",
+        "count": "48"
+      }
+    ],
+    "font-noto-kufi-arabic": [
+      {
+        "cask": "font-noto-kufi-arabic",
+        "count": "8"
+      }
+    ],
+    "font-noto-mono": [
+      {
+        "cask": "font-noto-mono",
+        "count": "97"
+      }
+    ],
+    "font-noto-mono-for-powerline": [
+      {
+        "cask": "font-noto-mono-for-powerline",
+        "count": "176"
+      }
+    ],
+    "font-noto-naskh-arabic": [
+      {
+        "cask": "font-noto-naskh-arabic",
+        "count": "8"
+      }
+    ],
+    "font-noto-nastaliq-urdu": [
+      {
+        "cask": "font-noto-nastaliq-urdu",
+        "count": "9"
+      }
+    ],
+    "font-noto-nerd-font": [
+      {
+        "cask": "font-noto-nerd-font",
+        "count": "116"
+      }
+    ],
+    "font-noto-nerd-font-mono": [
+      {
+        "cask": "font-noto-nerd-font-mono",
+        "count": "64"
+      }
+    ],
+    "font-noto-sans": [
+      {
+        "cask": "font-noto-sans",
+        "count": "171"
+      }
+    ],
+    "font-noto-sans-adlam": [
+      {
+        "cask": "font-noto-sans-adlam",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-adlam-unjoined": [
+      {
+        "cask": "font-noto-sans-adlam-unjoined",
+        "count": "9"
+      }
+    ],
+    "font-noto-sans-anatolian-hieroglyphs": [
+      {
+        "cask": "font-noto-sans-anatolian-hieroglyphs",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-arabic": [
+      {
+        "cask": "font-noto-sans-arabic",
+        "count": "10"
+      }
+    ],
+    "font-noto-sans-armenian": [
+      {
+        "cask": "font-noto-sans-armenian",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-avestan": [
+      {
+        "cask": "font-noto-sans-avestan",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-balinese": [
+      {
+        "cask": "font-noto-sans-balinese",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-bamum": [
+      {
+        "cask": "font-noto-sans-bamum",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-batak": [
+      {
+        "cask": "font-noto-sans-batak",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-bengali": [
+      {
+        "cask": "font-noto-sans-bengali",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-brahmi": [
+      {
+        "cask": "font-noto-sans-brahmi",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-buginese": [
+      {
+        "cask": "font-noto-sans-buginese",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-buhid": [
+      {
+        "cask": "font-noto-sans-buhid",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-canadian-aboriginal": [
+      {
+        "cask": "font-noto-sans-canadian-aboriginal",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-carian": [
+      {
+        "cask": "font-noto-sans-carian",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-chakma": [
+      {
+        "cask": "font-noto-sans-chakma",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-cham": [
+      {
+        "cask": "font-noto-sans-cham",
+        "count": "15"
+      }
+    ],
+    "font-noto-sans-cherokee": [
+      {
+        "cask": "font-noto-sans-cherokee",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-cjk": [
+      {
+        "cask": "font-noto-sans-cjk",
+        "count": "95"
+      }
+    ],
+    "font-noto-sans-cjk-jp": [
+      {
+        "cask": "font-noto-sans-cjk-jp",
+        "count": "201"
+      }
+    ],
+    "font-noto-sans-cjk-kr": [
+      {
+        "cask": "font-noto-sans-cjk-kr",
+        "count": "19"
+      }
+    ],
+    "font-noto-sans-cjk-sc": [
+      {
+        "cask": "font-noto-sans-cjk-sc",
+        "count": "24"
+      }
+    ],
+    "font-noto-sans-cjk-tc": [
+      {
+        "cask": "font-noto-sans-cjk-tc",
+        "count": "44"
+      }
+    ],
+    "font-noto-sans-coptic": [
+      {
+        "cask": "font-noto-sans-coptic",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-cuneiform": [
+      {
+        "cask": "font-noto-sans-cuneiform",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-cypriot": [
+      {
+        "cask": "font-noto-sans-cypriot",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-deseret": [
+      {
+        "cask": "font-noto-sans-deseret",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-devanagari": [
+      {
+        "cask": "font-noto-sans-devanagari",
+        "count": "14"
+      }
+    ],
+    "font-noto-sans-display": [
+      {
+        "cask": "font-noto-sans-display",
+        "count": "18"
+      }
+    ],
+    "font-noto-sans-egyptian-hieroglyphs": [
+      {
+        "cask": "font-noto-sans-egyptian-hieroglyphs",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-ethiopic": [
+      {
+        "cask": "font-noto-sans-ethiopic",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-georgian": [
+      {
+        "cask": "font-noto-sans-georgian",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-glagolitic": [
+      {
+        "cask": "font-noto-sans-glagolitic",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-gothic": [
+      {
+        "cask": "font-noto-sans-gothic",
+        "count": "16"
+      }
+    ],
+    "font-noto-sans-gujarati": [
+      {
+        "cask": "font-noto-sans-gujarati",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-gurmukhi": [
+      {
+        "cask": "font-noto-sans-gurmukhi",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-hanunoo": [
+      {
+        "cask": "font-noto-sans-hanunoo",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-hebrew": [
+      {
+        "cask": "font-noto-sans-hebrew",
+        "count": "12"
+      }
+    ],
+    "font-noto-sans-imperial-aramaic": [
+      {
+        "cask": "font-noto-sans-imperial-aramaic",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-inscriptional-pahlavi": [
+      {
+        "cask": "font-noto-sans-inscriptional-pahlavi",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-inscriptional-parthian": [
+      {
+        "cask": "font-noto-sans-inscriptional-parthian",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-javanese": [
+      {
+        "cask": "font-noto-sans-javanese",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-kaithi": [
+      {
+        "cask": "font-noto-sans-kaithi",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-kannada": [
+      {
+        "cask": "font-noto-sans-kannada",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-kayah-li": [
+      {
+        "cask": "font-noto-sans-kayah-li",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-kharoshthi": [
+      {
+        "cask": "font-noto-sans-kharoshthi",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-khmer": [
+      {
+        "cask": "font-noto-sans-khmer",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-lao": [
+      {
+        "cask": "font-noto-sans-lao",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-lepcha": [
+      {
+        "cask": "font-noto-sans-lepcha",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-limbu": [
+      {
+        "cask": "font-noto-sans-limbu",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-linear-b": [
+      {
+        "cask": "font-noto-sans-linear-b",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-lisu": [
+      {
+        "cask": "font-noto-sans-lisu",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-lycian": [
+      {
+        "cask": "font-noto-sans-lycian",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-lydian": [
+      {
+        "cask": "font-noto-sans-lydian",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-malayalam": [
+      {
+        "cask": "font-noto-sans-malayalam",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-mandaic": [
+      {
+        "cask": "font-noto-sans-mandaic",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-meetei-mayek": [
+      {
+        "cask": "font-noto-sans-meetei-mayek",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-mongolian": [
+      {
+        "cask": "font-noto-sans-mongolian",
+        "count": "6"
+      }
+    ],
+    "font-noto-sans-mono": [
+      {
+        "cask": "font-noto-sans-mono",
+        "count": "71"
+      }
+    ],
+    "font-noto-sans-myanmar": [
+      {
+        "cask": "font-noto-sans-myanmar",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-n-ko": [
+      {
+        "cask": "font-noto-sans-n-ko",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-new-tai-lue": [
+      {
+        "cask": "font-noto-sans-new-tai-lue",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-ogham": [
+      {
+        "cask": "font-noto-sans-ogham",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-ol-chiki": [
+      {
+        "cask": "font-noto-sans-ol-chiki",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-old-italic": [
+      {
+        "cask": "font-noto-sans-old-italic",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-old-persian": [
+      {
+        "cask": "font-noto-sans-old-persian",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-old-south-arabian": [
+      {
+        "cask": "font-noto-sans-old-south-arabian",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-old-turkic": [
+      {
+        "cask": "font-noto-sans-old-turkic",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-oriya": [
+      {
+        "cask": "font-noto-sans-oriya",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-osage": [
+      {
+        "cask": "font-noto-sans-osage",
+        "count": "9"
+      }
+    ],
+    "font-noto-sans-osmanya": [
+      {
+        "cask": "font-noto-sans-osmanya",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-phags-pa": [
+      {
+        "cask": "font-noto-sans-phags-pa",
+        "count": "9"
+      }
+    ],
+    "font-noto-sans-phoenician": [
+      {
+        "cask": "font-noto-sans-phoenician",
+        "count": "9"
+      }
+    ],
+    "font-noto-sans-rejang": [
+      {
+        "cask": "font-noto-sans-rejang",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-runic": [
+      {
+        "cask": "font-noto-sans-runic",
+        "count": "7"
+      }
+    ],
+    "font-noto-sans-samaritan": [
+      {
+        "cask": "font-noto-sans-samaritan",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-saurashtra": [
+      {
+        "cask": "font-noto-sans-saurashtra",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-shavian": [
+      {
+        "cask": "font-noto-sans-shavian",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-sinhala": [
+      {
+        "cask": "font-noto-sans-sinhala",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-sundanese": [
+      {
+        "cask": "font-noto-sans-sundanese",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-syloti-nagri": [
+      {
+        "cask": "font-noto-sans-syloti-nagri",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-symbols": [
+      {
+        "cask": "font-noto-sans-symbols",
+        "count": "19"
+      }
+    ],
+    "font-noto-sans-symbols2": [
+      {
+        "cask": "font-noto-sans-symbols2",
+        "count": "18"
+      }
+    ],
+    "font-noto-sans-syriac-eastern": [
+      {
+        "cask": "font-noto-sans-syriac-eastern",
+        "count": "9"
+      }
+    ],
+    "font-noto-sans-syriac-estrangela": [
+      {
+        "cask": "font-noto-sans-syriac-estrangela",
+        "count": "10"
+      }
+    ],
+    "font-noto-sans-syriac-western": [
+      {
+        "cask": "font-noto-sans-syriac-western",
+        "count": "10"
+      }
+    ],
+    "font-noto-sans-tagalog": [
+      {
+        "cask": "font-noto-sans-tagalog",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-tagbanwa": [
+      {
+        "cask": "font-noto-sans-tagbanwa",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-tai-le": [
+      {
+        "cask": "font-noto-sans-tai-le",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-tai-tham": [
+      {
+        "cask": "font-noto-sans-tai-tham",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-tai-viet": [
+      {
+        "cask": "font-noto-sans-tai-viet",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-tamil": [
+      {
+        "cask": "font-noto-sans-tamil",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-telugu": [
+      {
+        "cask": "font-noto-sans-telugu",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-thaana": [
+      {
+        "cask": "font-noto-sans-thaana",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-thai": [
+      {
+        "cask": "font-noto-sans-thai",
+        "count": "15"
+      }
+    ],
+    "font-noto-sans-tibetan": [
+      {
+        "cask": "font-noto-sans-tibetan",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-tifinagh": [
+      {
+        "cask": "font-noto-sans-tifinagh",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-ugaritic": [
+      {
+        "cask": "font-noto-sans-ugaritic",
+        "count": "9"
+      }
+    ],
+    "font-noto-sans-vai": [
+      {
+        "cask": "font-noto-sans-vai",
+        "count": "8"
+      }
+    ],
+    "font-noto-sans-yi": [
+      {
+        "cask": "font-noto-sans-yi",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif": [
+      {
+        "cask": "font-noto-serif",
+        "count": "79"
+      }
+    ],
+    "font-noto-serif-armenian": [
+      {
+        "cask": "font-noto-serif-armenian",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif-bengali": [
+      {
+        "cask": "font-noto-serif-bengali",
+        "count": "10"
+      }
+    ],
+    "font-noto-serif-cjk": [
+      {
+        "cask": "font-noto-serif-cjk",
+        "count": "67"
+      }
+    ],
+    "font-noto-serif-cjk-jp": [
+      {
+        "cask": "font-noto-serif-cjk-jp",
+        "count": "146"
+      }
+    ],
+    "font-noto-serif-cjk-kr": [
+      {
+        "cask": "font-noto-serif-cjk-kr",
+        "count": "12"
+      }
+    ],
+    "font-noto-serif-cjk-sc": [
+      {
+        "cask": "font-noto-serif-cjk-sc",
+        "count": "17"
+      }
+    ],
+    "font-noto-serif-cjk-tc": [
+      {
+        "cask": "font-noto-serif-cjk-tc",
+        "count": "42"
+      }
+    ],
+    "font-noto-serif-devanagari": [
+      {
+        "cask": "font-noto-serif-devanagari",
+        "count": "17"
+      }
+    ],
+    "font-noto-serif-display": [
+      {
+        "cask": "font-noto-serif-display",
+        "count": "14"
+      }
+    ],
+    "font-noto-serif-ethiopic": [
+      {
+        "cask": "font-noto-serif-ethiopic",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif-gujarati": [
+      {
+        "cask": "font-noto-serif-gujarati",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif-hebrew": [
+      {
+        "cask": "font-noto-serif-hebrew",
+        "count": "11"
+      }
+    ],
+    "font-noto-serif-kannada": [
+      {
+        "cask": "font-noto-serif-kannada",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif-khmer": [
+      {
+        "cask": "font-noto-serif-khmer",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif-lao": [
+      {
+        "cask": "font-noto-serif-lao",
+        "count": "9"
+      }
+    ],
+    "font-noto-serif-malayalam": [
+      {
+        "cask": "font-noto-serif-malayalam",
+        "count": "10"
+      }
+    ],
+    "font-noto-serif-myanmar": [
+      {
+        "cask": "font-noto-serif-myanmar",
+        "count": "10"
+      }
+    ],
+    "font-noto-serif-sinhala": [
+      {
+        "cask": "font-noto-serif-sinhala",
+        "count": "10"
+      }
+    ],
+    "font-noto-serif-tamil": [
+      {
+        "cask": "font-noto-serif-tamil",
+        "count": "11"
+      }
+    ],
+    "font-noto-serif-telugu": [
+      {
+        "cask": "font-noto-serif-telugu",
+        "count": "10"
+      }
+    ],
+    "font-noto-serif-thai": [
+      {
+        "cask": "font-noto-serif-thai",
+        "count": "16"
+      }
+    ],
+    "font-nova-cut": [
+      {
+        "cask": "font-nova-cut",
+        "count": "8"
+      }
+    ],
+    "font-nova-flat": [
+      {
+        "cask": "font-nova-flat",
+        "count": "7"
+      }
+    ],
+    "font-nova-mono": [
+      {
+        "cask": "font-nova-mono",
+        "count": "30"
+      }
+    ],
+    "font-nova-oval": [
+      {
+        "cask": "font-nova-oval",
+        "count": "7"
+      }
+    ],
+    "font-nova-round": [
+      {
+        "cask": "font-nova-round",
+        "count": "6"
+      }
+    ],
+    "font-nova-script": [
+      {
+        "cask": "font-nova-script",
+        "count": "6"
+      }
+    ],
+    "font-nova-slim": [
+      {
+        "cask": "font-nova-slim",
+        "count": "6"
+      }
+    ],
+    "font-nova-square": [
+      {
+        "cask": "font-nova-square",
+        "count": "6"
+      }
+    ],
+    "font-nunito": [
+      {
+        "cask": "font-nunito",
+        "count": "44"
+      }
+    ],
+    "font-ocr": [
+      {
+        "cask": "font-ocr",
+        "count": "15"
+      }
+    ],
+    "font-octicons": [
+      {
+        "cask": "font-octicons",
+        "count": "2"
+      }
+    ],
+    "font-office-code-pro": [
+      {
+        "cask": "font-office-code-pro",
+        "count": "87"
+      }
+    ],
+    "font-old-standard-tt": [
+      {
+        "cask": "font-old-standard-tt",
+        "count": "12"
+      }
+    ],
+    "font-open-huninn": [
+      {
+        "cask": "font-open-huninn",
+        "count": "4"
+      }
+    ],
+    "font-open-iconic": [
+      {
+        "cask": "font-open-iconic",
+        "count": "11"
+      }
+    ],
+    "font-open-khmer-school": [
+      {
+        "cask": "font-open-khmer-school",
+        "count": "3"
+      }
+    ],
+    "font-open-sans": [
+      {
+        "cask": "font-open-sans",
+        "count": "357"
+      }
+    ],
+    "font-open-sans-condensed": [
+      {
+        "cask": "font-open-sans-condensed",
+        "count": "62"
+      }
+    ],
+    "font-open-sans-hebrew": [
+      {
+        "cask": "font-open-sans-hebrew",
+        "count": "9"
+      }
+    ],
+    "font-open-sans-hebrew-condensed": [
+      {
+        "cask": "font-open-sans-hebrew-condensed",
+        "count": "9"
+      }
+    ],
+    "font-opendyslexic": [
+      {
+        "cask": "font-opendyslexic",
+        "count": "20"
+      }
+    ],
+    "font-opendyslexic-nerd-font": [
+      {
+        "cask": "font-opendyslexic-nerd-font",
+        "count": "18"
+      }
+    ],
+    "font-optician-sans": [
+      {
+        "cask": "font-optician-sans",
+        "count": "7"
+      }
+    ],
+    "font-oranienbaum": [
+      {
+        "cask": "font-oranienbaum",
+        "count": "7"
+      }
+    ],
+    "font-orbitron": [
+      {
+        "cask": "font-orbitron",
+        "count": "9"
+      }
+    ],
+    "font-ostrich-sans": [
+      {
+        "cask": "font-ostrich-sans",
+        "count": "9"
+      }
+    ],
+    "font-oswald": [
+      {
+        "cask": "font-oswald",
+        "count": "41"
+      }
+    ],
+    "font-overlock": [
+      {
+        "cask": "font-overlock",
+        "count": "8"
+      }
+    ],
+    "font-overlock-sc": [
+      {
+        "cask": "font-overlock-sc",
+        "count": "7"
+      }
+    ],
+    "font-overpass": [
+      {
+        "cask": "font-overpass",
+        "count": "52"
+      }
+    ],
+    "font-overpass-nerd-font": [
+      {
+        "cask": "font-overpass-nerd-font",
+        "count": "27"
+      }
+    ],
+    "font-oxygen": [
+      {
+        "cask": "font-oxygen",
+        "count": "13"
+      }
+    ],
+    "font-oxygen-mono": [
+      {
+        "cask": "font-oxygen-mono",
+        "count": "27"
+      }
+    ],
+    "font-pacifico": [
+      {
+        "cask": "font-pacifico",
+        "count": "24"
+      }
+    ],
+    "font-padauk": [
+      {
+        "cask": "font-padauk",
+        "count": "7"
+      }
+    ],
+    "font-passion-one": [
+      {
+        "cask": "font-passion-one",
+        "count": "6"
+      }
+    ],
+    "font-patua-one": [
+      {
+        "cask": "font-patua-one",
+        "count": "10"
+      }
+    ],
+    "font-permanent-marker": [
+      {
+        "cask": "font-permanent-marker",
+        "count": "16"
+      }
+    ],
+    "font-petit-formal-script": [
+      {
+        "cask": "font-petit-formal-script",
+        "count": "36"
+      }
+    ],
+    "font-playfair-display": [
+      {
+        "cask": "font-playfair-display",
+        "count": "35"
+      }
+    ],
+    "font-playfair-display-sc": [
+      {
+        "cask": "font-playfair-display-sc",
+        "count": "10"
+      }
+    ],
+    "font-poiret-one": [
+      {
+        "cask": "font-poiret-one",
+        "count": "7"
+      }
+    ],
+    "font-poller-one": [
+      {
+        "cask": "font-poller-one",
+        "count": "7"
+      }
+    ],
+    "font-poppins": [
+      {
+        "cask": "font-poppins",
+        "count": "52"
+      }
+    ],
+    "font-poppins-latin": [
+      {
+        "cask": "font-poppins-latin",
+        "count": "9"
+      }
+    ],
+    "font-powerline-symbols": [
+      {
+        "cask": "font-powerline-symbols",
+        "count": "455"
+      }
+    ],
+    "font-prata": [
+      {
+        "cask": "font-prata",
+        "count": "7"
+      }
+    ],
+    "font-press-start2p": [
+      {
+        "cask": "font-press-start2p",
+        "count": "12"
+      }
+    ],
+    "font-princess-sofia": [
+      {
+        "cask": "font-princess-sofia",
+        "count": "6"
+      }
+    ],
+    "font-prociono": [
+      {
+        "cask": "font-prociono",
+        "count": "9"
+      }
+    ],
+    "font-profont-nerd-font": [
+      {
+        "cask": "font-profont-nerd-font",
+        "count": "97"
+      }
+    ],
+    "font-profont-nerd-font-mono": [
+      {
+        "cask": "font-profont-nerd-font-mono",
+        "count": "68"
+      }
+    ],
+    "font-profontx": [
+      {
+        "cask": "font-profontx",
+        "count": "12"
+      }
+    ],
+    "font-proggyclean-nerd-font": [
+      {
+        "cask": "font-proggyclean-nerd-font",
+        "count": "56"
+      }
+    ],
+    "font-proggyclean-nerd-font-mono": [
+      {
+        "cask": "font-proggyclean-nerd-font-mono",
+        "count": "61"
+      }
+    ],
+    "font-proggycleantt-nerd-font": [
+      {
+        "cask": "font-proggycleantt-nerd-font",
+        "count": "22"
+      }
+    ],
+    "font-proza-libre": [
+      {
+        "cask": "font-proza-libre",
+        "count": "10"
+      }
+    ],
+    "font-pt-mono": [
+      {
+        "cask": "font-pt-mono",
+        "count": "54"
+      }
+    ],
+    "font-pt-sans": [
+      {
+        "cask": "font-pt-sans",
+        "count": "36"
+      }
+    ],
+    "font-pt-serif": [
+      {
+        "cask": "font-pt-serif",
+        "count": "27"
+      }
+    ],
+    "font-public-sans": [
+      {
+        "cask": "font-public-sans",
+        "count": "33"
+      }
+    ],
+    "font-px437-pxplus": [
+      {
+        "cask": "font-px437-pxplus",
+        "count": "14"
+      }
+    ],
+    "font-quattrocento": [
+      {
+        "cask": "font-quattrocento",
+        "count": "6"
+      }
+    ],
+    "font-quattrocento-sans": [
+      {
+        "cask": "font-quattrocento-sans",
+        "count": "12"
+      }
+    ],
+    "font-quebec-serial": [
+      {
+        "cask": "font-quebec-serial",
+        "count": "3"
+      }
+    ],
+    "font-questrial": [
+      {
+        "cask": "font-questrial",
+        "count": "10"
+      }
+    ],
+    "font-quicksand": [
+      {
+        "cask": "font-quicksand",
+        "count": "32"
+      }
+    ],
+    "font-rajdhani": [
+      {
+        "cask": "font-rajdhani",
+        "count": "7"
+      }
+    ],
+    "font-raleway": [
+      {
+        "cask": "font-raleway",
+        "count": "84"
+      }
+    ],
+    "font-raleway-dots": [
+      {
+        "cask": "font-raleway-dots",
+        "count": "15"
+      }
+    ],
+    "font-ranchers": [
+      {
+        "cask": "font-ranchers",
+        "count": "7"
+      }
+    ],
+    "font-redacted": [
+      {
+        "cask": "font-redacted",
+        "count": "10"
+      }
+    ],
+    "font-redhat": [
+      {
+        "cask": "font-redhat",
+        "count": "47"
+      }
+    ],
+    "font-ribeye": [
+      {
+        "cask": "font-ribeye",
+        "count": "5"
+      }
+    ],
+    "font-ribeye-marrow": [
+      {
+        "cask": "font-ribeye-marrow",
+        "count": "6"
+      }
+    ],
+    "font-ricty-diminished": [
+      {
+        "cask": "font-ricty-diminished",
+        "count": "534"
+      }
+    ],
+    "font-ricty_diminished-devicon": [
+      {
+        "cask": "font-ricty_diminished-devicon",
+        "count": "3"
+      }
+    ],
+    "font-righteous": [
+      {
+        "cask": "font-righteous",
+        "count": "8"
+      }
+    ],
+    "font-roboto": [
+      {
+        "cask": "font-roboto",
+        "count": "621"
+      }
+    ],
+    "font-roboto-condensed": [
+      {
+        "cask": "font-roboto-condensed",
+        "count": "179"
+      }
+    ],
+    "font-roboto-mono": [
+      {
+        "cask": "font-roboto-mono",
+        "count": "316"
+      }
+    ],
+    "font-roboto-mono-for-powerline": [
+      {
+        "cask": "font-roboto-mono-for-powerline",
+        "count": "283"
+      }
+    ],
+    "font-roboto-slab": [
+      {
+        "cask": "font-roboto-slab",
+        "count": "76"
+      }
+    ],
+    "font-robotomono-nerd-font": [
+      {
+        "cask": "font-robotomono-nerd-font",
+        "count": "281"
+      }
+    ],
+    "font-robotomono-nerd-font-mono": [
+      {
+        "cask": "font-robotomono-nerd-font-mono",
+        "count": "167"
+      }
+    ],
+    "font-rock-salt": [
+      {
+        "cask": "font-rock-salt",
+        "count": "5"
+      }
+    ],
+    "font-rounded-m-plus": [
+      {
+        "cask": "font-rounded-m-plus",
+        "count": "17"
+      }
+    ],
+    "font-routed-gothic": [
+      {
+        "cask": "font-routed-gothic",
+        "count": "14"
+      }
+    ],
+    "font-rubik": [
+      {
+        "cask": "font-rubik",
+        "count": "40"
+      }
+    ],
+    "font-ruda": [
+      {
+        "cask": "font-ruda",
+        "count": "1"
+      }
+    ],
+    "font-ruda-black": [
+      {
+        "cask": "font-ruda-black",
+        "count": "1"
+      }
+    ],
+    "font-ruda-bold": [
+      {
+        "cask": "font-ruda-bold",
+        "count": "1"
+      }
+    ],
+    "font-sacramento": [
+      {
+        "cask": "font-sacramento",
+        "count": "9"
+      }
+    ],
+    "font-san-francisco-compact": [
+      {
+        "cask": "font-san-francisco-compact",
+        "count": "3"
+      }
+    ],
+    "font-san-francisco-pro": [
+      {
+        "cask": "font-san-francisco-pro",
+        "count": "4"
+      }
+    ],
+    "font-sanfrancisco": [
+      {
+        "cask": "font-sanfrancisco",
+        "count": "1"
+      }
+    ],
+    "font-sans-forgetica": [
+      {
+        "cask": "font-sans-forgetica",
+        "count": "24"
+      }
+    ],
+    "font-sarasa-gothic": [
+      {
+        "cask": "font-sarasa-gothic",
+        "count": "216"
+      }
+    ],
+    "font-satisfy": [
+      {
+        "cask": "font-satisfy",
+        "count": "8"
+      }
+    ],
+    "font-saucecodepro-nerd-font": [
+      {
+        "cask": "font-saucecodepro-nerd-font",
+        "count": "256"
+      }
+    ],
+    "font-scheherazade": [
+      {
+        "cask": "font-scheherazade",
+        "count": "10"
+      }
+    ],
+    "font-sf-compact": [
+      {
+        "cask": "font-sf-compact",
+        "count": "3"
+      }
+    ],
+    "font-sf-mono": [
+      {
+        "cask": "font-sf-mono",
+        "count": "6"
+      }
+    ],
+    "font-sf-mono-nerd-font": [
+      {
+        "cask": "font-sf-mono-nerd-font",
+        "count": "42"
+      }
+    ],
+    "font-sf-pro": [
+      {
+        "cask": "font-sf-pro",
+        "count": "3"
+      }
+    ],
+    "font-shadows-into-light-two": [
+      {
+        "cask": "font-shadows-into-light-two",
+        "count": "7"
+      }
+    ],
+    "font-share": [
+      {
+        "cask": "font-share",
+        "count": "6"
+      }
+    ],
+    "font-share-tech": [
+      {
+        "cask": "font-share-tech",
+        "count": "9"
+      }
+    ],
+    "font-share-tech-mono": [
+      {
+        "cask": "font-share-tech-mono",
+        "count": "23"
+      }
+    ],
+    "font-sharetechmono-nerd-font": [
+      {
+        "cask": "font-sharetechmono-nerd-font",
+        "count": "44"
+      }
+    ],
+    "font-sharetechmono-nerd-font-mono": [
+      {
+        "cask": "font-sharetechmono-nerd-font-mono",
+        "count": "53"
+      }
+    ],
+    "font-shuretechmono-nerd-font": [
+      {
+        "cask": "font-shuretechmono-nerd-font",
+        "count": "17"
+      }
+    ],
+    "font-sigmar-one": [
+      {
+        "cask": "font-sigmar-one",
+        "count": "6"
+      }
+    ],
+    "font-simhei": [
+      {
+        "cask": "font-simhei",
+        "count": "2"
+      }
+    ],
+    "font-simonetta": [
+      {
+        "cask": "font-simonetta",
+        "count": "6"
+      }
+    ],
+    "font-simple-line-icons": [
+      {
+        "cask": "font-simple-line-icons",
+        "count": "34"
+      }
+    ],
+    "font-simsun": [
+      {
+        "cask": "font-simsun",
+        "count": "2"
+      }
+    ],
+    "font-six-caps": [
+      {
+        "cask": "font-six-caps",
+        "count": "6"
+      }
+    ],
+    "font-sniglet": [
+      {
+        "cask": "font-sniglet",
+        "count": "5"
+      }
+    ],
+    "font-sorts-mill-goudy": [
+      {
+        "cask": "font-sorts-mill-goudy",
+        "count": "12"
+      }
+    ],
+    "font-source-code-pro": [
+      {
+        "cask": "font-source-code-pro",
+        "count": "3,845"
+      }
+    ],
+    "font-source-code-pro-for-powerline": [
+      {
+        "cask": "font-source-code-pro-for-powerline",
+        "count": "755"
+      }
+    ],
+    "font-source-han-code-jp": [
+      {
+        "cask": "font-source-han-code-jp",
+        "count": "399"
+      }
+    ],
+    "font-source-han-mono": [
+      {
+        "cask": "font-source-han-mono",
+        "count": "33"
+      }
+    ],
+    "font-source-han-noto-cjk": [
+      {
+        "cask": "font-source-han-noto-cjk",
+        "count": "38"
+      }
+    ],
+    "font-source-han-sans": [
+      {
+        "cask": "font-source-han-sans",
+        "count": "188"
+      }
+    ],
+    "font-source-han-serif": [
+      {
+        "cask": "font-source-han-serif",
+        "count": "93"
+      }
+    ],
+    "font-source-han-serif-el-m": [
+      {
+        "cask": "font-source-han-serif-el-m",
+        "count": "12"
+      }
+    ],
+    "font-source-han-serif-sb-h": [
+      {
+        "cask": "font-source-han-serif-sb-h",
+        "count": "11"
+      }
+    ],
+    "font-source-sans-pro": [
+      {
+        "cask": "font-source-sans-pro",
+        "count": "388"
+      }
+    ],
+    "font-source-serif-pro": [
+      {
+        "cask": "font-source-serif-pro",
+        "count": "257"
+      }
+    ],
+    "font-sourcecodepro-nerd-font": [
+      {
+        "cask": "font-sourcecodepro-nerd-font",
+        "count": "1,418"
+      }
+    ],
+    "font-sourcecodepro-nerd-font-mono": [
+      {
+        "cask": "font-sourcecodepro-nerd-font-mono",
+        "count": "263"
+      }
+    ],
+    "font-space-grotesk": [
+      {
+        "cask": "font-space-grotesk",
+        "count": "14"
+      }
+    ],
+    "font-space-mono": [
+      {
+        "cask": "font-space-mono",
+        "count": "64"
+      }
+    ],
+    "font-spacemono-nerd-font": [
+      {
+        "cask": "font-spacemono-nerd-font",
+        "count": "128"
+      }
+    ],
+    "font-spacemono-nerd-font-mono": [
+      {
+        "cask": "font-spacemono-nerd-font-mono",
+        "count": "63"
+      }
+    ],
+    "font-special-elite": [
+      {
+        "cask": "font-special-elite",
+        "count": "10"
+      }
+    ],
+    "font-spectral": [
+      {
+        "cask": "font-spectral",
+        "count": "13"
+      }
+    ],
+    "font-spleen": [
+      {
+        "cask": "font-spleen",
+        "count": "18"
+      }
+    ],
+    "font-stix": [
+      {
+        "cask": "font-stix",
+        "count": "22"
+      }
+    ],
+    "font-sudo": [
+      {
+        "cask": "font-sudo",
+        "count": "56"
+      }
+    ],
+    "font-takaoex": [
+      {
+        "cask": "font-takaoex",
+        "count": "13"
+      }
+    ],
+    "font-tangerine": [
+      {
+        "cask": "font-tangerine",
+        "count": "8"
+      }
+    ],
+    "font-terminessttf-nerd-font": [
+      {
+        "cask": "font-terminessttf-nerd-font",
+        "count": "23"
+      }
+    ],
+    "font-terminus": [
+      {
+        "cask": "font-terminus",
+        "count": "143"
+      }
+    ],
+    "font-terminus-nerd-font": [
+      {
+        "cask": "font-terminus-nerd-font",
+        "count": "79"
+      }
+    ],
+    "font-terminus-nerd-font-mono": [
+      {
+        "cask": "font-terminus-nerd-font-mono",
+        "count": "91"
+      }
+    ],
+    "font-tex-gyre-adventor": [
+      {
+        "cask": "font-tex-gyre-adventor",
+        "count": "19"
+      }
+    ],
+    "font-tex-gyre-bonum": [
+      {
+        "cask": "font-tex-gyre-bonum",
+        "count": "18"
+      }
+    ],
+    "font-tex-gyre-bonum-math": [
+      {
+        "cask": "font-tex-gyre-bonum-math",
+        "count": "16"
+      }
+    ],
+    "font-tex-gyre-chorus": [
+      {
+        "cask": "font-tex-gyre-chorus",
+        "count": "17"
+      }
+    ],
+    "font-tex-gyre-cursor": [
+      {
+        "cask": "font-tex-gyre-cursor",
+        "count": "23"
+      }
+    ],
+    "font-tex-gyre-heros": [
+      {
+        "cask": "font-tex-gyre-heros",
+        "count": "23"
+      }
+    ],
+    "font-tex-gyre-pagella": [
+      {
+        "cask": "font-tex-gyre-pagella",
+        "count": "26"
+      }
+    ],
+    "font-tex-gyre-pagella-math": [
+      {
+        "cask": "font-tex-gyre-pagella-math",
+        "count": "23"
+      }
+    ],
+    "font-tex-gyre-schola": [
+      {
+        "cask": "font-tex-gyre-schola",
+        "count": "21"
+      }
+    ],
+    "font-tex-gyre-schola-math": [
+      {
+        "cask": "font-tex-gyre-schola-math",
+        "count": "16"
+      }
+    ],
+    "font-tex-gyre-termes": [
+      {
+        "cask": "font-tex-gyre-termes",
+        "count": "25"
+      }
+    ],
+    "font-tex-gyre-termes-math": [
+      {
+        "cask": "font-tex-gyre-termes-math",
+        "count": "19"
+      }
+    ],
+    "font-the-girl-next-door": [
+      {
+        "cask": "font-the-girl-next-door",
+        "count": "7"
+      }
+    ],
+    "font-thesansuhh": [
+      {
+        "cask": "font-thesansuhh",
+        "count": "1"
+      }
+    ],
+    "font-times-new-roman": [
+      {
+        "cask": "font-times-new-roman",
+        "count": "13"
+      }
+    ],
+    "font-tinos-nerd-font": [
+      {
+        "cask": "font-tinos-nerd-font",
+        "count": "69"
+      }
+    ],
+    "font-tinos-nerd-font-mono": [
+      {
+        "cask": "font-tinos-nerd-font-mono",
+        "count": "47"
+      }
+    ],
+    "font-titillium": [
+      {
+        "cask": "font-titillium",
+        "count": "21"
+      }
+    ],
+    "font-trebuchet-ms": [
+      {
+        "cask": "font-trebuchet-ms",
+        "count": "13"
+      }
+    ],
+    "font-tulpen-one": [
+      {
+        "cask": "font-tulpen-one",
+        "count": "6"
+      }
+    ],
+    "font-twitter-color-emoji": [
+      {
+        "cask": "font-twitter-color-emoji",
+        "count": "28"
+      }
+    ],
+    "font-ubuntu": [
+      {
+        "cask": "font-ubuntu",
+        "count": "246"
+      }
+    ],
+    "font-ubuntu-mono-derivative-powerline": [
+      {
+        "cask": "font-ubuntu-mono-derivative-powerline",
+        "count": "171"
+      }
+    ],
+    "font-ubuntu-nerd-font": [
+      {
+        "cask": "font-ubuntu-nerd-font",
+        "count": "179"
+      }
+    ],
+    "font-ubuntu-nerd-font-mono": [
+      {
+        "cask": "font-ubuntu-nerd-font-mono",
+        "count": "85"
+      }
+    ],
+    "font-ubuntumono-nerd-font": [
+      {
+        "cask": "font-ubuntumono-nerd-font",
+        "count": "225"
+      }
+    ],
+    "font-ubuntumono-nerd-font-mono": [
+      {
+        "cask": "font-ubuntumono-nerd-font-mono",
+        "count": "94"
+      }
+    ],
+    "font-urw-base35": [
+      {
+        "cask": "font-urw-base35",
+        "count": "11"
+      }
+    ],
+    "font-varela-round": [
+      {
+        "cask": "font-varela-round",
+        "count": "7"
+      }
+    ],
+    "font-verdana": [
+      {
+        "cask": "font-verdana",
+        "count": "13"
+      }
+    ],
+    "font-victor-mono": [
+      {
+        "cask": "font-victor-mono",
+        "count": "493"
+      }
+    ],
+    "font-victormono-nerd-font": [
+      {
+        "cask": "font-victormono-nerd-font",
+        "count": "49"
+      }
+    ],
+    "font-vidaloka": [
+      {
+        "cask": "font-vidaloka",
+        "count": "7"
+      }
+    ],
+    "font-vlgothic": [
+      {
+        "cask": "font-vlgothic",
+        "count": "3"
+      }
+    ],
+    "font-volkhov": [
+      {
+        "cask": "font-volkhov",
+        "count": "5"
+      }
+    ],
+    "font-vollkorn": [
+      {
+        "cask": "font-vollkorn",
+        "count": "21"
+      }
+    ],
+    "font-vt323": [
+      {
+        "cask": "font-vt323",
+        "count": "9"
+      }
+    ],
+    "font-wire-one": [
+      {
+        "cask": "font-wire-one",
+        "count": "5"
+      }
+    ],
+    "font-work-sans": [
+      {
+        "cask": "font-work-sans",
+        "count": "44"
+      }
+    ],
+    "font-xits": [
+      {
+        "cask": "font-xits",
+        "count": "24"
+      }
+    ],
+    "font-xkcd": [
+      {
+        "cask": "font-xkcd",
+        "count": "25"
+      }
+    ],
+    "font-xkcd-script": [
+      {
+        "cask": "font-xkcd-script",
+        "count": "15"
+      }
+    ],
+    "font-yellowtail": [
+      {
+        "cask": "font-yellowtail",
+        "count": "5"
+      }
+    ],
+    "font-yorkten": [
+      {
+        "cask": "font-yorkten",
+        "count": "4"
+      }
+    ],
+    "font-ysabeau": [
+      {
+        "cask": "font-ysabeau",
+        "count": "5"
+      }
+    ],
+    "font-zilla-slab": [
+      {
+        "cask": "font-zilla-slab",
+        "count": "14"
+      }
+    ],
+    "fontbase": [
+      {
+        "cask": "fontbase",
+        "count": "184"
+      }
+    ],
+    "fontexplorer-x-pro": [
+      {
+        "cask": "fontexplorer-x-pro",
+        "count": "39"
+      }
+    ],
+    "fontforge": [
+      {
+        "cask": "fontforge",
+        "count": "996"
+      }
+    ],
+    "fontgoggles": [
+      {
+        "cask": "fontgoggles",
+        "count": "108"
+      }
+    ],
+    "fontlab": [
+      {
+        "cask": "fontlab",
+        "count": "18"
+      }
+    ],
+    "fontplop": [
+      {
+        "cask": "fontplop",
+        "count": "76"
+      }
+    ],
+    "fontstand": [
+      {
+        "cask": "fontstand",
+        "count": "11"
+      }
+    ],
+    "foobar2000": [
+      {
+        "cask": "foobar2000",
+        "count": "3"
+      }
+    ],
+    "force-paste": [
+      {
+        "cask": "force-paste",
+        "count": "67"
+      }
+    ],
+    "forecast": [
+      {
+        "cask": "forecast",
+        "count": "19"
+      }
+    ],
+    "foreman": [
+      {
+        "cask": "foreman",
+        "count": "141"
+      }
+    ],
+    "fork": [
+      {
+        "cask": "fork",
+        "count": "2,778"
+      }
+    ],
+    "forklift": [
+      {
+        "cask": "forklift",
+        "count": "683"
+      }
+    ],
+    "forklift2": [
+      {
+        "cask": "forklift2",
+        "count": "19"
+      }
+    ],
+    "forticlient": [
+      {
+        "cask": "forticlient",
+        "count": "866"
+      }
+    ],
+    "foundationdb": [
+      {
+        "cask": "foundationdb",
+        "count": "1"
+      }
+    ],
+    "foxitreader": [
+      {
+        "cask": "foxitreader",
+        "count": "286"
+      }
+    ],
+    "foxmail": [
+      {
+        "cask": "foxmail",
+        "count": "107"
+      }
+    ],
+    "fpcsrc": [
+      {
+        "cask": "fpcsrc",
+        "count": "207"
+      }
+    ],
+    "fractal-bot": [
+      {
+        "cask": "fractal-bot",
+        "count": "6"
+      }
+    ],
+    "framer": [
+      {
+        "cask": "framer",
+        "count": "14"
+      }
+    ],
+    "framer-x": [
+      {
+        "cask": "framer-x",
+        "count": "49"
+      }
+    ],
+    "franz": [
+      {
+        "cask": "franz",
+        "count": "928"
+      }
+    ],
+    "freac": [
+      {
+        "cask": "freac",
+        "count": "165"
+      }
+    ],
+    "fredm-fuse": [
+      {
+        "cask": "fredm-fuse",
+        "count": "4"
+      }
+    ],
+    "free-download-manager": [
+      {
+        "cask": "free-download-manager",
+        "count": "438"
+      }
+    ],
+    "free-ruler": [
+      {
+        "cask": "free-ruler",
+        "count": "90"
+      }
+    ],
+    "free87-fr-comp": [
+      {
+        "cask": "free87-fr-comp",
+        "count": "3"
+      }
+    ],
+    "free87-fr-equa": [
+      {
+        "cask": "free87-fr-equa",
+        "count": "3"
+      }
+    ],
+    "free87-fr-gate": [
+      {
+        "cask": "free87-fr-gate",
+        "count": "3"
+      }
+    ],
+    "free87-fr-limit": [
+      {
+        "cask": "free87-fr-limit",
+        "count": "3"
+      }
+    ],
+    "freecad": [
+      {
+        "cask": "freecad",
+        "count": "1,094"
+      }
+    ],
+    "freecad-asm3": [
+      {
+        "cask": "freecad-asm3",
+        "count": "1"
+      }
+    ],
+    "freecad-dev": [
+      {
+        "cask": "freecad-dev",
+        "count": "1"
+      }
+    ],
+    "freecad-nightly": [
+      {
+        "cask": "freecad-nightly",
+        "count": "3"
+      }
+    ],
+    "freeclip": [
+      {
+        "cask": "freeclip",
+        "count": "3"
+      }
+    ],
+    "freecol": [
+      {
+        "cask": "freecol",
+        "count": "16"
+      }
+    ],
+    "freedom": [
+      {
+        "cask": "freedom",
+        "count": "78"
+      }
+    ],
+    "freedome": [
+      {
+        "cask": "freedome",
+        "count": "17"
+      }
+    ],
+    "freefilesync": [
+      {
+        "cask": "freefilesync",
+        "count": "5"
+      }
+    ],
+    "freemind": [
+      {
+        "cask": "freemind",
+        "count": "416"
+      }
+    ],
+    "freenettray": [
+      {
+        "cask": "freenettray",
+        "count": "25"
+      }
+    ],
+    "freeorion": [
+      {
+        "cask": "freeorion",
+        "count": "12"
+      }
+    ],
+    "freeplane": [
+      {
+        "cask": "freeplane",
+        "count": "294"
+      }
+    ],
+    "freesmug-chromium": [
+      {
+        "cask": "freesmug-chromium",
+        "count": "168"
+      }
+    ],
+    "freeter": [
+      {
+        "cask": "freeter",
+        "count": "20"
+      }
+    ],
+    "freeyourmusic": [
+      {
+        "cask": "freeyourmusic",
+        "count": "42"
+      }
+    ],
+    "freeze": [
+      {
+        "cask": "freeze",
+        "count": "64"
+      }
+    ],
+    "frequency-shifter": [
+      {
+        "cask": "frequency-shifter",
+        "count": "2"
+      }
+    ],
+    "frescobaldi": [
+      {
+        "cask": "frescobaldi",
+        "count": "130"
+      }
+    ],
+    "frhelper": [
+      {
+        "cask": "frhelper",
+        "count": "33"
+      }
+    ],
+    "fritzing": [
+      {
+        "cask": "fritzing",
+        "count": "639"
+      }
+    ],
+    "fromscratch": [
+      {
+        "cask": "fromscratch",
+        "count": "27"
+      }
+    ],
+    "front": [
+      {
+        "cask": "front",
+        "count": "52"
+      }
+    ],
+    "fruit": [
+      {
+        "cask": "fruit",
+        "count": "2"
+      }
+    ],
+    "fs-uae": [
+      {
+        "cask": "fs-uae",
+        "count": "43"
+      }
+    ],
+    "fsmonitor": [
+      {
+        "cask": "fsmonitor",
+        "count": "37"
+      }
+    ],
+    "fsnotes": [
+      {
+        "cask": "fsnotes",
+        "count": "843"
+      }
+    ],
+    "fstream": [
+      {
+        "cask": "fstream",
+        "count": "8"
+      }
+    ],
+    "ftdi-vcp-driver": [
+      {
+        "cask": "ftdi-vcp-driver",
+        "count": "70"
+      }
+    ],
+    "fugu": [
+      {
+        "cask": "fugu",
+        "count": "346"
+      }
+    ],
+    "fujifilm-x-raw-studio": [
+      {
+        "cask": "fujifilm-x-raw-studio",
+        "count": "7"
+      }
+    ],
+    "fujitsu-scansnap-home": [
+      {
+        "cask": "fujitsu-scansnap-home",
+        "count": "54"
+      }
+    ],
+    "fujitsu-scansnap-manager": [
+      {
+        "cask": "fujitsu-scansnap-manager",
+        "count": "22"
+      }
+    ],
+    "fujitsu-scansnap-manager-ix500": [
+      {
+        "cask": "fujitsu-scansnap-manager-ix500",
+        "count": "25"
+      }
+    ],
+    "fujitsu-scansnap-manager-s1300": [
+      {
+        "cask": "fujitsu-scansnap-manager-s1300",
+        "count": "7"
+      }
+    ],
+    "full-bucket-brigade-delay": [
+      {
+        "cask": "full-bucket-brigade-delay",
+        "count": "2"
+      }
+    ],
+    "full-bucket-mps": [
+      {
+        "cask": "full-bucket-mps",
+        "count": "2"
+      }
+    ],
+    "full-bucket-phaser": [
+      {
+        "cask": "full-bucket-phaser",
+        "count": "2"
+      }
+    ],
+    "functionflip": [
+      {
+        "cask": "functionflip",
+        "count": "14"
+      }
+    ],
+    "funter": [
+      {
+        "cask": "funter",
+        "count": "77"
+      }
+    ],
+    "fuse": [
+      {
+        "cask": "fuse",
+        "count": "518"
+      }
+    ],
+    "futuniuniu": [
+      {
+        "cask": "futuniuniu",
+        "count": "93"
+      }
+    ],
+    "fuwari": [
+      {
+        "cask": "fuwari",
+        "count": "10"
+      }
+    ],
+    "fuzzyclock": [
+      {
+        "cask": "fuzzyclock",
+        "count": "15"
+      }
+    ],
+    "gameranger": [
+      {
+        "cask": "gameranger",
+        "count": "9"
+      }
+    ],
+    "gameshow": [
+      {
+        "cask": "gameshow",
+        "count": "5"
+      }
+    ],
+    "ganache": [
+      {
+        "cask": "ganache",
+        "count": "127"
+      }
+    ],
+    "ganttproject": [
+      {
+        "cask": "ganttproject",
+        "count": "202"
+      }
+    ],
+    "gapid": [
+      {
+        "cask": "gapid",
+        "count": "1"
+      }
+    ],
+    "garagebuy": [
+      {
+        "cask": "garagebuy",
+        "count": "4"
+      }
+    ],
+    "garagesale": [
+      {
+        "cask": "garagesale",
+        "count": "3"
+      }
+    ],
+    "gargoyle": [
+      {
+        "cask": "gargoyle",
+        "count": "20"
+      }
+    ],
+    "garmin-basecamp": [
+      {
+        "cask": "garmin-basecamp",
+        "count": "35"
+      }
+    ],
+    "garmin-express": [
+      {
+        "cask": "garmin-express",
+        "count": "150"
+      }
+    ],
+    "garmin-virb-edit": [
+      {
+        "cask": "garmin-virb-edit",
+        "count": "1"
+      }
+    ],
+    "gas-mask": [
+      {
+        "cask": "gas-mask",
+        "count": "461"
+      }
+    ],
+    "gb-studio": [
+      {
+        "cask": "gb-studio",
+        "count": "4"
+      }
+    ],
+    "gcc-arm-embedded": [
+      {
+        "cask": "gcc-arm-embedded",
+        "count": "1,039"
+      }
+    ],
+    "gcc-arm-embedded-2017q2": [
+      {
+        "cask": "gcc-arm-embedded-2017q2",
+        "count": "2"
+      }
+    ],
+    "gcc-arm-embedded-2017q4": [
+      {
+        "cask": "gcc-arm-embedded-2017q4",
+        "count": "1"
+      }
+    ],
+    "gcc-arm-embedded-2019q4": [
+      {
+        "cask": "gcc-arm-embedded-2019q4",
+        "count": "2"
+      }
+    ],
+    "gcc-arm-embedded-4_9-2015q3": [
+      {
+        "cask": "gcc-arm-embedded-4_9-2015q3",
+        "count": "1"
+      }
+    ],
+    "gcollazo-mongodb": [
+      {
+        "cask": "gcollazo-mongodb",
+        "count": "92"
+      }
+    ],
+    "gdisk": [
+      {
+        "cask": "gdisk",
+        "count": "390"
+      }
+    ],
+    "gdlauncher": [
+      {
+        "cask": "gdlauncher",
+        "count": "3"
+      }
+    ],
+    "geany": [
+      {
+        "cask": "geany",
+        "count": "623"
+      }
+    ],
+    "gearboy": [
+      {
+        "cask": "gearboy",
+        "count": "22"
+      }
+    ],
+    "gearsystem": [
+      {
+        "cask": "gearsystem",
+        "count": "6"
+      }
+    ],
+    "geburtstagschecker": [
+      {
+        "cask": "geburtstagschecker",
+        "count": "5"
+      }
+    ],
+    "geekbench": [
+      {
+        "cask": "geekbench",
+        "count": "771"
+      }
+    ],
+    "geektool": [
+      {
+        "cask": "geektool",
+        "count": "173"
+      }
+    ],
+    "gemini": [
+      {
+        "cask": "gemini",
+        "count": "232"
+      }
+    ],
+    "geneious-prime": [
+      {
+        "cask": "geneious-prime",
+        "count": "2"
+      }
+    ],
+    "genymotion": [
+      {
+        "cask": "genymotion",
+        "count": "359"
+      }
+    ],
+    "geogebra": [
+      {
+        "cask": "geogebra",
+        "count": "232"
+      }
+    ],
+    "geomap": [
+      {
+        "cask": "geomap",
+        "count": "5"
+      }
+    ],
+    "geotag": [
+      {
+        "cask": "geotag",
+        "count": "18"
+      }
+    ],
+    "geotag-photos-pro": [
+      {
+        "cask": "geotag-photos-pro",
+        "count": "3"
+      }
+    ],
+    "geotagger": [
+      {
+        "cask": "geotagger",
+        "count": "1"
+      }
+    ],
+    "geph": [
+      {
+        "cask": "geph",
+        "count": "39"
+      }
+    ],
+    "gephi": [
+      {
+        "cask": "gephi",
+        "count": "213"
+      }
+    ],
+    "get-backup-pro": [
+      {
+        "cask": "get-backup-pro",
+        "count": "17"
+      }
+    ],
+    "get-iplayer-automator": [
+      {
+        "cask": "get-iplayer-automator",
+        "count": "22"
+      }
+    ],
+    "get-lyrical": [
+      {
+        "cask": "get-lyrical",
+        "count": "7"
+      }
+    ],
+    "getrasplex": [
+      {
+        "cask": "getrasplex",
+        "count": "3"
+      }
+    ],
+    "gfortran": [
+      {
+        "cask": "gfortran",
+        "count": "2,130"
+      }
+    ],
+    "gfxcardstatus": [
+      {
+        "cask": "gfxcardstatus",
+        "count": "359"
+      }
+    ],
+    "ghdl": [
+      {
+        "cask": "ghdl",
+        "count": "71"
+      }
+    ],
+    "ghidra": [
+      {
+        "cask": "ghidra",
+        "count": "787"
+      }
+    ],
+    "ghidra-beta": [
+      {
+        "cask": "ghidra-beta",
+        "count": "7"
+      }
+    ],
+    "ghost": [
+      {
+        "cask": "ghost",
+        "count": "55"
+      }
+    ],
+    "ghost-browser": [
+      {
+        "cask": "ghost-browser",
+        "count": "24"
+      }
+    ],
+    "ghosttile": [
+      {
+        "cask": "ghosttile",
+        "count": "19"
+      }
+    ],
+    "gifcapture": [
+      {
+        "cask": "gifcapture",
+        "count": "228"
+      }
+    ],
+    "gifox": [
+      {
+        "cask": "gifox",
+        "count": "179"
+      }
+    ],
+    "gifrocket": [
+      {
+        "cask": "gifrocket",
+        "count": "61"
+      }
+    ],
+    "gifs": [
+      {
+        "cask": "gifs",
+        "count": "19"
+      }
+    ],
+    "gimp": [
+      {
+        "cask": "gimp",
+        "count": "9,902"
+      }
+    ],
+    "gingko": [
+      {
+        "cask": "gingko",
+        "count": "11"
+      }
+    ],
+    "giphy-anywhere": [
+      {
+        "cask": "giphy-anywhere",
+        "count": "1"
+      }
+    ],
+    "gislook": [
+      {
+        "cask": "gislook",
+        "count": "1"
+      }
+    ],
+    "gisto": [
+      {
+        "cask": "gisto",
+        "count": "99"
+      }
+    ],
+    "git-it": [
+      {
+        "cask": "git-it",
+        "count": "51"
+      }
+    ],
+    "gitahead": [
+      {
+        "cask": "gitahead",
+        "count": "144"
+      }
+    ],
+    "gitblade": [
+      {
+        "cask": "gitblade",
+        "count": "68"
+      }
+    ],
+    "gitbook": [
+      {
+        "cask": "gitbook",
+        "count": "230"
+      }
+    ],
+    "gitbox": [
+      {
+        "cask": "gitbox",
+        "count": "11"
+      }
+    ],
+    "gitee": [
+      {
+        "cask": "gitee",
+        "count": "11"
+      }
+    ],
+    "giteye": [
+      {
+        "cask": "giteye",
+        "count": "30"
+      }
+    ],
+    "gitfiend": [
+      {
+        "cask": "gitfiend",
+        "count": "5"
+      }
+    ],
+    "gitfinder": [
+      {
+        "cask": "gitfinder",
+        "count": "38"
+      }
+    ],
+    "gitfox": [
+      {
+        "cask": "gitfox",
+        "count": "24"
+      }
+    ],
+    "github": [
+      {
+        "cask": "github",
+        "count": "5,557"
+      }
+    ],
+    "github-beta": [
+      {
+        "cask": "github-beta",
+        "count": "51"
+      }
+    ],
+    "githubpulse": [
+      {
+        "cask": "githubpulse",
+        "count": "16"
+      }
+    ],
+    "gitify": [
+      {
+        "cask": "gitify",
+        "count": "334"
+      }
+    ],
+    "gitkraken": [
+      {
+        "cask": "gitkraken",
+        "count": "2,264"
+      }
+    ],
+    "gitnote": [
+      {
+        "cask": "gitnote",
+        "count": "33"
+      }
+    ],
+    "gitscout": [
+      {
+        "cask": "gitscout",
+        "count": "16"
+      }
+    ],
+    "gitter": [
+      {
+        "cask": "gitter",
+        "count": "233"
+      }
+    ],
+    "gitup": [
+      {
+        "cask": "gitup",
+        "count": "708"
+      }
+    ],
+    "gitx": [
+      {
+        "cask": "gitx",
+        "count": "387"
+      }
+    ],
+    "glimmerblocker": [
+      {
+        "cask": "glimmerblocker",
+        "count": "5"
+      }
+    ],
+    "glip": [
+      {
+        "cask": "glip",
+        "count": "42"
+      }
+    ],
+    "globalmeet": [
+      {
+        "cask": "globalmeet",
+        "count": "8"
+      }
+    ],
+    "globalprotect": [
+      {
+        "cask": "globalprotect",
+        "count": "17"
+      }
+    ],
+    "gloomhaven-helper": [
+      {
+        "cask": "gloomhaven-helper",
+        "count": "343"
+      }
+    ],
+    "gltfquicklook": [
+      {
+        "cask": "gltfquicklook",
+        "count": "127"
+      }
+    ],
+    "glyphfinder": [
+      {
+        "cask": "glyphfinder",
+        "count": "17"
+      }
+    ],
+    "glyphs": [
+      {
+        "cask": "glyphs",
+        "count": "42"
+      }
+    ],
+    "gmail-notifier": [
+      {
+        "cask": "gmail-notifier",
+        "count": "30"
+      }
+    ],
+    "gmvault": [
+      {
+        "cask": "gmvault",
+        "count": "39"
+      }
+    ],
+    "gns3": [
+      {
+        "cask": "gns3",
+        "count": "240"
+      }
+    ],
+    "gnucash": [
+      {
+        "cask": "gnucash",
+        "count": "535"
+      }
+    ],
+    "go-agent": [
+      {
+        "cask": "go-agent",
+        "count": "14"
+      }
+    ],
+    "go-server": [
+      {
+        "cask": "go-server",
+        "count": "13"
+      }
+    ],
+    "go2shell": [
+      {
+        "cask": "go2shell",
+        "count": "466"
+      }
+    ],
+    "go64": [
+      {
+        "cask": "go64",
+        "count": "78"
+      }
+    ],
+    "godot": [
+      {
+        "cask": "godot",
+        "count": "2,636"
+      }
+    ],
+    "godot-mono": [
+      {
+        "cask": "godot-mono",
+        "count": "117"
+      }
+    ],
+    "godot-nightly": [
+      {
+        "cask": "godot-nightly",
+        "count": "8"
+      }
+    ],
+    "gog-downloader": [
+      {
+        "cask": "gog-downloader",
+        "count": "17"
+      }
+    ],
+    "gog-galaxy": [
+      {
+        "cask": "gog-galaxy",
+        "count": "424"
+      }
+    ],
+    "gogs": [
+      {
+        "cask": "gogs",
+        "count": "28"
+      }
+    ],
+    "goland": [
+      {
+        "cask": "goland",
+        "count": "1,700"
+      }
+    ],
+    "goldencheetah": [
+      {
+        "cask": "goldencheetah",
+        "count": "43"
+      }
+    ],
+    "goldendict": [
+      {
+        "cask": "goldendict",
+        "count": "29"
+      }
+    ],
+    "golem": [
+      {
+        "cask": "golem",
+        "count": "221"
+      }
+    ],
+    "golem-mainnet-launcher": [
+      {
+        "cask": "golem-mainnet-launcher",
+        "count": "194"
+      }
+    ],
+    "golly": [
+      {
+        "cask": "golly",
+        "count": "37"
+      }
+    ],
+    "gom-player": [
+      {
+        "cask": "gom-player",
+        "count": "2"
+      }
+    ],
+    "goodsync": [
+      {
+        "cask": "goodsync",
+        "count": "108"
+      }
+    ],
+    "goofy": [
+      {
+        "cask": "goofy",
+        "count": "152"
+      }
+    ],
+    "google-ads-editor": [
+      {
+        "cask": "google-ads-editor",
+        "count": "221"
+      }
+    ],
+    "google-backup-and-sync": [
+      {
+        "cask": "google-backup-and-sync",
+        "count": "2,985"
+      }
+    ],
+    "google-chat": [
+      {
+        "cask": "google-chat",
+        "count": "631"
+      }
+    ],
+    "google-chrome": [
+      {
+        "cask": "google-chrome",
+        "count": "51,553"
+      }
+    ],
+    "google-chrome-beta": [
+      {
+        "cask": "google-chrome-beta",
+        "count": "217"
+      }
+    ],
+    "google-chrome-canary": [
+      {
+        "cask": "google-chrome-canary",
+        "count": "1,194"
+      }
+    ],
+    "google-chrome-custom": [
+      {
+        "cask": "google-chrome-custom",
+        "count": "1"
+      }
+    ],
+    "google-chrome-dev": [
+      {
+        "cask": "google-chrome-dev",
+        "count": "248"
+      }
+    ],
+    "google-cloud-sdk": [
+      {
+        "cask": "google-cloud-sdk",
+        "count": "13,742"
+      }
+    ],
+    "google-drive-file-stream": [
+      {
+        "cask": "google-drive-file-stream",
+        "count": "4,316"
+      }
+    ],
+    "google-earth-pro": [
+      {
+        "cask": "google-earth-pro",
+        "count": "1,044"
+      }
+    ],
+    "google-featured-photos": [
+      {
+        "cask": "google-featured-photos",
+        "count": "30"
+      }
+    ],
+    "google-hangouts": [
+      {
+        "cask": "google-hangouts",
+        "count": "1,171"
+      }
+    ],
+    "google-japanese-ime": [
+      {
+        "cask": "google-japanese-ime",
+        "count": "1,401"
+      }
+    ],
+    "google-japanese-ime-dev": [
+      {
+        "cask": "google-japanese-ime-dev",
+        "count": "7"
+      }
+    ],
+    "google-nik-collection": [
+      {
+        "cask": "google-nik-collection",
+        "count": "21"
+      }
+    ],
+    "google-notifier": [
+      {
+        "cask": "google-notifier",
+        "count": "1"
+      }
+    ],
+    "google-photos-backup-and-sync": [
+      {
+        "cask": "google-photos-backup-and-sync",
+        "count": "196"
+      }
+    ],
+    "google-trends": [
+      {
+        "cask": "google-trends",
+        "count": "234"
+      }
+    ],
+    "google-web-designer": [
+      {
+        "cask": "google-web-designer",
+        "count": "290"
+      }
+    ],
+    "googleappengine": [
+      {
+        "cask": "googleappengine",
+        "count": "39"
+      }
+    ],
+    "gopanda": [
+      {
+        "cask": "gopanda",
+        "count": "14"
+      }
+    ],
+    "gopass-ui": [
+      {
+        "cask": "gopass-ui",
+        "count": "48"
+      }
+    ],
+    "gotiengviet": [
+      {
+        "cask": "gotiengviet",
+        "count": "30"
+      }
+    ],
+    "gpg-suite": [
+      {
+        "cask": "gpg-suite",
+        "count": "3,218"
+      }
+    ],
+    "gpg-suite-nightly": [
+      {
+        "cask": "gpg-suite-nightly",
+        "count": "12"
+      }
+    ],
+    "gpg-suite-no-mail": [
+      {
+        "cask": "gpg-suite-no-mail",
+        "count": "493"
+      }
+    ],
+    "gpg-suite-pinentry": [
+      {
+        "cask": "gpg-suite-pinentry",
+        "count": "85"
+      }
+    ],
+    "gpg-sync": [
+      {
+        "cask": "gpg-sync",
+        "count": "30"
+      }
+    ],
+    "gplates": [
+      {
+        "cask": "gplates",
+        "count": "3"
+      }
+    ],
+    "gpodder": [
+      {
+        "cask": "gpodder",
+        "count": "49"
+      }
+    ],
+    "gpower": [
+      {
+        "cask": "gpower",
+        "count": "10"
+      }
+    ],
+    "gps4cam": [
+      {
+        "cask": "gps4cam",
+        "count": "1"
+      }
+    ],
+    "gpsdump": [
+      {
+        "cask": "gpsdump",
+        "count": "2"
+      }
+    ],
+    "gpxsee": [
+      {
+        "cask": "gpxsee",
+        "count": "84"
+      }
+    ],
+    "gqrx": [
+      {
+        "cask": "gqrx",
+        "count": "591"
+      }
+    ],
+    "graalvm-ce": [
+      {
+        "cask": "graalvm-ce",
+        "count": "2"
+      }
+    ],
+    "graalvm-ce-java11": [
+      {
+        "cask": "graalvm-ce-java11",
+        "count": "797"
+      }
+    ],
+    "graalvm-ce-java8": [
+      {
+        "cask": "graalvm-ce-java8",
+        "count": "498"
+      }
+    ],
+    "graalvm-ee-java11": [
+      {
+        "cask": "graalvm-ee-java11",
+        "count": "1"
+      }
+    ],
+    "graalvm-yoco": [
+      {
+        "cask": "graalvm-yoco",
+        "count": "10"
+      }
+    ],
+    "grads": [
+      {
+        "cask": "grads",
+        "count": "104"
+      }
+    ],
+    "grafx": [
+      {
+        "cask": "grafx",
+        "count": "20"
+      }
+    ],
+    "grakn-workbase": [
+      {
+        "cask": "grakn-workbase",
+        "count": "139"
+      }
+    ],
+    "grammarly": [
+      {
+        "cask": "grammarly",
+        "count": "948"
+      }
+    ],
+    "gramps": [
+      {
+        "cask": "gramps",
+        "count": "66"
+      }
+    ],
+    "grandperspective": [
+      {
+        "cask": "grandperspective",
+        "count": "893"
+      }
+    ],
+    "grandtotal": [
+      {
+        "cask": "grandtotal",
+        "count": "13"
+      }
+    ],
+    "graphicconverter": [
+      {
+        "cask": "graphicconverter",
+        "count": "90"
+      }
+    ],
+    "graphiql": [
+      {
+        "cask": "graphiql",
+        "count": "3,790"
+      }
+    ],
+    "graphql-ide": [
+      {
+        "cask": "graphql-ide",
+        "count": "50"
+      }
+    ],
+    "graphql-playground": [
+      {
+        "cask": "graphql-playground",
+        "count": "2,482"
+      }
+    ],
+    "graphsketcher": [
+      {
+        "cask": "graphsketcher",
+        "count": "15"
+      }
+    ],
+    "gray": [
+      {
+        "cask": "gray",
+        "count": "157"
+      }
+    ],
+    "greenfoot": [
+      {
+        "cask": "greenfoot",
+        "count": "6"
+      }
+    ],
+    "gretl": [
+      {
+        "cask": "gretl",
+        "count": "26"
+      }
+    ],
+    "gridea": [
+      {
+        "cask": "gridea",
+        "count": "39"
+      }
+    ],
+    "grids": [
+      {
+        "cask": "grids",
+        "count": "10"
+      }
+    ],
+    "grip": [
+      {
+        "cask": "grip",
+        "count": "2"
+      }
+    ],
+    "grisbi": [
+      {
+        "cask": "grisbi",
+        "count": "5"
+      }
+    ],
+    "growlnotify": [
+      {
+        "cask": "growlnotify",
+        "count": "113"
+      }
+    ],
+    "grpc-java": [
+      {
+        "cask": "grpc-java",
+        "count": "6"
+      }
+    ],
+    "grpc-web": [
+      {
+        "cask": "grpc-web",
+        "count": "14"
+      }
+    ],
+    "gsplus": [
+      {
+        "cask": "gsplus",
+        "count": "2"
+      }
+    ],
+    "gsport": [
+      {
+        "cask": "gsport",
+        "count": "2"
+      }
+    ],
+    "gswitch": [
+      {
+        "cask": "gswitch",
+        "count": "863"
+      }
+    ],
+    "gtkwave": [
+      {
+        "cask": "gtkwave",
+        "count": "757"
+      }
+    ],
+    "gtt-taskbar": [
+      {
+        "cask": "gtt-taskbar",
+        "count": "3"
+      }
+    ],
+    "gu-base": [
+      {
+        "cask": "gu-base",
+        "count": "11"
+      }
+    ],
+    "gu-scala": [
+      {
+        "cask": "gu-scala",
+        "count": "13"
+      }
+    ],
+    "guijs": [
+      {
+        "cask": "guijs",
+        "count": "23"
+      }
+    ],
+    "guild-wars2": [
+      {
+        "cask": "guild-wars2",
+        "count": "35"
+      }
+    ],
+    "guitar-pro": [
+      {
+        "cask": "guitar-pro",
+        "count": "65"
+      }
+    ],
+    "gulp": [
+      {
+        "cask": "gulp",
+        "count": "886"
+      }
+    ],
+    "guppy": [
+      {
+        "cask": "guppy",
+        "count": "6"
+      }
+    ],
+    "gureumkim": [
+      {
+        "cask": "gureumkim",
+        "count": "201"
+      }
+    ],
+    "gutenprint": [
+      {
+        "cask": "gutenprint",
+        "count": "58"
+      }
+    ],
+    "gyazmail": [
+      {
+        "cask": "gyazmail",
+        "count": "3"
+      }
+    ],
+    "gyazo": [
+      {
+        "cask": "gyazo",
+        "count": "188"
+      }
+    ],
+    "gzdoom": [
+      {
+        "cask": "gzdoom",
+        "count": "114"
+      }
+    ],
+    "ha-menu": [
+      {
+        "cask": "ha-menu",
+        "count": "69"
+      }
+    ],
+    "hab": [
+      {
+        "cask": "hab",
+        "count": "4"
+      }
+    ],
+    "hachidori": [
+      {
+        "cask": "hachidori",
+        "count": "3"
+      }
+    ],
+    "hackaru": [
+      {
+        "cask": "hackaru",
+        "count": "1"
+      }
+    ],
+    "hacker-menu": [
+      {
+        "cask": "hacker-menu",
+        "count": "33"
+      }
+    ],
+    "hackety-hack": [
+      {
+        "cask": "hackety-hack",
+        "count": "3"
+      }
+    ],
+    "hackhands": [
+      {
+        "cask": "hackhands",
+        "count": "6"
+      }
+    ],
+    "hackintool": [
+      {
+        "cask": "hackintool",
+        "count": "172"
+      }
+    ],
+    "hackmd": [
+      {
+        "cask": "hackmd",
+        "count": "18"
+      }
+    ],
+    "hakuneko": [
+      {
+        "cask": "hakuneko",
+        "count": "22"
+      }
+    ],
+    "hallelujahinputmethod": [
+      {
+        "cask": "hallelujahinputmethod",
+        "count": "3"
+      }
+    ],
+    "hammerspoon": [
+      {
+        "cask": "hammerspoon",
+        "count": "1,695"
+      }
+    ],
+    "hamsket-nightly": [
+      {
+        "cask": "hamsket-nightly",
+        "count": "19"
+      }
+    ],
+    "hand-mirror": [
+      {
+        "cask": "hand-mirror",
+        "count": "31"
+      }
+    ],
+    "handbrake": [
+      {
+        "cask": "handbrake",
+        "count": "4,070"
+      }
+    ],
+    "handbrake-nightly": [
+      {
+        "cask": "handbrake-nightly",
+        "count": "39"
+      }
+    ],
+    "handbrakebatch": [
+      {
+        "cask": "handbrakebatch",
+        "count": "35"
+      }
+    ],
+    "hands-off": [
+      {
+        "cask": "hands-off",
+        "count": "28"
+      }
+    ],
+    "handshaker": [
+      {
+        "cask": "handshaker",
+        "count": "113"
+      }
+    ],
+    "handylock": [
+      {
+        "cask": "handylock",
+        "count": "5"
+      }
+    ],
+    "happygrep": [
+      {
+        "cask": "happygrep",
+        "count": "8"
+      }
+    ],
+    "haptic-touch-bar": [
+      {
+        "cask": "haptic-touch-bar",
+        "count": "86"
+      }
+    ],
+    "haptickey": [
+      {
+        "cask": "haptickey",
+        "count": "171"
+      }
+    ],
+    "harbor": [
+      {
+        "cask": "harbor",
+        "count": "8"
+      }
+    ],
+    "harmony": [
+      {
+        "cask": "harmony",
+        "count": "25"
+      }
+    ],
+    "haroopad": [
+      {
+        "cask": "haroopad",
+        "count": "29"
+      }
+    ],
+    "harvest": [
+      {
+        "cask": "harvest",
+        "count": "235"
+      }
+    ],
+    "hashbackup": [
+      {
+        "cask": "hashbackup",
+        "count": "9"
+      }
+    ],
+    "haskell-for-mac": [
+      {
+        "cask": "haskell-for-mac",
+        "count": "121"
+      }
+    ],
+    "hazel": [
+      {
+        "cask": "hazel",
+        "count": "466"
+      }
+    ],
+    "hazeover": [
+      {
+        "cask": "hazeover",
+        "count": "111"
+      }
+    ],
+    "hbuilder": [
+      {
+        "cask": "hbuilder",
+        "count": "39"
+      }
+    ],
+    "hbuilderx": [
+      {
+        "cask": "hbuilderx",
+        "count": "120"
+      }
+    ],
+    "hdhomerun": [
+      {
+        "cask": "hdhomerun",
+        "count": "24"
+      }
+    ],
+    "hdrmerge": [
+      {
+        "cask": "hdrmerge",
+        "count": "7"
+      }
+    ],
+    "headset": [
+      {
+        "cask": "headset",
+        "count": "30"
+      }
+    ],
+    "heaven": [
+      {
+        "cask": "heaven",
+        "count": "50"
+      }
+    ],
+    "hedgewars": [
+      {
+        "cask": "hedgewars",
+        "count": "49"
+      }
+    ],
+    "heimdall-suite": [
+      {
+        "cask": "heimdall-suite",
+        "count": "32"
+      }
+    ],
+    "helium": [
+      {
+        "cask": "helium",
+        "count": "201"
+      }
+    ],
+    "helm": [
+      {
+        "cask": "helm",
+        "count": "7"
+      }
+    ],
+    "helo": [
+      {
+        "cask": "helo",
+        "count": "2"
+      }
+    ],
+    "hermes": [
+      {
+        "cask": "hermes",
+        "count": "53"
+      }
+    ],
+    "hex": [
+      {
+        "cask": "hex",
+        "count": "24"
+      }
+    ],
+    "hex-fiend": [
+      {
+        "cask": "hex-fiend",
+        "count": "954"
+      }
+    ],
+    "hex-fiend-beta": [
+      {
+        "cask": "hex-fiend-beta",
+        "count": "21"
+      }
+    ],
+    "hfsleuth": [
+      {
+        "cask": "hfsleuth",
+        "count": "19"
+      }
+    ],
+    "hiarcs-chess-explorer": [
+      {
+        "cask": "hiarcs-chess-explorer",
+        "count": "13"
+      }
+    ],
+    "hiddenbar": [
+      {
+        "cask": "hiddenbar",
+        "count": "722"
+      }
+    ],
+    "hider": [
+      {
+        "cask": "hider",
+        "count": "2"
+      }
+    ],
+    "hipchat": [
+      {
+        "cask": "hipchat",
+        "count": "114"
+      }
+    ],
+    "historyhound": [
+      {
+        "cask": "historyhound",
+        "count": "8"
+      }
+    ],
+    "hma-pro-vpn": [
+      {
+        "cask": "hma-pro-vpn",
+        "count": "41"
+      }
+    ],
+    "hockey": [
+      {
+        "cask": "hockey",
+        "count": "7"
+      }
+    ],
+    "hocus-focus": [
+      {
+        "cask": "hocus-focus",
+        "count": "72"
+      }
+    ],
+    "holavpn": [
+      {
+        "cask": "holavpn",
+        "count": "18"
+      }
+    ],
+    "home-inventory": [
+      {
+        "cask": "home-inventory",
+        "count": "5"
+      }
+    ],
+    "homedale": [
+      {
+        "cask": "homedale",
+        "count": "3"
+      }
+    ],
+    "honer": [
+      {
+        "cask": "honer",
+        "count": "19"
+      }
+    ],
+    "honto": [
+      {
+        "cask": "honto",
+        "count": "14"
+      }
+    ],
+    "hook": [
+      {
+        "cask": "hook",
+        "count": "7"
+      }
+    ],
+    "hopper-debugger-server": [
+      {
+        "cask": "hopper-debugger-server",
+        "count": "21"
+      }
+    ],
+    "hopper-disassembler": [
+      {
+        "cask": "hopper-disassembler",
+        "count": "12"
+      }
+    ],
+    "horndis": [
+      {
+        "cask": "horndis",
+        "count": "321"
+      }
+    ],
+    "horndis-pre": [
+      {
+        "cask": "horndis-pre",
+        "count": "1"
+      }
+    ],
+    "horos": [
+      {
+        "cask": "horos",
+        "count": "103"
+      }
+    ],
+    "hostbuddy": [
+      {
+        "cask": "hostbuddy",
+        "count": "1"
+      }
+    ],
+    "hosts": [
+      {
+        "cask": "hosts",
+        "count": "2"
+      }
+    ],
+    "hosty": [
+      {
+        "cask": "hosty",
+        "count": "1"
+      }
+    ],
+    "hotswitch": [
+      {
+        "cask": "hotswitch",
+        "count": "7"
+      }
+    ],
+    "houdahspot": [
+      {
+        "cask": "houdahspot",
+        "count": "32"
+      }
+    ],
+    "houseparty": [
+      {
+        "cask": "houseparty",
+        "count": "469"
+      }
+    ],
+    "hp-connectivity-kit": [
+      {
+        "cask": "hp-connectivity-kit",
+        "count": "18"
+      }
+    ],
+    "hp-easy-start": [
+      {
+        "cask": "hp-easy-start",
+        "count": "92"
+      }
+    ],
+    "hp-eprint": [
+      {
+        "cask": "hp-eprint",
+        "count": "17"
+      }
+    ],
+    "hp-prime": [
+      {
+        "cask": "hp-prime",
+        "count": "19"
+      }
+    ],
+    "hstracker": [
+      {
+        "cask": "hstracker",
+        "count": "46"
+      }
+    ],
+    "http-toolkit": [
+      {
+        "cask": "http-toolkit",
+        "count": "108"
+      }
+    ],
+    "hubic": [
+      {
+        "cask": "hubic",
+        "count": "1"
+      }
+    ],
+    "hubstaff": [
+      {
+        "cask": "hubstaff",
+        "count": "32"
+      }
+    ],
+    "hue-topia": [
+      {
+        "cask": "hue-topia",
+        "count": "16"
+      }
+    ],
+    "hugin": [
+      {
+        "cask": "hugin",
+        "count": "133"
+      }
+    ],
+    "huion-tablet-driver": [
+      {
+        "cask": "huion-tablet-driver",
+        "count": "1"
+      }
+    ],
+    "hummingbird": [
+      {
+        "cask": "hummingbird",
+        "count": "33"
+      }
+    ],
+    "hwmonitorsmc2": [
+      {
+        "cask": "hwmonitorsmc2",
+        "count": "3"
+      }
+    ],
+    "hwsensors": [
+      {
+        "cask": "hwsensors",
+        "count": "195"
+      }
+    ],
+    "hydrogen": [
+      {
+        "cask": "hydrogen",
+        "count": "28"
+      }
+    ],
+    "hype": [
+      {
+        "cask": "hype",
+        "count": "19"
+      }
+    ],
+    "hyper": [
+      {
+        "cask": "hyper",
+        "count": "4,354"
+      }
+    ],
+    "hyper-canary": [
+      {
+        "cask": "hyper-canary",
+        "count": "19"
+      }
+    ],
+    "hyperbackupexplorer": [
+      {
+        "cask": "hyperbackupexplorer",
+        "count": "15"
+      }
+    ],
+    "hyperdock": [
+      {
+        "cask": "hyperdock",
+        "count": "240"
+      }
+    ],
+    "hyperion-download-manager": [
+      {
+        "cask": "hyperion-download-manager",
+        "count": "2"
+      }
+    ],
+    "hyperswitch": [
+      {
+        "cask": "hyperswitch",
+        "count": "878"
+      }
+    ],
+    "i1profiler": [
+      {
+        "cask": "i1profiler",
+        "count": "68"
+      }
+    ],
+    "ibabel": [
+      {
+        "cask": "ibabel",
+        "count": "12"
+      }
+    ],
+    "ibackup": [
+      {
+        "cask": "ibackup",
+        "count": "6"
+      }
+    ],
+    "ibackup-viewer": [
+      {
+        "cask": "ibackup-viewer",
+        "count": "34"
+      }
+    ],
+    "ibackupbot": [
+      {
+        "cask": "ibackupbot",
+        "count": "11"
+      }
+    ],
+    "ibettercharge": [
+      {
+        "cask": "ibettercharge",
+        "count": "10"
+      }
+    ],
+    "ibm-cloud-cli": [
+      {
+        "cask": "ibm-cloud-cli",
+        "count": "111"
+      }
+    ],
+    "ibored": [
+      {
+        "cask": "ibored",
+        "count": "8"
+      }
+    ],
+    "icab": [
+      {
+        "cask": "icab",
+        "count": "16"
+      }
+    ],
+    "icamsource": [
+      {
+        "cask": "icamsource",
+        "count": "1"
+      }
+    ],
+    "icanhazshortcut": [
+      {
+        "cask": "icanhazshortcut",
+        "count": "27"
+      }
+    ],
+    "icc": [
+      {
+        "cask": "icc",
+        "count": "24"
+      }
+    ],
+    "iceberg": [
+      {
+        "cask": "iceberg",
+        "count": "9"
+      }
+    ],
+    "icecat": [
+      {
+        "cask": "icecat",
+        "count": "3"
+      }
+    ],
+    "icefloor": [
+      {
+        "cask": "icefloor",
+        "count": "18"
+      }
+    ],
+    "icegridgui": [
+      {
+        "cask": "icegridgui",
+        "count": "3"
+      }
+    ],
+    "icegridgui36": [
+      {
+        "cask": "icegridgui36",
+        "count": "1"
+      }
+    ],
+    "icestudio": [
+      {
+        "cask": "icestudio",
+        "count": "7"
+      }
+    ],
+    "ichm": [
+      {
+        "cask": "ichm",
+        "count": "64"
+      }
+    ],
+    "icloud-control": [
+      {
+        "cask": "icloud-control",
+        "count": "40"
+      }
+    ],
+    "icm-browser": [
+      {
+        "cask": "icm-browser",
+        "count": "1"
+      }
+    ],
+    "iconizer": [
+      {
+        "cask": "iconizer",
+        "count": "52"
+      }
+    ],
+    "iconjar": [
+      {
+        "cask": "iconjar",
+        "count": "61"
+      }
+    ],
+    "iconping": [
+      {
+        "cask": "iconping",
+        "count": "15"
+      }
+    ],
+    "icons": [
+      {
+        "cask": "icons",
+        "count": "13"
+      }
+    ],
+    "icons8": [
+      {
+        "cask": "icons8",
+        "count": "55"
+      }
+    ],
+    "icq": [
+      {
+        "cask": "icq",
+        "count": "42"
+      }
+    ],
+    "id3-editor": [
+      {
+        "cask": "id3-editor",
+        "count": "45"
+      }
+    ],
+    "idafree": [
+      {
+        "cask": "idafree",
+        "count": "46"
+      }
+    ],
+    "idagio": [
+      {
+        "cask": "idagio",
+        "count": "17"
+      }
+    ],
+    "idefrag": [
+      {
+        "cask": "idefrag",
+        "count": "10"
+      }
+    ],
+    "idisplay": [
+      {
+        "cask": "idisplay",
+        "count": "11"
+      }
+    ],
+    "idrive": [
+      {
+        "cask": "idrive",
+        "count": "40"
+      }
+    ],
+    "ieasemusic": [
+      {
+        "cask": "ieasemusic",
+        "count": "178"
+      }
+    ],
+    "iexplorer": [
+      {
+        "cask": "iexplorer",
+        "count": "85"
+      }
+    ],
+    "ifunbox": [
+      {
+        "cask": "ifunbox",
+        "count": "90"
+      }
+    ],
+    "igdm": [
+      {
+        "cask": "igdm",
+        "count": "52"
+      }
+    ],
+    "igetter": [
+      {
+        "cask": "igetter",
+        "count": "47"
+      }
+    ],
+    "iglance": [
+      {
+        "cask": "iglance",
+        "count": "1,028"
+      }
+    ],
+    "ignis": [
+      {
+        "cask": "ignis",
+        "count": "3"
+      }
+    ],
+    "igniteamps-anvil": [
+      {
+        "cask": "igniteamps-anvil",
+        "count": "2"
+      }
+    ],
+    "igniteamps-nrr1": [
+      {
+        "cask": "igniteamps-nrr1",
+        "count": "2"
+      }
+    ],
+    "igniteamps-profet": [
+      {
+        "cask": "igniteamps-profet",
+        "count": "2"
+      }
+    ],
+    "igniteamps-pteqx": [
+      {
+        "cask": "igniteamps-pteqx",
+        "count": "2"
+      }
+    ],
+    "igniteamps-ts999": [
+      {
+        "cask": "igniteamps-ts999",
+        "count": "2"
+      }
+    ],
+    "igor-pro": [
+      {
+        "cask": "igor-pro",
+        "count": "1"
+      }
+    ],
+    "iguanatexmac": [
+      {
+        "cask": "iguanatexmac",
+        "count": "4"
+      }
+    ],
+    "igv": [
+      {
+        "cask": "igv",
+        "count": "56"
+      }
+    ],
+    "iina": [
+      {
+        "cask": "iina",
+        "count": "6,011"
+      }
+    ],
+    "iina-plus": [
+      {
+        "cask": "iina-plus",
+        "count": "151"
+      }
+    ],
+    "ilok-license-manager": [
+      {
+        "cask": "ilok-license-manager",
+        "count": "50"
+      }
+    ],
+    "ilya-birman-typography-layout": [
+      {
+        "cask": "ilya-birman-typography-layout",
+        "count": "19"
+      }
+    ],
+    "image-tool": [
+      {
+        "cask": "image-tool",
+        "count": "21"
+      }
+    ],
+    "image2icon": [
+      {
+        "cask": "image2icon",
+        "count": "171"
+      }
+    ],
+    "imagealpha": [
+      {
+        "cask": "imagealpha",
+        "count": "201"
+      }
+    ],
+    "imagej": [
+      {
+        "cask": "imagej",
+        "count": "119"
+      }
+    ],
+    "imagemin": [
+      {
+        "cask": "imagemin",
+        "count": "32"
+      }
+    ],
+    "imageoptim": [
+      {
+        "cask": "imageoptim",
+        "count": "2,201"
+      }
+    ],
+    "imaging-edge": [
+      {
+        "cask": "imaging-edge",
+        "count": "31"
+      }
+    ],
+    "imazing": [
+      {
+        "cask": "imazing",
+        "count": "584"
+      }
+    ],
+    "imazing-mini": [
+      {
+        "cask": "imazing-mini",
+        "count": "11"
+      }
+    ],
+    "imeshortcuts": [
+      {
+        "cask": "imeshortcuts",
+        "count": "1"
+      }
+    ],
+    "imgbrd-grabber-nightly": [
+      {
+        "cask": "imgbrd-grabber-nightly",
+        "count": "4"
+      }
+    ],
+    "imgotv": [
+      {
+        "cask": "imgotv",
+        "count": "23"
+      }
+    ],
+    "imgur": [
+      {
+        "cask": "imgur",
+        "count": "30"
+      }
+    ],
+    "imitone": [
+      {
+        "cask": "imitone",
+        "count": "6"
+      }
+    ],
+    "imo": [
+      {
+        "cask": "imo",
+        "count": "5"
+      }
+    ],
+    "impactor": [
+      {
+        "cask": "impactor",
+        "count": "105"
+      }
+    ],
+    "imusic": [
+      {
+        "cask": "imusic",
+        "count": "2"
+      }
+    ],
+    "inav-configurator": [
+      {
+        "cask": "inav-configurator",
+        "count": "12"
+      }
+    ],
+    "inboard": [
+      {
+        "cask": "inboard",
+        "count": "5"
+      }
+    ],
+    "indigo": [
+      {
+        "cask": "indigo",
+        "count": "8"
+      }
+    ],
+    "inform": [
+      {
+        "cask": "inform",
+        "count": "8"
+      }
+    ],
+    "inkdrop": [
+      {
+        "cask": "inkdrop",
+        "count": "94"
+      }
+    ],
+    "inkpod": [
+      {
+        "cask": "inkpod",
+        "count": "2"
+      }
+    ],
+    "inkscape": [
+      {
+        "cask": "inkscape",
+        "count": "8,379"
+      }
+    ],
+    "inky": [
+      {
+        "cask": "inky",
+        "count": "16"
+      }
+    ],
+    "inloop-qlplayground": [
+      {
+        "cask": "inloop-qlplayground",
+        "count": "10"
+      }
+    ],
+    "insomnia": [
+      {
+        "cask": "insomnia",
+        "count": "10,578"
+      }
+    ],
+    "insomnia-designer": [
+      {
+        "cask": "insomnia-designer",
+        "count": "51"
+      }
+    ],
+    "inspec": [
+      {
+        "cask": "inspec",
+        "count": "570"
+      }
+    ],
+    "inssider": [
+      {
+        "cask": "inssider",
+        "count": "64"
+      }
+    ],
+    "insta360-studio": [
+      {
+        "cask": "insta360-studio",
+        "count": "11"
+      }
+    ],
+    "install-disk-creator": [
+      {
+        "cask": "install-disk-creator",
+        "count": "94"
+      }
+    ],
+    "install-unity": [
+      {
+        "cask": "install-unity",
+        "count": "9"
+      }
+    ],
+    "install_mono_mdk": [
+      {
+        "cask": "install_mono_mdk",
+        "count": "2"
+      }
+    ],
+    "install_xamarin_ios": [
+      {
+        "cask": "install_xamarin_ios",
+        "count": "2"
+      }
+    ],
+    "install_xamarin_mac": [
+      {
+        "cask": "install_xamarin_mac",
+        "count": "2"
+      }
+    ],
+    "instant-articles-builder": [
+      {
+        "cask": "instant-articles-builder",
+        "count": "2"
+      }
+    ],
+    "instasizer": [
+      {
+        "cask": "instasizer",
+        "count": "2"
+      }
+    ],
+    "insync": [
+      {
+        "cask": "insync",
+        "count": "143"
+      }
+    ],
+    "integrity": [
+      {
+        "cask": "integrity",
+        "count": "65"
+      }
+    ],
+    "intel-haxm": [
+      {
+        "cask": "intel-haxm",
+        "count": "752"
+      }
+    ],
+    "intel-power-gadget": [
+      {
+        "cask": "intel-power-gadget",
+        "count": "1,093"
+      }
+    ],
+    "intel-psxe-ce-c-plus-plus": [
+      {
+        "cask": "intel-psxe-ce-c-plus-plus",
+        "count": "5"
+      }
+    ],
+    "intellij-idea": [
+      {
+        "cask": "intellij-idea",
+        "count": "8,281"
+      }
+    ],
+    "intellij-idea-ce": [
+      {
+        "cask": "intellij-idea-ce",
+        "count": "5,551"
+      }
+    ],
+    "intellij-idea-newest": [
+      {
+        "cask": "intellij-idea-newest",
+        "count": "1"
+      }
+    ],
+    "intelliscape-caffeine": [
+      {
+        "cask": "intelliscape-caffeine",
+        "count": "60"
+      }
+    ],
+    "intelliscape-caffeine-beta": [
+      {
+        "cask": "intelliscape-caffeine-beta",
+        "count": "4"
+      }
+    ],
+    "interarchy": [
+      {
+        "cask": "interarchy",
+        "count": "2"
+      }
+    ],
+    "invesalius": [
+      {
+        "cask": "invesalius",
+        "count": "1"
+      }
+    ],
+    "invisiblix": [
+      {
+        "cask": "invisiblix",
+        "count": "2"
+      }
+    ],
+    "invisionsync": [
+      {
+        "cask": "invisionsync",
+        "count": "23"
+      }
+    ],
+    "invisor-lite": [
+      {
+        "cask": "invisor-lite",
+        "count": "8"
+      }
+    ],
+    "invisorql": [
+      {
+        "cask": "invisorql",
+        "count": "1"
+      }
+    ],
+    "inxmail-professional": [
+      {
+        "cask": "inxmail-professional",
+        "count": "1"
+      }
+    ],
+    "iograph": [
+      {
+        "cask": "iograph",
+        "count": "2"
+      }
+    ],
+    "ionic-lab": [
+      {
+        "cask": "ionic-lab",
+        "count": "17"
+      }
+    ],
+    "ionic-machina-cli": [
+      {
+        "cask": "ionic-machina-cli",
+        "count": "8"
+      }
+    ],
+    "ioninja": [
+      {
+        "cask": "ioninja",
+        "count": "13"
+      }
+    ],
+    "ioquake3": [
+      {
+        "cask": "ioquake3",
+        "count": "134"
+      }
+    ],
+    "ios-app-signer": [
+      {
+        "cask": "ios-app-signer",
+        "count": "96"
+      }
+    ],
+    "ios-console": [
+      {
+        "cask": "ios-console",
+        "count": "41"
+      }
+    ],
+    "ios-saver": [
+      {
+        "cask": "ios-saver",
+        "count": "12"
+      }
+    ],
+    "iota-wallet": [
+      {
+        "cask": "iota-wallet",
+        "count": "6"
+      }
+    ],
+    "ip-in-menu-bar": [
+      {
+        "cask": "ip-in-menu-bar",
+        "count": "74"
+      }
+    ],
+    "ipa-manager": [
+      {
+        "cask": "ipa-manager",
+        "count": "9"
+      }
+    ],
+    "ipartition": [
+      {
+        "cask": "ipartition",
+        "count": "44"
+      }
+    ],
+    "ipe": [
+      {
+        "cask": "ipe",
+        "count": "69"
+      }
+    ],
+    "ipepresenter": [
+      {
+        "cask": "ipepresenter",
+        "count": "12"
+      }
+    ],
+    "ipfs": [
+      {
+        "cask": "ipfs",
+        "count": "554"
+      }
+    ],
+    "iphoney": [
+      {
+        "cask": "iphoney",
+        "count": "8"
+      }
+    ],
+    "iphoto-library-manager": [
+      {
+        "cask": "iphoto-library-manager",
+        "count": "10"
+      }
+    ],
+    "ipremoteutility": [
+      {
+        "cask": "ipremoteutility",
+        "count": "1"
+      }
+    ],
+    "ipsecuritas": [
+      {
+        "cask": "ipsecuritas",
+        "count": "18"
+      }
+    ],
+    "ipvanish-vpn": [
+      {
+        "cask": "ipvanish-vpn",
+        "count": "55"
+      }
+    ],
+    "ipynb-quicklook": [
+      {
+        "cask": "ipynb-quicklook",
+        "count": "67"
+      }
+    ],
+    "iqiyi": [
+      {
+        "cask": "iqiyi",
+        "count": "1"
+      }
+    ],
+    "iqiyi-meeting": [
+      {
+        "cask": "iqiyi-meeting",
+        "count": "1"
+      }
+    ],
+    "irccloud": [
+      {
+        "cask": "irccloud",
+        "count": "57"
+      }
+    ],
+    "ireadfast": [
+      {
+        "cask": "ireadfast",
+        "count": "6"
+      }
+    ],
+    "iridient-developer": [
+      {
+        "cask": "iridient-developer",
+        "count": "5"
+      }
+    ],
+    "iridium": [
+      {
+        "cask": "iridium",
+        "count": "70"
+      }
+    ],
+    "iringg": [
+      {
+        "cask": "iringg",
+        "count": "1"
+      }
+    ],
+    "irip": [
+      {
+        "cask": "irip",
+        "count": "1"
+      }
+    ],
+    "iris": [
+      {
+        "cask": "iris",
+        "count": "20"
+      }
+    ],
+    "irreader": [
+      {
+        "cask": "irreader",
+        "count": "2"
+      }
+    ],
+    "isabelle": [
+      {
+        "cask": "isabelle",
+        "count": "42"
+      }
+    ],
+    "ishowu": [
+      {
+        "cask": "ishowu",
+        "count": "148"
+      }
+    ],
+    "ishowu-instant": [
+      {
+        "cask": "ishowu-instant",
+        "count": "31"
+      }
+    ],
+    "isimulator": [
+      {
+        "cask": "isimulator",
+        "count": "20"
+      }
+    ],
+    "islide": [
+      {
+        "cask": "islide",
+        "count": "45"
+      }
+    ],
+    "isolator": [
+      {
+        "cask": "isolator",
+        "count": "18"
+      }
+    ],
+    "istat-menus": [
+      {
+        "cask": "istat-menus",
+        "count": "2,311"
+      }
+    ],
+    "istat-menus5": [
+      {
+        "cask": "istat-menus5",
+        "count": "45"
+      }
+    ],
+    "istat-server": [
+      {
+        "cask": "istat-server",
+        "count": "53"
+      }
+    ],
+    "isteg": [
+      {
+        "cask": "isteg",
+        "count": "22"
+      }
+    ],
+    "istumbler": [
+      {
+        "cask": "istumbler",
+        "count": "89"
+      }
+    ],
+    "isubtitle": [
+      {
+        "cask": "isubtitle",
+        "count": "11"
+      }
+    ],
+    "iswiff": [
+      {
+        "cask": "iswiff",
+        "count": "10"
+      }
+    ],
+    "isyncr": [
+      {
+        "cask": "isyncr",
+        "count": "9"
+      }
+    ],
+    "itau": [
+      {
+        "cask": "itau",
+        "count": "29"
+      }
+    ],
+    "itch": [
+      {
+        "cask": "itch",
+        "count": "62"
+      }
+    ],
+    "iterm2": [
+      {
+        "cask": "iterm2",
+        "count": "55,891"
+      }
+    ],
+    "iterm2-beta": [
+      {
+        "cask": "iterm2-beta",
+        "count": "385"
+      }
+    ],
+    "iterm2-legacy": [
+      {
+        "cask": "iterm2-legacy",
+        "count": "17"
+      }
+    ],
+    "iterm2-nightly": [
+      {
+        "cask": "iterm2-nightly",
+        "count": "245"
+      }
+    ],
+    "ithoughtsx": [
+      {
+        "cask": "ithoughtsx",
+        "count": "26"
+      }
+    ],
+    "itk-snap": [
+      {
+        "cask": "itk-snap",
+        "count": "18"
+      }
+    ],
+    "itools": [
+      {
+        "cask": "itools",
+        "count": "71"
+      }
+    ],
+    "itrash": [
+      {
+        "cask": "itrash",
+        "count": "4"
+      }
+    ],
+    "itsycal": [
+      {
+        "cask": "itsycal",
+        "count": "1,498"
+      }
+    ],
+    "itubedownloader": [
+      {
+        "cask": "itubedownloader",
+        "count": "36"
+      }
+    ],
+    "itunes-producer": [
+      {
+        "cask": "itunes-producer",
+        "count": "3"
+      }
+    ],
+    "itunes-volume-control": [
+      {
+        "cask": "itunes-volume-control",
+        "count": "9"
+      }
+    ],
+    "ivideonclient": [
+      {
+        "cask": "ivideonclient",
+        "count": "4"
+      }
+    ],
+    "ivideonserver": [
+      {
+        "cask": "ivideonserver",
+        "count": "5"
+      }
+    ],
+    "ivolume": [
+      {
+        "cask": "ivolume",
+        "count": "4"
+      }
+    ],
+    "ivpn": [
+      {
+        "cask": "ivpn",
+        "count": "42"
+      }
+    ],
+    "izip": [
+      {
+        "cask": "izip",
+        "count": "106"
+      }
+    ],
+    "j": [
+      {
+        "cask": "j",
+        "count": "36"
+      }
+    ],
+    "jabra-direct": [
+      {
+        "cask": "jabra-direct",
+        "count": "98"
+      }
+    ],
+    "jabref": [
+      {
+        "cask": "jabref",
+        "count": "306"
+      }
+    ],
+    "jad": [
+      {
+        "cask": "jad",
+        "count": "283"
+      }
+    ],
+    "jaikoz": [
+      {
+        "cask": "jaikoz",
+        "count": "10"
+      }
+    ],
+    "jaikoz930": [
+      {
+        "cask": "jaikoz930",
+        "count": "1"
+      }
+    ],
+    "jaksta-media-recorder": [
+      {
+        "cask": "jaksta-media-recorder",
+        "count": "4"
+      }
+    ],
+    "jalbum": [
+      {
+        "cask": "jalbum",
+        "count": "7"
+      }
+    ],
+    "jalview": [
+      {
+        "cask": "jalview",
+        "count": "21"
+      }
+    ],
+    "jameica": [
+      {
+        "cask": "jameica",
+        "count": "5"
+      }
+    ],
+    "james": [
+      {
+        "cask": "james",
+        "count": "19"
+      }
+    ],
+    "jamf-migrator": [
+      {
+        "cask": "jamf-migrator",
+        "count": "14"
+      }
+    ],
+    "jami": [
+      {
+        "cask": "jami",
+        "count": "235"
+      }
+    ],
+    "jamovi": [
+      {
+        "cask": "jamovi",
+        "count": "17"
+      }
+    ],
+    "jandi": [
+      {
+        "cask": "jandi",
+        "count": "9"
+      }
+    ],
+    "jasp": [
+      {
+        "cask": "jasp",
+        "count": "28"
+      }
+    ],
+    "jasper": [
+      {
+        "cask": "jasper",
+        "count": "40"
+      }
+    ],
+    "java": [
+      {
+        "cask": "java",
+        "count": "63,416"
+      }
+    ],
+    "java-8-custom": [
+      {
+        "cask": "java-8-custom",
+        "count": "2"
+      }
+    ],
+    "java-beta": [
+      {
+        "cask": "java-beta",
+        "count": "17"
+      }
+    ],
+    "java11": [
+      {
+        "cask": "java11",
+        "count": "13,258"
+      }
+    ],
+    "java6": [
+      {
+        "cask": "java6",
+        "count": "1,689"
+      }
+    ],
+    "java7": [
+      {
+        "cask": "java7",
+        "count": "2"
+      }
+    ],
+    "java8": [
+      {
+        "cask": "java8",
+        "count": "46"
+      }
+    ],
+    "java8u181": [
+      {
+        "cask": "java8u181",
+        "count": "3"
+      }
+    ],
+    "java9": [
+      {
+        "cask": "java9",
+        "count": "90"
+      }
+    ],
+    "java_11_0_2": [
+      {
+        "cask": "java_11_0_2",
+        "count": "1"
+      }
+    ],
+    "jaxx-liberty": [
+      {
+        "cask": "jaxx-liberty",
+        "count": "32"
+      }
+    ],
+    "jazzup": [
+      {
+        "cask": "jazzup",
+        "count": "7"
+      }
+    ],
+    "jb-openjdk11": [
+      {
+        "cask": "jb-openjdk11",
+        "count": "1"
+      }
+    ],
+    "jbidwatcher": [
+      {
+        "cask": "jbidwatcher",
+        "count": "10"
+      }
+    ],
+    "jbrowse": [
+      {
+        "cask": "jbrowse",
+        "count": "26"
+      }
+    ],
+    "jclasslib-bytecode-viewer": [
+      {
+        "cask": "jclasslib-bytecode-viewer",
+        "count": "19"
+      }
+    ],
+    "jcryptool": [
+      {
+        "cask": "jcryptool",
+        "count": "15"
+      }
+    ],
+    "jd-gui": [
+      {
+        "cask": "jd-gui",
+        "count": "1,174"
+      }
+    ],
+    "jdiskreport": [
+      {
+        "cask": "jdiskreport",
+        "count": "40"
+      }
+    ],
+    "jdk-mission-control": [
+      {
+        "cask": "jdk-mission-control",
+        "count": "65"
+      }
+    ],
+    "jdk-mission-control-snapshot": [
+      {
+        "cask": "jdk-mission-control-snapshot",
+        "count": "3"
+      }
+    ],
+    "jdownloader": [
+      {
+        "cask": "jdownloader",
+        "count": "873"
+      }
+    ],
+    "jedit": [
+      {
+        "cask": "jedit",
+        "count": "77"
+      }
+    ],
+    "jedit-omega": [
+      {
+        "cask": "jedit-omega",
+        "count": "13"
+      }
+    ],
+    "jenkins-menu": [
+      {
+        "cask": "jenkins-menu",
+        "count": "24"
+      }
+    ],
+    "jeromelebel-mongohub": [
+      {
+        "cask": "jeromelebel-mongohub",
+        "count": "63"
+      }
+    ],
+    "jet": [
+      {
+        "cask": "jet",
+        "count": "1,080"
+      }
+    ],
+    "jetbrains-toolbox": [
+      {
+        "cask": "jetbrains-toolbox",
+        "count": "4,415"
+      }
+    ],
+    "jettison": [
+      {
+        "cask": "jettison",
+        "count": "17"
+      }
+    ],
+    "jewelrybox": [
+      {
+        "cask": "jewelrybox",
+        "count": "4"
+      }
+    ],
+    "jgrasp": [
+      {
+        "cask": "jgrasp",
+        "count": "23"
+      }
+    ],
+    "jietu": [
+      {
+        "cask": "jietu",
+        "count": "91"
+      }
+    ],
+    "jiggler": [
+      {
+        "cask": "jiggler",
+        "count": "167"
+      }
+    ],
+    "jing": [
+      {
+        "cask": "jing",
+        "count": "76"
+      }
+    ],
+    "jira-client": [
+      {
+        "cask": "jira-client",
+        "count": "273"
+      }
+    ],
+    "jitouch": [
+      {
+        "cask": "jitouch",
+        "count": "40"
+      }
+    ],
+    "jitsi": [
+      {
+        "cask": "jitsi",
+        "count": "715"
+      }
+    ],
+    "jitsi-meet": [
+      {
+        "cask": "jitsi-meet",
+        "count": "1,198"
+      }
+    ],
+    "jmc": [
+      {
+        "cask": "jmc",
+        "count": "65"
+      }
+    ],
+    "jmetrik": [
+      {
+        "cask": "jmetrik",
+        "count": "1"
+      }
+    ],
+    "joinme": [
+      {
+        "cask": "joinme",
+        "count": "45"
+      }
+    ],
+    "joker": [
+      {
+        "cask": "joker",
+        "count": "31"
+      }
+    ],
+    "jollysfastvnc": [
+      {
+        "cask": "jollysfastvnc",
+        "count": "86"
+      }
+    ],
+    "joox": [
+      {
+        "cask": "joox",
+        "count": "2"
+      }
+    ],
+    "joplin": [
+      {
+        "cask": "joplin",
+        "count": "6,618"
+      }
+    ],
+    "joshaven-winbox": [
+      {
+        "cask": "joshaven-winbox",
+        "count": "72"
+      }
+    ],
+    "josm": [
+      {
+        "cask": "josm",
+        "count": "301"
+      }
+    ],
+    "journey": [
+      {
+        "cask": "journey",
+        "count": "51"
+      }
+    ],
+    "jprofiler": [
+      {
+        "cask": "jprofiler",
+        "count": "149"
+      }
+    ],
+    "jqbx": [
+      {
+        "cask": "jqbx",
+        "count": "63"
+      }
+    ],
+    "jsontohandyjson": [
+      {
+        "cask": "jsontohandyjson",
+        "count": "3"
+      }
+    ],
+    "jsui": [
+      {
+        "cask": "jsui",
+        "count": "10"
+      }
+    ],
+    "jtool": [
+      {
+        "cask": "jtool",
+        "count": "89"
+      }
+    ],
+    "jtool2": [
+      {
+        "cask": "jtool2",
+        "count": "76"
+      }
+    ],
+    "jubler": [
+      {
+        "cask": "jubler",
+        "count": "65"
+      }
+    ],
+    "juicebar": [
+      {
+        "cask": "juicebar",
+        "count": "2"
+      }
+    ],
+    "julia": [
+      {
+        "cask": "julia",
+        "count": "3,039"
+      }
+    ],
+    "julia-lts": [
+      {
+        "cask": "julia-lts",
+        "count": "13"
+      }
+    ],
+    "julia-nightly": [
+      {
+        "cask": "julia-nightly",
+        "count": "20"
+      }
+    ],
+    "jump": [
+      {
+        "cask": "jump",
+        "count": "38"
+      }
+    ],
+    "jump-desktop-connect": [
+      {
+        "cask": "jump-desktop-connect",
+        "count": "4"
+      }
+    ],
+    "jumpcut": [
+      {
+        "cask": "jumpcut",
+        "count": "1,648"
+      }
+    ],
+    "jumpshare": [
+      {
+        "cask": "jumpshare",
+        "count": "11"
+      }
+    ],
+    "jupyter-notebook-ql": [
+      {
+        "cask": "jupyter-notebook-ql",
+        "count": "168"
+      }
+    ],
+    "jupyter-notebook-viewer": [
+      {
+        "cask": "jupyter-notebook-viewer",
+        "count": "535"
+      }
+    ],
+    "k2tf": [
+      {
+        "cask": "k2tf",
+        "count": "1"
+      }
+    ],
+    "k40-whisperer": [
+      {
+        "cask": "k40-whisperer",
+        "count": "1"
+      }
+    ],
+    "kactus": [
+      {
+        "cask": "kactus",
+        "count": "14"
+      }
+    ],
+    "kafka-tool": [
+      {
+        "cask": "kafka-tool",
+        "count": "185"
+      }
+    ],
+    "kakapo": [
+      {
+        "cask": "kakapo",
+        "count": "6"
+      }
+    ],
+    "kaku": [
+      {
+        "cask": "kaku",
+        "count": "4"
+      }
+    ],
+    "kaleidoscope": [
+      {
+        "cask": "kaleidoscope",
+        "count": "624"
+      }
+    ],
+    "kanmail": [
+      {
+        "cask": "kanmail",
+        "count": "1"
+      }
+    ],
+    "kap": [
+      {
+        "cask": "kap",
+        "count": "2,049"
+      }
+    ],
+    "kap-beta": [
+      {
+        "cask": "kap-beta",
+        "count": "6"
+      }
+    ],
+    "kapitainsky-rclone-browser": [
+      {
+        "cask": "kapitainsky-rclone-browser",
+        "count": "33"
+      }
+    ],
+    "kapow": [
+      {
+        "cask": "kapow",
+        "count": "12"
+      }
+    ],
+    "karabiner": [
+      {
+        "cask": "karabiner",
+        "count": "1"
+      }
+    ],
+    "karabiner-elements": [
+      {
+        "cask": "karabiner-elements",
+        "count": "5,097"
+      }
+    ],
+    "katalon-studio": [
+      {
+        "cask": "katalon-studio",
+        "count": "130"
+      }
+    ],
+    "katana": [
+      {
+        "cask": "katana",
+        "count": "18"
+      }
+    ],
+    "kawa": [
+      {
+        "cask": "kawa",
+        "count": "122"
+      }
+    ],
+    "kc-ausweisapp2": [
+      {
+        "cask": "kc-ausweisapp2",
+        "count": "1"
+      }
+    ],
+    "kc-knockknock": [
+      {
+        "cask": "kc-knockknock",
+        "count": "1"
+      }
+    ],
+    "kde-connect": [
+      {
+        "cask": "kde-connect",
+        "count": "3"
+      }
+    ],
+    "kdiff3": [
+      {
+        "cask": "kdiff3",
+        "count": "272"
+      }
+    ],
+    "keep": [
+      {
+        "cask": "keep",
+        "count": "58"
+      }
+    ],
+    "keep-it": [
+      {
+        "cask": "keep-it",
+        "count": "13"
+      }
+    ],
+    "keepassx": [
+      {
+        "cask": "keepassx",
+        "count": "1,502"
+      }
+    ],
+    "keepassxc": [
+      {
+        "cask": "keepassxc",
+        "count": "11,688"
+      }
+    ],
+    "keepassxc-beta": [
+      {
+        "cask": "keepassxc-beta",
+        "count": "25"
+      }
+    ],
+    "keepassxc-snapshot": [
+      {
+        "cask": "keepassxc-snapshot",
+        "count": "26"
+      }
+    ],
+    "keeper-password-manager": [
+      {
+        "cask": "keeper-password-manager",
+        "count": "80"
+      }
+    ],
+    "keepingyouawake": [
+      {
+        "cask": "keepingyouawake",
+        "count": "2,460"
+      }
+    ],
+    "keeweb": [
+      {
+        "cask": "keeweb",
+        "count": "361"
+      }
+    ],
+    "keka": [
+      {
+        "cask": "keka",
+        "count": "5,397"
+      }
+    ],
+    "keka-beta": [
+      {
+        "cask": "keka-beta",
+        "count": "46"
+      }
+    ],
+    "kekadefaultapp": [
+      {
+        "cask": "kekadefaultapp",
+        "count": "236"
+      }
+    ],
+    "kellerkinder-time-machine-status": [
+      {
+        "cask": "kellerkinder-time-machine-status",
+        "count": "2"
+      }
+    ],
+    "kensington-trackball-works": [
+      {
+        "cask": "kensington-trackball-works",
+        "count": "33"
+      }
+    ],
+    "kern": [
+      {
+        "cask": "kern",
+        "count": "1"
+      }
+    ],
+    "kext-updater": [
+      {
+        "cask": "kext-updater",
+        "count": "97"
+      }
+    ],
+    "kext-utility": [
+      {
+        "cask": "kext-utility",
+        "count": "99"
+      }
+    ],
+    "kextviewr": [
+      {
+        "cask": "kextviewr",
+        "count": "87"
+      }
+    ],
+    "key-codes": [
+      {
+        "cask": "key-codes",
+        "count": "68"
+      }
+    ],
+    "keybase": [
+      {
+        "cask": "keybase",
+        "count": "2,994"
+      }
+    ],
+    "keyboard": [
+      {
+        "cask": "keyboard",
+        "count": "2"
+      }
+    ],
+    "keyboard-cleaner": [
+      {
+        "cask": "keyboard-cleaner",
+        "count": "181"
+      }
+    ],
+    "keyboard-lock": [
+      {
+        "cask": "keyboard-lock",
+        "count": "29"
+      }
+    ],
+    "keyboard-maestro": [
+      {
+        "cask": "keyboard-maestro",
+        "count": "398"
+      }
+    ],
+    "keyboard-maestro8": [
+      {
+        "cask": "keyboard-maestro8",
+        "count": "3"
+      }
+    ],
+    "keyboardcleantool": [
+      {
+        "cask": "keyboardcleantool",
+        "count": "256"
+      }
+    ],
+    "keycast": [
+      {
+        "cask": "keycast",
+        "count": "31"
+      }
+    ],
+    "keycastr": [
+      {
+        "cask": "keycastr",
+        "count": "2,350"
+      }
+    ],
+    "keychain-pkcs11": [
+      {
+        "cask": "keychain-pkcs11",
+        "count": "10"
+      }
+    ],
+    "keychaincheck2": [
+      {
+        "cask": "keychaincheck2",
+        "count": "5"
+      }
+    ],
+    "keycue": [
+      {
+        "cask": "keycue",
+        "count": "45"
+      }
+    ],
+    "keyfinder": [
+      {
+        "cask": "keyfinder",
+        "count": "6"
+      }
+    ],
+    "keylayout-colemak": [
+      {
+        "cask": "keylayout-colemak",
+        "count": "1"
+      }
+    ],
+    "keymanager": [
+      {
+        "cask": "keymanager",
+        "count": "17"
+      }
+    ],
+    "keypad-layout": [
+      {
+        "cask": "keypad-layout",
+        "count": "13"
+      }
+    ],
+    "keys": [
+      {
+        "cask": "keys",
+        "count": "4"
+      }
+    ],
+    "keyshot": [
+      {
+        "cask": "keyshot",
+        "count": "3"
+      }
+    ],
+    "keystore-explorer": [
+      {
+        "cask": "keystore-explorer",
+        "count": "424"
+      }
+    ],
+    "khmer-unicode-layout": [
+      {
+        "cask": "khmer-unicode-layout",
+        "count": "2"
+      }
+    ],
+    "kicad": [
+      {
+        "cask": "kicad",
+        "count": "368"
+      }
+    ],
+    "kid3": [
+      {
+        "cask": "kid3",
+        "count": "383"
+      }
+    ],
+    "kiibohd-configurator": [
+      {
+        "cask": "kiibohd-configurator",
+        "count": "11"
+      }
+    ],
+    "kindle": [
+      {
+        "cask": "kindle",
+        "count": "2,057"
+      }
+    ],
+    "kindle-50131": [
+      {
+        "cask": "kindle-50131",
+        "count": "3"
+      }
+    ],
+    "kindle-comic-converter": [
+      {
+        "cask": "kindle-comic-converter",
+        "count": "61"
+      }
+    ],
+    "kindle-comic-creator": [
+      {
+        "cask": "kindle-comic-creator",
+        "count": "438"
+      }
+    ],
+    "kindle-previewer": [
+      {
+        "cask": "kindle-previewer",
+        "count": "146"
+      }
+    ],
+    "kindle@1.25.2": [
+      {
+        "cask": "kindle@1.25.2",
+        "count": "1"
+      }
+    ],
+    "kindle_50131": [
+      {
+        "cask": "kindle_50131",
+        "count": "1"
+      }
+    ],
+    "kindle_55093": [
+      {
+        "cask": "kindle_55093",
+        "count": "1"
+      }
+    ],
+    "kindlegen": [
+      {
+        "cask": "kindlegen",
+        "count": "522"
+      }
+    ],
+    "kinesis-smart-set": [
+      {
+        "cask": "kinesis-smart-set",
+        "count": "1"
+      }
+    ],
+    "kinesis-smartset": [
+      {
+        "cask": "kinesis-smartset",
+        "count": "3"
+      }
+    ],
+    "kinza": [
+      {
+        "cask": "kinza",
+        "count": "4"
+      }
+    ],
+    "kitabu": [
+      {
+        "cask": "kitabu",
+        "count": "7"
+      }
+    ],
+    "kite": [
+      {
+        "cask": "kite",
+        "count": "524"
+      }
+    ],
+    "kitematic": [
+      {
+        "cask": "kitematic",
+        "count": "2,002"
+      }
+    ],
+    "kitematic0176": [
+      {
+        "cask": "kitematic0176",
+        "count": "1"
+      }
+    ],
+    "kitt": [
+      {
+        "cask": "kitt",
+        "count": "6"
+      }
+    ],
+    "kitty": [
+      {
+        "cask": "kitty",
+        "count": "3,280"
+      }
+    ],
+    "kiwi-for-g-suite": [
+      {
+        "cask": "kiwi-for-g-suite",
+        "count": "54"
+      }
+    ],
+    "kiwix": [
+      {
+        "cask": "kiwix",
+        "count": "58"
+      }
+    ],
+    "kk7ds-python-runtime": [
+      {
+        "cask": "kk7ds-python-runtime",
+        "count": "37"
+      }
+    ],
+    "kkbox": [
+      {
+        "cask": "kkbox",
+        "count": "27"
+      }
+    ],
+    "klatexformula": [
+      {
+        "cask": "klatexformula",
+        "count": "67"
+      }
+    ],
+    "klayout": [
+      {
+        "cask": "klayout",
+        "count": "29"
+      }
+    ],
+    "klokki": [
+      {
+        "cask": "klokki",
+        "count": "10"
+      }
+    ],
+    "kmbmpdc": [
+      {
+        "cask": "kmbmpdc",
+        "count": "21"
+      }
+    ],
+    "kmplayer": [
+      {
+        "cask": "kmplayer",
+        "count": "91"
+      }
+    ],
+    "knime": [
+      {
+        "cask": "knime",
+        "count": "61"
+      }
+    ],
+    "knock": [
+      {
+        "cask": "knock",
+        "count": "16"
+      }
+    ],
+    "knockknock": [
+      {
+        "cask": "knockknock",
+        "count": "294"
+      }
+    ],
+    "knotes": [
+      {
+        "cask": "knotes",
+        "count": "9"
+      }
+    ],
+    "knox": [
+      {
+        "cask": "knox",
+        "count": "16"
+      }
+    ],
+    "knuff": [
+      {
+        "cask": "knuff",
+        "count": "11"
+      }
+    ],
+    "koa11y": [
+      {
+        "cask": "koa11y",
+        "count": "11"
+      }
+    ],
+    "koala": [
+      {
+        "cask": "koala",
+        "count": "29"
+      }
+    ],
+    "kobo": [
+      {
+        "cask": "kobo",
+        "count": "112"
+      }
+    ],
+    "kode54-cog": [
+      {
+        "cask": "kode54-cog",
+        "count": "110"
+      }
+    ],
+    "kodelife": [
+      {
+        "cask": "kodelife",
+        "count": "16"
+      }
+    ],
+    "kodi": [
+      {
+        "cask": "kodi",
+        "count": "968"
+      }
+    ],
+    "komet": [
+      {
+        "cask": "komet",
+        "count": "3"
+      }
+    ],
+    "komodo-edit": [
+      {
+        "cask": "komodo-edit",
+        "count": "65"
+      }
+    ],
+    "komodo-ide": [
+      {
+        "cask": "komodo-ide",
+        "count": "37"
+      }
+    ],
+    "kompozer": [
+      {
+        "cask": "kompozer",
+        "count": "5"
+      }
+    ],
+    "konica-minolta-bizhub-c220-c280-c360-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c220-c280-c360-driver",
+        "count": "1"
+      }
+    ],
+    "konica-minolta-bizhub-c554-c364-109-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c554-c364-109-driver",
+        "count": "1"
+      }
+    ],
+    "konica-minolta-bizhub-c650i-c360i-c4050i-c4000i-c3320i-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c650i-c360i-c4050i-c4000i-c3320i-driver",
+        "count": "112"
+      }
+    ],
+    "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver": [
+      {
+        "cask": "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver",
+        "count": "6"
+      }
+    ],
+    "kotlin-native": [
+      {
+        "cask": "kotlin-native",
+        "count": "156"
+      }
+    ],
+    "krew": [
+      {
+        "cask": "krew",
+        "count": "1"
+      }
+    ],
+    "krisp": [
+      {
+        "cask": "krisp",
+        "count": "503"
+      }
+    ],
+    "krita": [
+      {
+        "cask": "krita",
+        "count": "809"
+      }
+    ],
+    "kroger-ascii": [
+      {
+        "cask": "kroger-ascii",
+        "count": "1"
+      }
+    ],
+    "krush": [
+      {
+        "cask": "krush",
+        "count": "4"
+      }
+    ],
+    "ksdiff": [
+      {
+        "cask": "ksdiff",
+        "count": "117"
+      }
+    ],
+    "kstars": [
+      {
+        "cask": "kstars",
+        "count": "25"
+      }
+    ],
+    "kubar": [
+      {
+        "cask": "kubar",
+        "count": "2"
+      }
+    ],
+    "kube-cluster": [
+      {
+        "cask": "kube-cluster",
+        "count": "9"
+      }
+    ],
+    "kube-forwarder": [
+      {
+        "cask": "kube-forwarder",
+        "count": "204"
+      }
+    ],
+    "kubecontext": [
+      {
+        "cask": "kubecontext",
+        "count": "115"
+      }
+    ],
+    "kubedog": [
+      {
+        "cask": "kubedog",
+        "count": "1"
+      }
+    ],
+    "kubenav": [
+      {
+        "cask": "kubenav",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.11.3": [
+      {
+        "cask": "kubernetes-cli-1.11.3",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.0": [
+      {
+        "cask": "kubernetes-cli-1.13.0",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.12": [
+      {
+        "cask": "kubernetes-cli-1.13.12",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.13.6": [
+      {
+        "cask": "kubernetes-cli-1.13.6",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.14.6": [
+      {
+        "cask": "kubernetes-cli-1.14.6",
+        "count": "3"
+      }
+    ],
+    "kubernetes-cli-1.15.11": [
+      {
+        "cask": "kubernetes-cli-1.15.11",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.16.3": [
+      {
+        "cask": "kubernetes-cli-1.16.3",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.16.6": [
+      {
+        "cask": "kubernetes-cli-1.16.6",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.16.8": [
+      {
+        "cask": "kubernetes-cli-1.16.8",
+        "count": "1"
+      }
+    ],
+    "kubernetes-cli-1.17.0": [
+      {
+        "cask": "kubernetes-cli-1.17.0",
+        "count": "2"
+      }
+    ],
+    "kubernetes-cli-1.17.4": [
+      {
+        "cask": "kubernetes-cli-1.17.4",
+        "count": "1"
+      }
+    ],
+    "kubernetic": [
+      {
+        "cask": "kubernetic",
+        "count": "204"
+      }
+    ],
+    "kugoumusic": [
+      {
+        "cask": "kugoumusic",
+        "count": "55"
+      }
+    ],
+    "kvirc": [
+      {
+        "cask": "kvirc",
+        "count": "32"
+      }
+    ],
+    "kyocera-printer-drivers": [
+      {
+        "cask": "kyocera-printer-drivers",
+        "count": "1"
+      }
+    ],
+    "lab": [
+      {
+        "cask": "lab",
+        "count": "15"
+      }
+    ],
+    "labelme": [
+      {
+        "cask": "labelme",
+        "count": "173"
+      }
+    ],
+    "lacie-network-assistant": [
+      {
+        "cask": "lacie-network-assistant",
+        "count": "1"
+      }
+    ],
+    "lacona": [
+      {
+        "cask": "lacona",
+        "count": "24"
+      }
+    ],
+    "ladiomanager": [
+      {
+        "cask": "ladiomanager",
+        "count": "1"
+      }
+    ],
+    "lando": [
+      {
+        "cask": "lando",
+        "count": "741"
+      }
+    ],
+    "lantern": [
+      {
+        "cask": "lantern",
+        "count": "130"
+      }
+    ],
+    "laravel-kit": [
+      {
+        "cask": "laravel-kit",
+        "count": "38"
+      }
+    ],
+    "lark": [
+      {
+        "cask": "lark",
+        "count": "79"
+      }
+    ],
+    "lastfm": [
+      {
+        "cask": "lastfm",
+        "count": "86"
+      }
+    ],
+    "lastpass": [
+      {
+        "cask": "lastpass",
+        "count": "1,838"
+      }
+    ],
+    "latest": [
+      {
+        "cask": "latest",
+        "count": "164"
+      }
+    ],
+    "latexdraw": [
+      {
+        "cask": "latexdraw",
+        "count": "53"
+      }
+    ],
+    "latexit": [
+      {
+        "cask": "latexit",
+        "count": "718"
+      }
+    ],
+    "launchbar": [
+      {
+        "cask": "launchbar",
+        "count": "220"
+      }
+    ],
+    "launchcontrol": [
+      {
+        "cask": "launchcontrol",
+        "count": "858"
+      }
+    ],
+    "launchpad-manager": [
+      {
+        "cask": "launchpad-manager",
+        "count": "88"
+      }
+    ],
+    "launchrocket": [
+      {
+        "cask": "launchrocket",
+        "count": "1,021"
+      }
+    ],
+    "launchy": [
+      {
+        "cask": "launchy",
+        "count": "13"
+      }
+    ],
+    "laverna": [
+      {
+        "cask": "laverna",
+        "count": "18"
+      }
+    ],
+    "lazarus": [
+      {
+        "cask": "lazarus",
+        "count": "148"
+      }
+    ],
+    "lazpaint": [
+      {
+        "cask": "lazpaint",
+        "count": "33"
+      }
+    ],
+    "lazy": [
+      {
+        "cask": "lazy",
+        "count": "8"
+      }
+    ],
+    "lbry": [
+      {
+        "cask": "lbry",
+        "count": "63"
+      }
+    ],
+    "league-displays": [
+      {
+        "cask": "league-displays",
+        "count": "3"
+      }
+    ],
+    "league-of-legends": [
+      {
+        "cask": "league-of-legends",
+        "count": "521"
+      }
+    ],
+    "leanote": [
+      {
+        "cask": "leanote",
+        "count": "21"
+      }
+    ],
+    "leap-motion": [
+      {
+        "cask": "leap-motion",
+        "count": "14"
+      }
+    ],
+    "ledger-live": [
+      {
+        "cask": "ledger-live",
+        "count": "241"
+      }
+    ],
+    "leech": [
+      {
+        "cask": "leech",
+        "count": "14"
+      }
+    ],
+    "lego-digital-designer": [
+      {
+        "cask": "lego-digital-designer",
+        "count": "23"
+      }
+    ],
+    "lego-mindstorms-ev3": [
+      {
+        "cask": "lego-mindstorms-ev3",
+        "count": "54"
+      }
+    ],
+    "lehreroffice": [
+      {
+        "cask": "lehreroffice",
+        "count": "4"
+      }
+    ],
+    "leksah": [
+      {
+        "cask": "leksah",
+        "count": "16"
+      }
+    ],
+    "lektor": [
+      {
+        "cask": "lektor",
+        "count": "13"
+      }
+    ],
+    "lelivrescolairefr": [
+      {
+        "cask": "lelivrescolairefr",
+        "count": "2"
+      }
+    ],
+    "lens": [
+      {
+        "cask": "lens",
+        "count": "599"
+      }
+    ],
+    "leocad": [
+      {
+        "cask": "leocad",
+        "count": "22"
+      }
+    ],
+    "lepton": [
+      {
+        "cask": "lepton",
+        "count": "549"
+      }
+    ],
+    "lets-view": [
+      {
+        "cask": "lets-view",
+        "count": "1"
+      }
+    ],
+    "letsview": [
+      {
+        "cask": "letsview",
+        "count": "4"
+      }
+    ],
+    "levelator": [
+      {
+        "cask": "levelator",
+        "count": "8"
+      }
+    ],
+    "lg-onscreen-control": [
+      {
+        "cask": "lg-onscreen-control",
+        "count": "63"
+      }
+    ],
+    "liberica-jdk11": [
+      {
+        "cask": "liberica-jdk11",
+        "count": "24"
+      }
+    ],
+    "liberica-jdk11-full": [
+      {
+        "cask": "liberica-jdk11-full",
+        "count": "19"
+      }
+    ],
+    "liberica-jdk11-lite": [
+      {
+        "cask": "liberica-jdk11-lite",
+        "count": "2"
+      }
+    ],
+    "liberica-jdk12": [
+      {
+        "cask": "liberica-jdk12",
+        "count": "5"
+      }
+    ],
+    "liberica-jdk12-lite": [
+      {
+        "cask": "liberica-jdk12-lite",
+        "count": "1"
+      }
+    ],
+    "liberica-jdk13": [
+      {
+        "cask": "liberica-jdk13",
+        "count": "14"
+      }
+    ],
+    "liberica-jdk13-full": [
+      {
+        "cask": "liberica-jdk13-full",
+        "count": "9"
+      }
+    ],
+    "liberica-jdk13-lite": [
+      {
+        "cask": "liberica-jdk13-lite",
+        "count": "2"
+      }
+    ],
+    "liberica-jdk14": [
+      {
+        "cask": "liberica-jdk14",
+        "count": "19"
+      }
+    ],
+    "liberica-jdk14-full": [
+      {
+        "cask": "liberica-jdk14-full",
+        "count": "21"
+      }
+    ],
+    "liberica-jdk14-lite": [
+      {
+        "cask": "liberica-jdk14-lite",
+        "count": "3"
+      }
+    ],
+    "liberica-jdk8": [
+      {
+        "cask": "liberica-jdk8",
+        "count": "1,001"
+      }
+    ],
+    "liberica-jdk8-full": [
+      {
+        "cask": "liberica-jdk8-full",
+        "count": "455"
+      }
+    ],
+    "liberica-jre11": [
+      {
+        "cask": "liberica-jre11",
+        "count": "4"
+      }
+    ],
+    "liberica-jre11-full": [
+      {
+        "cask": "liberica-jre11-full",
+        "count": "3"
+      }
+    ],
+    "liberica-jre13": [
+      {
+        "cask": "liberica-jre13",
+        "count": "1"
+      }
+    ],
+    "liberica-jre13-full": [
+      {
+        "cask": "liberica-jre13-full",
+        "count": "3"
+      }
+    ],
+    "liberica-jre14": [
+      {
+        "cask": "liberica-jre14",
+        "count": "2"
+      }
+    ],
+    "liberica-jre14-full": [
+      {
+        "cask": "liberica-jre14-full",
+        "count": "2"
+      }
+    ],
+    "liberica-jre8": [
+      {
+        "cask": "liberica-jre8",
+        "count": "4"
+      }
+    ],
+    "liberica-jre8-full": [
+      {
+        "cask": "liberica-jre8-full",
+        "count": "8"
+      }
+    ],
+    "librecad": [
+      {
+        "cask": "librecad",
+        "count": "249"
+      }
+    ],
+    "libreelec-usb-sd-creator": [
+      {
+        "cask": "libreelec-usb-sd-creator",
+        "count": "24"
+      }
+    ],
+    "libreoffice": [
+      {
+        "cask": "libreoffice",
+        "count": "10,174"
+      }
+    ],
+    "libreoffice-language-pack": [
+      {
+        "cask": "libreoffice-language-pack",
+        "count": "1,315"
+      }
+    ],
+    "libreoffice-still": [
+      {
+        "cask": "libreoffice-still",
+        "count": "35"
+      }
+    ],
+    "libreofficeja": [
+      {
+        "cask": "libreofficeja",
+        "count": "3"
+      }
+    ],
+    "librepcb": [
+      {
+        "cask": "librepcb",
+        "count": "9"
+      }
+    ],
+    "licecap": [
+      {
+        "cask": "licecap",
+        "count": "1,296"
+      }
+    ],
+    "license-control-center": [
+      {
+        "cask": "license-control-center",
+        "count": "2"
+      }
+    ],
+    "licensed": [
+      {
+        "cask": "licensed",
+        "count": "5"
+      }
+    ],
+    "liclipse": [
+      {
+        "cask": "liclipse",
+        "count": "9"
+      }
+    ],
+    "lidarr": [
+      {
+        "cask": "lidarr",
+        "count": "21"
+      }
+    ],
+    "lifesize": [
+      {
+        "cask": "lifesize",
+        "count": "80"
+      }
+    ],
+    "lift-java": [
+      {
+        "cask": "lift-java",
+        "count": "1"
+      }
+    ],
+    "lightgallery": [
+      {
+        "cask": "lightgallery",
+        "count": "26"
+      }
+    ],
+    "lighting": [
+      {
+        "cask": "lighting",
+        "count": "11"
+      }
+    ],
+    "lightpaper": [
+      {
+        "cask": "lightpaper",
+        "count": "8"
+      }
+    ],
+    "lightproxy": [
+      {
+        "cask": "lightproxy",
+        "count": "21"
+      }
+    ],
+    "lighttable": [
+      {
+        "cask": "lighttable",
+        "count": "117"
+      }
+    ],
+    "lightworks": [
+      {
+        "cask": "lightworks",
+        "count": "65"
+      }
+    ],
+    "lijitest": [
+      {
+        "cask": "lijitest",
+        "count": "2"
+      }
+    ],
+    "lilypond": [
+      {
+        "cask": "lilypond",
+        "count": "106"
+      }
+    ],
+    "lilypond-dev": [
+      {
+        "cask": "lilypond-dev",
+        "count": "21"
+      }
+    ],
+    "lilypond-unofficial": [
+      {
+        "cask": "lilypond-unofficial",
+        "count": "3"
+      }
+    ],
+    "lilypond64": [
+      {
+        "cask": "lilypond64",
+        "count": "1"
+      }
+    ],
+    "limiter-no6": [
+      {
+        "cask": "limiter-no6",
+        "count": "2"
+      }
+    ],
+    "lincastor": [
+      {
+        "cask": "lincastor",
+        "count": "10"
+      }
+    ],
+    "line-bot-designer": [
+      {
+        "cask": "line-bot-designer",
+        "count": "5"
+      }
+    ],
+    "linear": [
+      {
+        "cask": "linear",
+        "count": "38"
+      }
+    ],
+    "linein": [
+      {
+        "cask": "linein",
+        "count": "71"
+      }
+    ],
+    "lingo": [
+      {
+        "cask": "lingo",
+        "count": "9"
+      }
+    ],
+    "lingon-x": [
+      {
+        "cask": "lingon-x",
+        "count": "185"
+      }
+    ],
+    "lingon-x5": [
+      {
+        "cask": "lingon-x5",
+        "count": "2"
+      }
+    ],
+    "linkliar": [
+      {
+        "cask": "linkliar",
+        "count": "123"
+      }
+    ],
+    "linphone": [
+      {
+        "cask": "linphone",
+        "count": "211"
+      }
+    ],
+    "lisanet-gimp": [
+      {
+        "cask": "lisanet-gimp",
+        "count": "12"
+      }
+    ],
+    "listen1": [
+      {
+        "cask": "listen1",
+        "count": "93"
+      }
+    ],
+    "litecoin": [
+      {
+        "cask": "litecoin",
+        "count": "9"
+      }
+    ],
+    "liteicon": [
+      {
+        "cask": "liteicon",
+        "count": "107"
+      }
+    ],
+    "liteide": [
+      {
+        "cask": "liteide",
+        "count": "134"
+      }
+    ],
+    "liteswitch-x": [
+      {
+        "cask": "liteswitch-x",
+        "count": "2"
+      }
+    ],
+    "little-snitch": [
+      {
+        "cask": "little-snitch",
+        "count": "1,251"
+      }
+    ],
+    "little-snitch-nightly": [
+      {
+        "cask": "little-snitch-nightly",
+        "count": "22"
+      }
+    ],
+    "littlesecrets": [
+      {
+        "cask": "littlesecrets",
+        "count": "4"
+      }
+    ],
+    "livechat": [
+      {
+        "cask": "livechat",
+        "count": "1"
+      }
+    ],
+    "livereload": [
+      {
+        "cask": "livereload",
+        "count": "34"
+      }
+    ],
+    "livetail": [
+      {
+        "cask": "livetail",
+        "count": "8"
+      }
+    ],
+    "liya": [
+      {
+        "cask": "liya",
+        "count": "11"
+      }
+    ],
+    "lmms": [
+      {
+        "cask": "lmms",
+        "count": "142"
+      }
+    ],
+    "lmsclients-squeezeplay": [
+      {
+        "cask": "lmsclients-squeezeplay",
+        "count": "6"
+      }
+    ],
+    "lnkd-ads-cli": [
+      {
+        "cask": "lnkd-ads-cli",
+        "count": "29,626"
+      }
+    ],
+    "lnkd-amf-cli": [
+      {
+        "cask": "lnkd-amf-cli",
+        "count": "17,710"
+      }
+    ],
+    "lnkd-amf-qualys": [
+      {
+        "cask": "lnkd-amf-qualys",
+        "count": "51,905"
+      }
+    ],
+    "lnkd-argos-tracert-cli": [
+      {
+        "cask": "lnkd-argos-tracert-cli",
+        "count": "29,902"
+      }
+    ],
+    "lnkd-arrow": [
+      {
+        "cask": "lnkd-arrow",
+        "count": "45,087"
+      }
+    ],
+    "lnkd-artifact-tools": [
+      {
+        "cask": "lnkd-artifact-tools",
+        "count": "30,315"
+      }
+    ],
+    "lnkd-ask-project-tools": [
+      {
+        "cask": "lnkd-ask-project-tools",
+        "count": "38,588"
+      }
+    ],
+    "lnkd-assembler-cli": [
+      {
+        "cask": "lnkd-assembler-cli",
+        "count": "33,628"
+      }
+    ],
+    "lnkd-assembler-rollback-cli": [
+      {
+        "cask": "lnkd-assembler-rollback-cli",
+        "count": "28,727"
+      }
+    ],
+    "lnkd-ats-admin-cli": [
+      {
+        "cask": "lnkd-ats-admin-cli",
+        "count": "30,952"
+      }
+    ],
+    "lnkd-ats-tools": [
+      {
+        "cask": "lnkd-ats-tools",
+        "count": "106,048"
+      }
+    ],
+    "lnkd-auto2to4": [
+      {
+        "cask": "lnkd-auto2to4",
+        "count": "30,135"
+      }
+    ],
+    "lnkd-autoalerts-cli": [
+      {
+        "cask": "lnkd-autoalerts-cli",
+        "count": "15,957"
+      }
+    ],
+    "lnkd-autoalerts-cli-go": [
+      {
+        "cask": "lnkd-autoalerts-cli-go",
+        "count": "29,156"
+      }
+    ],
+    "lnkd-autochangelog": [
+      {
+        "cask": "lnkd-autochangelog",
+        "count": "25,868"
+      }
+    ],
+    "lnkd-autometrics-index-cli": [
+      {
+        "cask": "lnkd-autometrics-index-cli",
+        "count": "39,672"
+      }
+    ],
+    "lnkd-autopilot": [
+      {
+        "cask": "lnkd-autopilot",
+        "count": "17,435"
+      }
+    ],
+    "lnkd-aws-tools": [
+      {
+        "cask": "lnkd-aws-tools",
+        "count": "17,498"
+      }
+    ],
+    "lnkd-az-imds-control": [
+      {
+        "cask": "lnkd-az-imds-control",
+        "count": "50,698"
+      }
+    ],
+    "lnkd-base": [
+      {
+        "cask": "lnkd-base",
+        "count": "69,640"
+      }
+    ],
+    "lnkd-bastion": [
+      {
+        "cask": "lnkd-bastion",
+        "count": "17,294"
+      }
+    ],
+    "lnkd-batman": [
+      {
+        "cask": "lnkd-batman",
+        "count": "17,339"
+      }
+    ],
+    "lnkd-bazel-wrapper": [
+      {
+        "cask": "lnkd-bazel-wrapper",
+        "count": "41,002"
+      }
+    ],
+    "lnkd-binary-cache": [
+      {
+        "cask": "lnkd-binary-cache",
+        "count": "30,463"
+      }
+    ],
+    "lnkd-bloodhound": [
+      {
+        "cask": "lnkd-bloodhound",
+        "count": "41,658"
+      }
+    ],
+    "lnkd-blueshift-grid-migration-cli": [
+      {
+        "cask": "lnkd-blueshift-grid-migration-cli",
+        "count": "32,487"
+      }
+    ],
+    "lnkd-brannigan": [
+      {
+        "cask": "lnkd-brannigan",
+        "count": "30,578"
+      }
+    ],
+    "lnkd-brooklin-tool": [
+      {
+        "cask": "lnkd-brooklin-tool",
+        "count": "88,229"
+      }
+    ],
+    "lnkd-caas-fleet": [
+      {
+        "cask": "lnkd-caas-fleet",
+        "count": "30,369"
+      }
+    ],
+    "lnkd-caas-tools": [
+      {
+        "cask": "lnkd-caas-tools",
+        "count": "67,219"
+      }
+    ],
+    "lnkd-cablein": [
+      {
+        "cask": "lnkd-cablein",
+        "count": "29,647"
+      }
+    ],
+    "lnkd-cachemanager-cli": [
+      {
+        "cask": "lnkd-cachemanager-cli",
+        "count": "32,953"
+      }
+    ],
+    "lnkd-cam-cli": [
+      {
+        "cask": "lnkd-cam-cli",
+        "count": "16,956"
+      }
+    ],
+    "lnkd-camels": [
+      {
+        "cask": "lnkd-camels",
+        "count": "17,598"
+      }
+    ],
+    "lnkd-ccdo": [
+      {
+        "cask": "lnkd-ccdo",
+        "count": "37,189"
+      }
+    ],
+    "lnkd-cfg2-commands": [
+      {
+        "cask": "lnkd-cfg2-commands",
+        "count": "62,914"
+      }
+    ],
+    "lnkd-chimp-cli": [
+      {
+        "cask": "lnkd-chimp-cli",
+        "count": "42,961"
+      }
+    ],
+    "lnkd-cia-utilities": [
+      {
+        "cask": "lnkd-cia-utilities",
+        "count": "16,751"
+      }
+    ],
+    "lnkd-cit": [
+      {
+        "cask": "lnkd-cit",
+        "count": "29,628"
+      }
+    ],
+    "lnkd-clean-staging": [
+      {
+        "cask": "lnkd-clean-staging",
+        "count": "23,607"
+      }
+    ],
+    "lnkd-cleanpython27": [
+      {
+        "cask": "lnkd-cleanpython27",
+        "count": "7,133"
+      }
+    ],
+    "lnkd-cleanpython35": [
+      {
+        "cask": "lnkd-cleanpython35",
+        "count": "7,113"
+      }
+    ],
+    "lnkd-cleanpython36": [
+      {
+        "cask": "lnkd-cleanpython36",
+        "count": "7,175"
+      }
+    ],
+    "lnkd-cleanpython37": [
+      {
+        "cask": "lnkd-cleanpython37",
+        "count": "12,376"
+      }
+    ],
+    "lnkd-cleanpython38": [
+      {
+        "cask": "lnkd-cleanpython38",
+        "count": "14,753"
+      }
+    ],
+    "lnkd-cli-bench": [
+      {
+        "cask": "lnkd-cli-bench",
+        "count": "29,012"
+      }
+    ],
+    "lnkd-clusterator-cli": [
+      {
+        "cask": "lnkd-clusterator-cli",
+        "count": "16,703"
+      }
+    ],
+    "lnkd-code-search-cli": [
+      {
+        "cask": "lnkd-code-search-cli",
+        "count": "38,674"
+      }
+    ],
+    "lnkd-codecoverage-tools": [
+      {
+        "cask": "lnkd-codecoverage-tools",
+        "count": "17,609"
+      }
+    ],
+    "lnkd-commerce-workflow-tool": [
+      {
+        "cask": "lnkd-commerce-workflow-tool",
+        "count": "17,328"
+      }
+    ],
+    "lnkd-compatibility-test-tool": [
+      {
+        "cask": "lnkd-compatibility-test-tool",
+        "count": "29,671"
+      }
+    ],
+    "lnkd-configure-app-runtime": [
+      {
+        "cask": "lnkd-configure-app-runtime",
+        "count": "17,559"
+      }
+    ],
+    "lnkd-content-sre-iris-dashboard-autogen": [
+      {
+        "cask": "lnkd-content-sre-iris-dashboard-autogen",
+        "count": "18,849"
+      }
+    ],
+    "lnkd-couch-tracker-cli": [
+      {
+        "cask": "lnkd-couch-tracker-cli",
+        "count": "18,088"
+      }
+    ],
+    "lnkd-couchbase-tools": [
+      {
+        "cask": "lnkd-couchbase-tools",
+        "count": "53,038"
+      }
+    ],
+    "lnkd-craem": [
+      {
+        "cask": "lnkd-craem",
+        "count": "31,241"
+      }
+    ],
+    "lnkd-crt-clis": [
+      {
+        "cask": "lnkd-crt-clis",
+        "count": "26,466"
+      }
+    ],
+    "lnkd-csm-pycli-test": [
+      {
+        "cask": "lnkd-csm-pycli-test",
+        "count": "15,096"
+      }
+    ],
+    "lnkd-curli": [
+      {
+        "cask": "lnkd-curli",
+        "count": "24,789"
+      }
+    ],
+    "lnkd-d2-config-cli": [
+      {
+        "cask": "lnkd-d2-config-cli",
+        "count": "34,516"
+      }
+    ],
+    "lnkd-d2-staging-cli": [
+      {
+        "cask": "lnkd-d2-staging-cli",
+        "count": "22,410"
+      }
+    ],
+    "lnkd-d2autotuner": [
+      {
+        "cask": "lnkd-d2autotuner",
+        "count": "27,666"
+      }
+    ],
+    "lnkd-dali-cli": [
+      {
+        "cask": "lnkd-dali-cli",
+        "count": "17,446"
+      }
+    ],
+    "lnkd-dash": [
+      {
+        "cask": "lnkd-dash",
+        "count": "17,091"
+      }
+    ],
+    "lnkd-dasre-tableau-insights-cli": [
+      {
+        "cask": "lnkd-dasre-tableau-insights-cli",
+        "count": "29,676"
+      }
+    ],
+    "lnkd-dasre-tools": [
+      {
+        "cask": "lnkd-dasre-tools",
+        "count": "31,463"
+      }
+    ],
+    "lnkd-data-derived": [
+      {
+        "cask": "lnkd-data-derived",
+        "count": "9,820"
+      }
+    ],
+    "lnkd-deadpool": [
+      {
+        "cask": "lnkd-deadpool",
+        "count": "17,626"
+      }
+    ],
+    "lnkd-debug-ssh": [
+      {
+        "cask": "lnkd-debug-ssh",
+        "count": "62,676"
+      }
+    ],
+    "lnkd-delta": [
+      {
+        "cask": "lnkd-delta",
+        "count": "18,035"
+      }
+    ],
+    "lnkd-dependency-test-cli": [
+      {
+        "cask": "lnkd-dependency-test-cli",
+        "count": "25,681"
+      }
+    ],
+    "lnkd-deployment-tools": [
+      {
+        "cask": "lnkd-deployment-tools",
+        "count": "57,795"
+      }
+    ],
+    "lnkd-diffoscope-cli": [
+      {
+        "cask": "lnkd-diffoscope-cli",
+        "count": "29,352"
+      }
+    ],
+    "lnkd-disre-cli-tools": [
+      {
+        "cask": "lnkd-disre-cli-tools",
+        "count": "30,016"
+      }
+    ],
+    "lnkd-docin-cli": [
+      {
+        "cask": "lnkd-docin-cli",
+        "count": "22,687"
+      }
+    ],
+    "lnkd-dss-cli": [
+      {
+        "cask": "lnkd-dss-cli",
+        "count": "17,746"
+      }
+    ],
+    "lnkd-dynamic-acl-tool": [
+      {
+        "cask": "lnkd-dynamic-acl-tool",
+        "count": "40,783"
+      }
+    ],
+    "lnkd-e2d": [
+      {
+        "cask": "lnkd-e2d",
+        "count": "30,528"
+      }
+    ],
+    "lnkd-e8-cli": [
+      {
+        "cask": "lnkd-e8-cli",
+        "count": "29,378"
+      }
+    ],
+    "lnkd-ecl": [
+      {
+        "cask": "lnkd-ecl",
+        "count": "599,383"
+      }
+    ],
+    "lnkd-eh": [
+      {
+        "cask": "lnkd-eh",
+        "count": "29,229"
+      }
+    ],
+    "lnkd-ehssh": [
+      {
+        "cask": "lnkd-ehssh",
+        "count": "30,520"
+      }
+    ],
+    "lnkd-ekg-cli": [
+      {
+        "cask": "lnkd-ekg-cli",
+        "count": "30,678"
+      }
+    ],
+    "lnkd-elkb-tools": [
+      {
+        "cask": "lnkd-elkb-tools",
+        "count": "17,315"
+      }
+    ],
+    "lnkd-encryption-tools": [
+      {
+        "cask": "lnkd-encryption-tools",
+        "count": "17,041"
+      }
+    ],
+    "lnkd-epsilon-cli": [
+      {
+        "cask": "lnkd-epsilon-cli",
+        "count": "18,124"
+      }
+    ],
+    "lnkd-ergo": [
+      {
+        "cask": "lnkd-ergo",
+        "count": "30,122"
+      }
+    ],
+    "lnkd-ers-new": [
+      {
+        "cask": "lnkd-ers-new",
+        "count": "17,211"
+      }
+    ],
+    "lnkd-espresso-storage-node-hooks": [
+      {
+        "cask": "lnkd-espresso-storage-node-hooks",
+        "count": "71,052"
+      }
+    ],
+    "lnkd-espresso-utilities": [
+      {
+        "cask": "lnkd-espresso-utilities",
+        "count": "89,091"
+      }
+    ],
+    "lnkd-et": [
+      {
+        "cask": "lnkd-et",
+        "count": "28,440"
+      }
+    ],
+    "lnkd-filtercall": [
+      {
+        "cask": "lnkd-filtercall",
+        "count": "46,991"
+      }
+    ],
+    "lnkd-flagship-bundle": [
+      {
+        "cask": "lnkd-flagship-bundle",
+        "count": "57,408"
+      }
+    ],
+    "lnkd-flashdisag-amf": [
+      {
+        "cask": "lnkd-flashdisag-amf",
+        "count": "30,646"
+      }
+    ],
+    "lnkd-flatc": [
+      {
+        "cask": "lnkd-flatc",
+        "count": "17,770"
+      }
+    ],
+    "lnkd-flood": [
+      {
+        "cask": "lnkd-flood",
+        "count": "17,028"
+      }
+    ],
+    "lnkd-fossor-li": [
+      {
+        "cask": "lnkd-fossor-li",
+        "count": "30,174"
+      }
+    ],
+    "lnkd-fua-cli": [
+      {
+        "cask": "lnkd-fua-cli",
+        "count": "16,419"
+      }
+    ],
+    "lnkd-gaas-client": [
+      {
+        "cask": "lnkd-gaas-client",
+        "count": "60,206"
+      }
+    ],
+    "lnkd-galene-index-cli": [
+      {
+        "cask": "lnkd-galene-index-cli",
+        "count": "35,906"
+      }
+    ],
+    "lnkd-get-oncall": [
+      {
+        "cask": "lnkd-get-oncall",
+        "count": "30,990"
+      }
+    ],
+    "lnkd-git-commands": [
+      {
+        "cask": "lnkd-git-commands",
+        "count": "76,195"
+      }
+    ],
+    "lnkd-git-submit": [
+      {
+        "cask": "lnkd-git-submit",
+        "count": "67,925"
+      }
+    ],
+    "lnkd-gnsops-tools": [
+      {
+        "cask": "lnkd-gnsops-tools",
+        "count": "39,722"
+      }
+    ],
+    "lnkd-go-log-replay": [
+      {
+        "cask": "lnkd-go-log-replay",
+        "count": "31,349"
+      }
+    ],
+    "lnkd-go-map": [
+      {
+        "cask": "lnkd-go-map",
+        "count": "17,784"
+      }
+    ],
+    "lnkd-go-redliner": [
+      {
+        "cask": "lnkd-go-redliner",
+        "count": "35,396"
+      }
+    ],
+    "lnkd-go-status": [
+      {
+        "cask": "lnkd-go-status",
+        "count": "42,201"
+      }
+    ],
+    "lnkd-gobblin-hooks": [
+      {
+        "cask": "lnkd-gobblin-hooks",
+        "count": "32,656"
+      }
+    ],
+    "lnkd-gobroke": [
+      {
+        "cask": "lnkd-gobroke",
+        "count": "43,802"
+      }
+    ],
+    "lnkd-gogo": [
+      {
+        "cask": "lnkd-gogo",
+        "count": "16,284"
+      }
+    ],
+    "lnkd-gradle-abtest-cli": [
+      {
+        "cask": "lnkd-gradle-abtest-cli",
+        "count": "26,575"
+      }
+    ],
+    "lnkd-hac-ai-tool": [
+      {
+        "cask": "lnkd-hac-ai-tool",
+        "count": "31,223"
+      }
+    ],
+    "lnkd-hadoop-cli": [
+      {
+        "cask": "lnkd-hadoop-cli",
+        "count": "22,242"
+      }
+    ],
+    "lnkd-harbor": [
+      {
+        "cask": "lnkd-harbor",
+        "count": "16,929"
+      }
+    ],
+    "lnkd-hardware-info": [
+      {
+        "cask": "lnkd-hardware-info",
+        "count": "30,524"
+      }
+    ],
+    "lnkd-hbfgradle": [
+      {
+        "cask": "lnkd-hbfgradle",
+        "count": "46,803"
+      }
+    ],
+    "lnkd-helios-cli": [
+      {
+        "cask": "lnkd-helios-cli",
+        "count": "30,223"
+      }
+    ],
+    "lnkd-helix-sre-tools": [
+      {
+        "cask": "lnkd-helix-sre-tools",
+        "count": "16,909"
+      }
+    ],
+    "lnkd-histogram": [
+      {
+        "cask": "lnkd-histogram",
+        "count": "17,116"
+      }
+    ],
+    "lnkd-hodor": [
+      {
+        "cask": "lnkd-hodor",
+        "count": "31,035"
+      }
+    ],
+    "lnkd-hong-kong": [
+      {
+        "cask": "lnkd-hong-kong",
+        "count": "31,406"
+      }
+    ],
+    "lnkd-host-information-tool-cli": [
+      {
+        "cask": "lnkd-host-information-tool-cli",
+        "count": "28,900"
+      }
+    ],
+    "lnkd-hosted-search-cli": [
+      {
+        "cask": "lnkd-hosted-search-cli",
+        "count": "45,586"
+      }
+    ],
+    "lnkd-hostli": [
+      {
+        "cask": "lnkd-hostli",
+        "count": "29,463"
+      }
+    ],
+    "lnkd-i18n-orphan": [
+      {
+        "cask": "lnkd-i18n-orphan",
+        "count": "16,290"
+      }
+    ],
+    "lnkd-id-tools": [
+      {
+        "cask": "lnkd-id-tools",
+        "count": "56,181"
+      }
+    ],
+    "lnkd-image-tool": [
+      {
+        "cask": "lnkd-image-tool",
+        "count": "99,464"
+      }
+    ],
+    "lnkd-informed-cli": [
+      {
+        "cask": "lnkd-informed-cli",
+        "count": "18,074"
+      }
+    ],
+    "lnkd-informed2-cli": [
+      {
+        "cask": "lnkd-informed2-cli",
+        "count": "40,558"
+      }
+    ],
+    "lnkd-ingraphs-cli": [
+      {
+        "cask": "lnkd-ingraphs-cli",
+        "count": "30,100"
+      }
+    ],
+    "lnkd-ingraphs-jinja": [
+      {
+        "cask": "lnkd-ingraphs-jinja",
+        "count": "30,480"
+      }
+    ],
+    "lnkd-inlogs-cli": [
+      {
+        "cask": "lnkd-inlogs-cli",
+        "count": "69,036"
+      }
+    ],
+    "lnkd-inmon-cli": [
+      {
+        "cask": "lnkd-inmon-cli",
+        "count": "16,494"
+      }
+    ],
+    "lnkd-inphone": [
+      {
+        "cask": "lnkd-inphone",
+        "count": "42,347"
+      }
+    ],
+    "lnkd-insearch-cli": [
+      {
+        "cask": "lnkd-insearch-cli",
+        "count": "30,323"
+      }
+    ],
+    "lnkd-inuse-cli": [
+      {
+        "cask": "lnkd-inuse-cli",
+        "count": "43,384"
+      }
+    ],
+    "lnkd-invincible-runner": [
+      {
+        "cask": "lnkd-invincible-runner",
+        "count": "31,455"
+      }
+    ],
+    "lnkd-invips-cli": [
+      {
+        "cask": "lnkd-invips-cli",
+        "count": "17,757"
+      }
+    ],
+    "lnkd-irresistible-force-cli": [
+      {
+        "cask": "lnkd-irresistible-force-cli",
+        "count": "33,971"
+      }
+    ],
+    "lnkd-java-11-zulu": [
+      {
+        "cask": "lnkd-java-11-zulu",
+        "count": "436"
+      }
+    ],
+    "lnkd-java-7u51": [
+      {
+        "cask": "lnkd-java-7u51",
+        "count": "11"
+      }
+    ],
+    "lnkd-java-8u121": [
+      {
+        "cask": "lnkd-java-8u121",
+        "count": "10"
+      }
+    ],
+    "lnkd-java-8u172": [
+      {
+        "cask": "lnkd-java-8u172",
+        "count": "21"
+      }
+    ],
+    "lnkd-java-8u172-zulu": [
+      {
+        "cask": "lnkd-java-8u172-zulu",
+        "count": "8"
+      }
+    ],
+    "lnkd-java-8u40": [
+      {
+        "cask": "lnkd-java-8u40",
+        "count": "10"
+      }
+    ],
+    "lnkd-java-8u5": [
+      {
+        "cask": "lnkd-java-8u5",
+        "count": "8"
+      }
+    ],
+    "lnkd-java-8u72": [
+      {
+        "cask": "lnkd-java-8u72",
+        "count": "9"
+      }
+    ],
+    "lnkd-java-cli-example": [
+      {
+        "cask": "lnkd-java-cli-example",
+        "count": "16,518"
+      }
+    ],
+    "lnkd-java-launcher": [
+      {
+        "cask": "lnkd-java-launcher",
+        "count": "26,643"
+      }
+    ],
+    "lnkd-java-sre-cli": [
+      {
+        "cask": "lnkd-java-sre-cli",
+        "count": "25,860"
+      }
+    ],
+    "lnkd-java-version-check": [
+      {
+        "cask": "lnkd-java-version-check",
+        "count": "16,708"
+      }
+    ],
+    "lnkd-jdk11u5-zulu": [
+      {
+        "cask": "lnkd-jdk11u5-zulu",
+        "count": "6"
+      }
+    ],
+    "lnkd-jeeves-cli": [
+      {
+        "cask": "lnkd-jeeves-cli",
+        "count": "36,996"
+      }
+    ],
+    "lnkd-jet-unminify-cli": [
+      {
+        "cask": "lnkd-jet-unminify-cli",
+        "count": "30,636"
+      }
+    ],
+    "lnkd-jit-acl-cli": [
+      {
+        "cask": "lnkd-jit-acl-cli",
+        "count": "30,472"
+      }
+    ],
+    "lnkd-jobs-tool": [
+      {
+        "cask": "lnkd-jobs-tool",
+        "count": "29,022"
+      }
+    ],
+    "lnkd-jpulse": [
+      {
+        "cask": "lnkd-jpulse",
+        "count": "31,391"
+      }
+    ],
+    "lnkd-jqtop": [
+      {
+        "cask": "lnkd-jqtop",
+        "count": "29,566"
+      }
+    ],
+    "lnkd-jstf": [
+      {
+        "cask": "lnkd-jstf",
+        "count": "36,138"
+      }
+    ],
+    "lnkd-just": [
+      {
+        "cask": "lnkd-just",
+        "count": "31,162"
+      }
+    ],
+    "lnkd-jvmtop-cli": [
+      {
+        "cask": "lnkd-jvmtop-cli",
+        "count": "17,727"
+      }
+    ],
+    "lnkd-kafka-tool": [
+      {
+        "cask": "lnkd-kafka-tool",
+        "count": "20,909"
+      }
+    ],
+    "lnkd-kcap": [
+      {
+        "cask": "lnkd-kcap",
+        "count": "16,430"
+      }
+    ],
+    "lnkd-keep-running": [
+      {
+        "cask": "lnkd-keep-running",
+        "count": "16,527"
+      }
+    ],
+    "lnkd-kevin-cli": [
+      {
+        "cask": "lnkd-kevin-cli",
+        "count": "16,949"
+      }
+    ],
+    "lnkd-kms-cli": [
+      {
+        "cask": "lnkd-kms-cli",
+        "count": "67,999"
+      }
+    ],
+    "lnkd-ksre-tool": [
+      {
+        "cask": "lnkd-ksre-tool",
+        "count": "16,918"
+      }
+    ],
+    "lnkd-ktool": [
+      {
+        "cask": "lnkd-ktool",
+        "count": "42,327"
+      }
+    ],
+    "lnkd-labservice-tools": [
+      {
+        "cask": "lnkd-labservice-tools",
+        "count": "104,655"
+      }
+    ],
+    "lnkd-learning-sre-tools": [
+      {
+        "cask": "lnkd-learning-sre-tools",
+        "count": "15,752"
+      }
+    ],
+    "lnkd-li-idea": [
+      {
+        "cask": "lnkd-li-idea",
+        "count": "1,278"
+      }
+    ],
+    "lnkd-lid-host-history": [
+      {
+        "cask": "lnkd-lid-host-history",
+        "count": "31,242"
+      }
+    ],
+    "lnkd-lid-image-runner": [
+      {
+        "cask": "lnkd-lid-image-runner",
+        "count": "32,461"
+      }
+    ],
+    "lnkd-lid-runner": [
+      {
+        "cask": "lnkd-lid-runner",
+        "count": "29,112"
+      }
+    ],
+    "lnkd-lid-server-cli": [
+      {
+        "cask": "lnkd-lid-server-cli",
+        "count": "33,040"
+      }
+    ],
+    "lnkd-ligradle": [
+      {
+        "cask": "lnkd-ligradle",
+        "count": "33,409"
+      }
+    ],
+    "lnkd-lintellijps-cli": [
+      {
+        "cask": "lnkd-lintellijps-cli",
+        "count": "29,519"
+      }
+    ],
+    "lnkd-lintli-cli": [
+      {
+        "cask": "lnkd-lintli-cli",
+        "count": "56,476"
+      }
+    ],
+    "lnkd-lipy-followfeed": [
+      {
+        "cask": "lnkd-lipy-followfeed",
+        "count": "40,672"
+      }
+    ],
+    "lnkd-lipy-javaformat-app": [
+      {
+        "cask": "lnkd-lipy-javaformat-app",
+        "count": "16,602"
+      }
+    ],
+    "lnkd-lipy-kubectl": [
+      {
+        "cask": "lnkd-lipy-kubectl",
+        "count": "36,838"
+      }
+    ],
+    "lnkd-lipy-mdc": [
+      {
+        "cask": "lnkd-lipy-mdc",
+        "count": "39,701"
+      }
+    ],
+    "lnkd-lipy-pd-aggregator-app": [
+      {
+        "cask": "lnkd-lipy-pd-aggregator-app",
+        "count": "26,818"
+      }
+    ],
+    "lnkd-lipy-ranking-benchmark": [
+      {
+        "cask": "lnkd-lipy-ranking-benchmark",
+        "count": "17,769"
+      }
+    ],
+    "lnkd-lipy-security-scanner-app": [
+      {
+        "cask": "lnkd-lipy-security-scanner-app",
+        "count": "17,686"
+      }
+    ],
+    "lnkd-lipy-sourcecount-app": [
+      {
+        "cask": "lnkd-lipy-sourcecount-app",
+        "count": "16,374"
+      }
+    ],
+    "lnkd-lipy-uberlint": [
+      {
+        "cask": "lnkd-lipy-uberlint",
+        "count": "31,184"
+      }
+    ],
+    "lnkd-lipy-whatami-cli": [
+      {
+        "cask": "lnkd-lipy-whatami-cli",
+        "count": "18,061"
+      }
+    ],
+    "lnkd-lix-cli": [
+      {
+        "cask": "lnkd-lix-cli",
+        "count": "29,195"
+      }
+    ],
+    "lnkd-lls-cp-cli": [
+      {
+        "cask": "lnkd-lls-cp-cli",
+        "count": "32,791"
+      }
+    ],
+    "lnkd-lms-productivity-analysis-tools": [
+      {
+        "cask": "lnkd-lms-productivity-analysis-tools",
+        "count": "31,479"
+      }
+    ],
+    "lnkd-locker-cli": [
+      {
+        "cask": "lnkd-locker-cli",
+        "count": "39,057"
+      }
+    ],
+    "lnkd-lodgeit-cli": [
+      {
+        "cask": "lnkd-lodgeit-cli",
+        "count": "17,215"
+      }
+    ],
+    "lnkd-log-analyze": [
+      {
+        "cask": "lnkd-log-analyze",
+        "count": "30,208"
+      }
+    ],
+    "lnkd-logli": [
+      {
+        "cask": "lnkd-logli",
+        "count": "27,563"
+      }
+    ],
+    "lnkd-lps-cli": [
+      {
+        "cask": "lnkd-lps-cli",
+        "count": "53,304"
+      }
+    ],
+    "lnkd-luigi-cli": [
+      {
+        "cask": "lnkd-luigi-cli",
+        "count": "30,274"
+      }
+    ],
+    "lnkd-maestro-cli": [
+      {
+        "cask": "lnkd-maestro-cli",
+        "count": "54,083"
+      }
+    ],
+    "lnkd-manage-ssh": [
+      {
+        "cask": "lnkd-manage-ssh",
+        "count": "100,391"
+      }
+    ],
+    "lnkd-manifold": [
+      {
+        "cask": "lnkd-manifold",
+        "count": "31,487"
+      }
+    ],
+    "lnkd-media-tools": [
+      {
+        "cask": "lnkd-media-tools",
+        "count": "65,177"
+      }
+    ],
+    "lnkd-member-id-obftable-gen": [
+      {
+        "cask": "lnkd-member-id-obftable-gen",
+        "count": "30,328"
+      }
+    ],
+    "lnkd-member-restriction-benchmark": [
+      {
+        "cask": "lnkd-member-restriction-benchmark",
+        "count": "18,262"
+      }
+    ],
+    "lnkd-messaging-dev-tools": [
+      {
+        "cask": "lnkd-messaging-dev-tools",
+        "count": "17,199"
+      }
+    ],
+    "lnkd-metal-cli": [
+      {
+        "cask": "lnkd-metal-cli",
+        "count": "34,477"
+      }
+    ],
+    "lnkd-metget": [
+      {
+        "cask": "lnkd-metget",
+        "count": "16,834"
+      }
+    ],
+    "lnkd-metrics-client": [
+      {
+        "cask": "lnkd-metrics-client",
+        "count": "27,189"
+      }
+    ],
+    "lnkd-metrics-validator": [
+      {
+        "cask": "lnkd-metrics-validator",
+        "count": "46,875"
+      }
+    ],
+    "lnkd-midgard-utils": [
+      {
+        "cask": "lnkd-midgard-utils",
+        "count": "29,764"
+      }
+    ],
+    "lnkd-min": [
+      {
+        "cask": "lnkd-min",
+        "count": "31,283"
+      }
+    ],
+    "lnkd-mint": [
+      {
+        "cask": "lnkd-mint",
+        "count": "52,460"
+      }
+    ],
+    "lnkd-mint-integration": [
+      {
+        "cask": "lnkd-mint-integration",
+        "count": "18,395"
+      }
+    ],
+    "lnkd-model-creation-tool": [
+      {
+        "cask": "lnkd-model-creation-tool",
+        "count": "49,491"
+      }
+    ],
+    "lnkd-mp-maker": [
+      {
+        "cask": "lnkd-mp-maker",
+        "count": "35,348"
+      }
+    ],
+    "lnkd-mri": [
+      {
+        "cask": "lnkd-mri",
+        "count": "30,537"
+      }
+    ],
+    "lnkd-mysql-backup": [
+      {
+        "cask": "lnkd-mysql-backup",
+        "count": "18,109"
+      }
+    ],
+    "lnkd-mysqlmon-control": [
+      {
+        "cask": "lnkd-mysqlmon-control",
+        "count": "69,845"
+      }
+    ],
+    "lnkd-neo-builder": [
+      {
+        "cask": "lnkd-neo-builder",
+        "count": "55,993"
+      }
+    ],
+    "lnkd-neo-decom": [
+      {
+        "cask": "lnkd-neo-decom",
+        "count": "30,240"
+      }
+    ],
+    "lnkd-neo-silencer": [
+      {
+        "cask": "lnkd-neo-silencer",
+        "count": "17,092"
+      }
+    ],
+    "lnkd-norbert-cli": [
+      {
+        "cask": "lnkd-norbert-cli",
+        "count": "30,921"
+      }
+    ],
+    "lnkd-notgot": [
+      {
+        "cask": "lnkd-notgot",
+        "count": "27,091"
+      }
+    ],
+    "lnkd-nuage-auto-tools": [
+      {
+        "cask": "lnkd-nuage-auto-tools",
+        "count": "17,066"
+      }
+    ],
+    "lnkd-nurse-cli": [
+      {
+        "cask": "lnkd-nurse-cli",
+        "count": "17,890"
+      }
+    ],
+    "lnkd-odp": [
+      {
+        "cask": "lnkd-odp",
+        "count": "28,372"
+      }
+    ],
+    "lnkd-oncall-cli": [
+      {
+        "cask": "lnkd-oncall-cli",
+        "count": "17,784"
+      }
+    ],
+    "lnkd-oncall-custom-shifts": [
+      {
+        "cask": "lnkd-oncall-custom-shifts",
+        "count": "18,040"
+      }
+    ],
+    "lnkd-ondemand-sflow": [
+      {
+        "cask": "lnkd-ondemand-sflow",
+        "count": "18,159"
+      }
+    ],
+    "lnkd-oops": [
+      {
+        "cask": "lnkd-oops",
+        "count": "30,207"
+      }
+    ],
+    "lnkd-oracle-compliance-check": [
+      {
+        "cask": "lnkd-oracle-compliance-check",
+        "count": "25,368"
+      }
+    ],
+    "lnkd-orca-cli": [
+      {
+        "cask": "lnkd-orca-cli",
+        "count": "63,918"
+      }
+    ],
+    "lnkd-p4p-espresso": [
+      {
+        "cask": "lnkd-p4p-espresso",
+        "count": "33,442"
+      }
+    ],
+    "lnkd-p4p-jmx": [
+      {
+        "cask": "lnkd-p4p-jmx",
+        "count": "64,234"
+      }
+    ],
+    "lnkd-p4p-logrep": [
+      {
+        "cask": "lnkd-p4p-logrep",
+        "count": "42,774"
+      }
+    ],
+    "lnkd-p4p-oncall": [
+      {
+        "cask": "lnkd-p4p-oncall",
+        "count": "36,862"
+      }
+    ],
+    "lnkd-p4p-restli": [
+      {
+        "cask": "lnkd-p4p-restli",
+        "count": "49,228"
+      }
+    ],
+    "lnkd-parsein": [
+      {
+        "cask": "lnkd-parsein",
+        "count": "30,531"
+      }
+    ],
+    "lnkd-pem-cli": [
+      {
+        "cask": "lnkd-pem-cli",
+        "count": "34,073"
+      }
+    ],
+    "lnkd-perf-runner": [
+      {
+        "cask": "lnkd-perf-runner",
+        "count": "17,218"
+      }
+    ],
+    "lnkd-perseustool": [
+      {
+        "cask": "lnkd-perseustool",
+        "count": "74,710"
+      }
+    ],
+    "lnkd-pexcacheclean": [
+      {
+        "cask": "lnkd-pexcacheclean",
+        "count": "30,228"
+      }
+    ],
+    "lnkd-pillar-review-tool": [
+      {
+        "cask": "lnkd-pillar-review-tool",
+        "count": "69,151"
+      }
+    ],
+    "lnkd-pinot-utils": [
+      {
+        "cask": "lnkd-pinot-utils",
+        "count": "32,458"
+      }
+    ],
+    "lnkd-platform-sre-tools": [
+      {
+        "cask": "lnkd-platform-sre-tools",
+        "count": "22,294"
+      }
+    ],
+    "lnkd-pmu-cli": [
+      {
+        "cask": "lnkd-pmu-cli",
+        "count": "24,229"
+      }
+    ],
+    "lnkd-pop-buildout-tools": [
+      {
+        "cask": "lnkd-pop-buildout-tools",
+        "count": "31,528"
+      }
+    ],
+    "lnkd-pq-batch-cli": [
+      {
+        "cask": "lnkd-pq-batch-cli",
+        "count": "29,586"
+      }
+    ],
+    "lnkd-production-cli": [
+      {
+        "cask": "lnkd-production-cli",
+        "count": "29,769"
+      }
+    ],
+    "lnkd-prom-devices": [
+      {
+        "cask": "lnkd-prom-devices",
+        "count": "18,140"
+      }
+    ],
+    "lnkd-pylene-cli": [
+      {
+        "cask": "lnkd-pylene-cli",
+        "count": "128,957"
+      }
+    ],
+    "lnkd-python-dependency-inspector": [
+      {
+        "cask": "lnkd-python-dependency-inspector",
+        "count": "16,400"
+      }
+    ],
+    "lnkd-pyusage": [
+      {
+        "cask": "lnkd-pyusage",
+        "count": "29,302"
+      }
+    ],
+    "lnkd-qdt-cli": [
+      {
+        "cask": "lnkd-qdt-cli",
+        "count": "29,709"
+      }
+    ],
+    "lnkd-qei-cli": [
+      {
+        "cask": "lnkd-qei-cli",
+        "count": "16,628"
+      }
+    ],
+    "lnkd-querylog-parser": [
+      {
+        "cask": "lnkd-querylog-parser",
+        "count": "19,202"
+      }
+    ],
+    "lnkd-quotas": [
+      {
+        "cask": "lnkd-quotas",
+        "count": "31,409"
+      }
+    ],
+    "lnkd-race-cli": [
+      {
+        "cask": "lnkd-race-cli",
+        "count": "17,693"
+      }
+    ],
+    "lnkd-race-marshal-cli": [
+      {
+        "cask": "lnkd-race-marshal-cli",
+        "count": "17,820"
+      }
+    ],
+    "lnkd-rack-check-cli": [
+      {
+        "cask": "lnkd-rack-check-cli",
+        "count": "29,999"
+      }
+    ],
+    "lnkd-rain-adoption-utils": [
+      {
+        "cask": "lnkd-rain-adoption-utils",
+        "count": "17,780"
+      }
+    ],
+    "lnkd-rain-agent": [
+      {
+        "cask": "lnkd-rain-agent",
+        "count": "29,948"
+      }
+    ],
+    "lnkd-rain-cli": [
+      {
+        "cask": "lnkd-rain-cli",
+        "count": "69,323"
+      }
+    ],
+    "lnkd-rain-free": [
+      {
+        "cask": "lnkd-rain-free",
+        "count": "40,690"
+      }
+    ],
+    "lnkd-rainicorn": [
+      {
+        "cask": "lnkd-rainicorn",
+        "count": "18,742"
+      }
+    ],
+    "lnkd-rate-my-build": [
+      {
+        "cask": "lnkd-rate-my-build",
+        "count": "65,654"
+      }
+    ],
+    "lnkd-rb-cli": [
+      {
+        "cask": "lnkd-rb-cli",
+        "count": "27,692"
+      }
+    ],
+    "lnkd-rb-status": [
+      {
+        "cask": "lnkd-rb-status",
+        "count": "15,810"
+      }
+    ],
+    "lnkd-rdev-cli": [
+      {
+        "cask": "lnkd-rdev-cli",
+        "count": "78,725"
+      }
+    ],
+    "lnkd-rdt": [
+      {
+        "cask": "lnkd-rdt",
+        "count": "30,508"
+      }
+    ],
+    "lnkd-redliner-checks": [
+      {
+        "cask": "lnkd-redliner-checks",
+        "count": "52,512"
+      }
+    ],
+    "lnkd-redliner-cli": [
+      {
+        "cask": "lnkd-redliner-cli",
+        "count": "45,195"
+      }
+    ],
+    "lnkd-roomcheck": [
+      {
+        "cask": "lnkd-roomcheck",
+        "count": "26,875"
+      }
+    ],
+    "lnkd-rover-cli": [
+      {
+        "cask": "lnkd-rover-cli",
+        "count": "30,018"
+      }
+    ],
+    "lnkd-samples": [
+      {
+        "cask": "lnkd-samples",
+        "count": "31,558"
+      }
+    ],
+    "lnkd-samza-build-cli": [
+      {
+        "cask": "lnkd-samza-build-cli",
+        "count": "25,451"
+      }
+    ],
+    "lnkd-samza-hacks-cli": [
+      {
+        "cask": "lnkd-samza-hacks-cli",
+        "count": "17,235"
+      }
+    ],
+    "lnkd-samza-nurse-cli": [
+      {
+        "cask": "lnkd-samza-nurse-cli",
+        "count": "30,836"
+      }
+    ],
+    "lnkd-samza-sql-shell": [
+      {
+        "cask": "lnkd-samza-sql-shell",
+        "count": "25,720"
+      }
+    ],
+    "lnkd-samza-tool": [
+      {
+        "cask": "lnkd-samza-tool",
+        "count": "39,452"
+      }
+    ],
+    "lnkd-samza-tools": [
+      {
+        "cask": "lnkd-samza-tools",
+        "count": "54,185"
+      }
+    ],
+    "lnkd-sar-collector": [
+      {
+        "cask": "lnkd-sar-collector",
+        "count": "30,660"
+      }
+    ],
+    "lnkd-search-cloud-cli": [
+      {
+        "cask": "lnkd-search-cloud-cli",
+        "count": "65,888"
+      }
+    ],
+    "lnkd-search-sre-tools": [
+      {
+        "cask": "lnkd-search-sre-tools",
+        "count": "17,828"
+      }
+    ],
+    "lnkd-seas-logfilter": [
+      {
+        "cask": "lnkd-seas-logfilter",
+        "count": "38,450"
+      }
+    ],
+    "lnkd-secsre-tools": [
+      {
+        "cask": "lnkd-secsre-tools",
+        "count": "16,546"
+      }
+    ],
+    "lnkd-shrimp-cli": [
+      {
+        "cask": "lnkd-shrimp-cli",
+        "count": "30,548"
+      }
+    ],
+    "lnkd-shuffle-cli": [
+      {
+        "cask": "lnkd-shuffle-cli",
+        "count": "18,127"
+      }
+    ],
+    "lnkd-si-ops-tools": [
+      {
+        "cask": "lnkd-si-ops-tools",
+        "count": "26,487"
+      }
+    ],
+    "lnkd-sideload-cli": [
+      {
+        "cask": "lnkd-sideload-cli",
+        "count": "14,298"
+      }
+    ],
+    "lnkd-simple-ingraphs": [
+      {
+        "cask": "lnkd-simple-ingraphs",
+        "count": "79,660"
+      }
+    ],
+    "lnkd-singlemaster": [
+      {
+        "cask": "lnkd-singlemaster",
+        "count": "17,252"
+      }
+    ],
+    "lnkd-snapdragon": [
+      {
+        "cask": "lnkd-snapdragon",
+        "count": "31,548"
+      }
+    ],
+    "lnkd-snapshot-service-worker-hooks": [
+      {
+        "cask": "lnkd-snapshot-service-worker-hooks",
+        "count": "42,966"
+      }
+    ],
+    "lnkd-sos-cli": [
+      {
+        "cask": "lnkd-sos-cli",
+        "count": "31,642"
+      }
+    ],
+    "lnkd-spark-notebook": [
+      {
+        "cask": "lnkd-spark-notebook",
+        "count": "30,872"
+      }
+    ],
+    "lnkd-sparkjoy-cli": [
+      {
+        "cask": "lnkd-sparkjoy-cli",
+        "count": "41,452"
+      }
+    ],
+    "lnkd-srd-cli": [
+      {
+        "cask": "lnkd-srd-cli",
+        "count": "24,808"
+      }
+    ],
+    "lnkd-sre-cli": [
+      {
+        "cask": "lnkd-sre-cli",
+        "count": "40,936"
+      }
+    ],
+    "lnkd-sre-decom": [
+      {
+        "cask": "lnkd-sre-decom",
+        "count": "30,342"
+      }
+    ],
+    "lnkd-sre-gc-report": [
+      {
+        "cask": "lnkd-sre-gc-report",
+        "count": "17,251"
+      }
+    ],
+    "lnkd-ssh-ca-cli": [
+      {
+        "cask": "lnkd-ssh-ca-cli",
+        "count": "95,609"
+      }
+    ],
+    "lnkd-ssh-range": [
+      {
+        "cask": "lnkd-ssh-range",
+        "count": "40,907"
+      }
+    ],
+    "lnkd-st-dashboard-cli": [
+      {
+        "cask": "lnkd-st-dashboard-cli",
+        "count": "31,715"
+      }
+    ],
+    "lnkd-stickyrouting-ops": [
+      {
+        "cask": "lnkd-stickyrouting-ops",
+        "count": "22,258"
+      }
+    ],
+    "lnkd-svin": [
+      {
+        "cask": "lnkd-svin",
+        "count": "34,347"
+      }
+    ],
+    "lnkd-svn2git": [
+      {
+        "cask": "lnkd-svn2git",
+        "count": "45,083"
+      }
+    ],
+    "lnkd-tabby-mctabface": [
+      {
+        "cask": "lnkd-tabby-mctabface",
+        "count": "15,833"
+      }
+    ],
+    "lnkd-tail-metrics": [
+      {
+        "cask": "lnkd-tail-metrics",
+        "count": "17,692"
+      }
+    ],
+    "lnkd-test-cli": [
+      {
+        "cask": "lnkd-test-cli",
+        "count": "29,215"
+      }
+    ],
+    "lnkd-thin-archive": [
+      {
+        "cask": "lnkd-thin-archive",
+        "count": "17,330"
+      }
+    ],
+    "lnkd-tjacker": [
+      {
+        "cask": "lnkd-tjacker",
+        "count": "17,240"
+      }
+    ],
+    "lnkd-tm2-execution-engine": [
+      {
+        "cask": "lnkd-tm2-execution-engine",
+        "count": "47,187"
+      }
+    ],
+    "lnkd-tms-cli": [
+      {
+        "cask": "lnkd-tms-cli",
+        "count": "64,432"
+      }
+    ],
+    "lnkd-tools-slo": [
+      {
+        "cask": "lnkd-tools-slo",
+        "count": "29,529"
+      }
+    ],
+    "lnkd-tor1up-cli": [
+      {
+        "cask": "lnkd-tor1up-cli",
+        "count": "38,863"
+      }
+    ],
+    "lnkd-track-tools-cli": [
+      {
+        "cask": "lnkd-track-tools-cli",
+        "count": "22,720"
+      }
+    ],
+    "lnkd-traffic-remap-builder": [
+      {
+        "cask": "lnkd-traffic-remap-builder",
+        "count": "56,703"
+      }
+    ],
+    "lnkd-trigger-build": [
+      {
+        "cask": "lnkd-trigger-build",
+        "count": "29,926"
+      }
+    ],
+    "lnkd-trjson": [
+      {
+        "cask": "lnkd-trjson",
+        "count": "16,516"
+      }
+    ],
+    "lnkd-umbrella": [
+      {
+        "cask": "lnkd-umbrella",
+        "count": "29,932"
+      }
+    ],
+    "lnkd-ump-tool": [
+      {
+        "cask": "lnkd-ump-tool",
+        "count": "31,248"
+      }
+    ],
+    "lnkd-uss-azure-cli": [
+      {
+        "cask": "lnkd-uss-azure-cli",
+        "count": "38,771"
+      }
+    ],
+    "lnkd-validate-range-yaml-precommit": [
+      {
+        "cask": "lnkd-validate-range-yaml-precommit",
+        "count": "29,819"
+      }
+    ],
+    "lnkd-venice-tools": [
+      {
+        "cask": "lnkd-venice-tools",
+        "count": "63,578"
+      }
+    ],
+    "lnkd-venus-ull": [
+      {
+        "cask": "lnkd-venus-ull",
+        "count": "31,493"
+      }
+    ],
+    "lnkd-veritas-cli": [
+      {
+        "cask": "lnkd-veritas-cli",
+        "count": "16,649"
+      }
+    ],
+    "lnkd-video-cli": [
+      {
+        "cask": "lnkd-video-cli",
+        "count": "30,160"
+      }
+    ],
+    "lnkd-volta": [
+      {
+        "cask": "lnkd-volta",
+        "count": "36,759"
+      }
+    ],
+    "lnkd-volta-install": [
+      {
+        "cask": "lnkd-volta-install",
+        "count": "32,036"
+      }
+    ],
+    "lnkd-wastin-triage": [
+      {
+        "cask": "lnkd-wastin-triage",
+        "count": "16,747"
+      }
+    ],
+    "lnkd-waterbear-cli": [
+      {
+        "cask": "lnkd-waterbear-cli",
+        "count": "56,248"
+      }
+    ],
+    "lnkd-wk": [
+      {
+        "cask": "lnkd-wk",
+        "count": "25,793"
+      }
+    ],
+    "lnkd-wormhole-cli": [
+      {
+        "cask": "lnkd-wormhole-cli",
+        "count": "59,233"
+      }
+    ],
+    "lnkd-wrapped-python-tools": [
+      {
+        "cask": "lnkd-wrapped-python-tools",
+        "count": "28,969"
+      }
+    ],
+    "lnkd-yoda": [
+      {
+        "cask": "lnkd-yoda",
+        "count": "53,569"
+      }
+    ],
+    "lnkd-zing-tool": [
+      {
+        "cask": "lnkd-zing-tool",
+        "count": "17,985"
+      }
+    ],
+    "lnkd-zipline-cli": [
+      {
+        "cask": "lnkd-zipline-cli",
+        "count": "31,122"
+      }
+    ],
+    "lnkd-zoidberg": [
+      {
+        "cask": "lnkd-zoidberg",
+        "count": "30,952"
+      }
+    ],
+    "lnkd-zookeeper-hooks": [
+      {
+        "cask": "lnkd-zookeeper-hooks",
+        "count": "31,595"
+      }
+    ],
+    "lnkd-zookeeper-tools": [
+      {
+        "cask": "lnkd-zookeeper-tools",
+        "count": "30,923"
+      }
+    ],
+    "lnkd-zulu-jdk": [
+      {
+        "cask": "lnkd-zulu-jdk",
+        "count": "7,091"
+      }
+    ],
+    "lnkd-zulu-jdk-11": [
+      {
+        "cask": "lnkd-zulu-jdk-11",
+        "count": "6,102"
+      }
+    ],
+    "lnkd-zulu-jdk-8": [
+      {
+        "cask": "lnkd-zulu-jdk-8",
+        "count": "4,556"
+      }
+    ],
+    "loading": [
+      {
+        "cask": "loading",
+        "count": "40"
+      }
+    ],
+    "local": [
+      {
+        "cask": "local",
+        "count": "179"
+      }
+    ],
+    "local-by-flywheel": [
+      {
+        "cask": "local-by-flywheel",
+        "count": "5"
+      }
+    ],
+    "localdev": [
+      {
+        "cask": "localdev",
+        "count": "7"
+      }
+    ],
+    "localizationeditor": [
+      {
+        "cask": "localizationeditor",
+        "count": "69"
+      }
+    ],
+    "lockdown": [
+      {
+        "cask": "lockdown",
+        "count": "73"
+      }
+    ],
+    "lockrattler": [
+      {
+        "cask": "lockrattler",
+        "count": "17"
+      }
+    ],
+    "logdna-agent": [
+      {
+        "cask": "logdna-agent",
+        "count": "40"
+      }
+    ],
+    "logdna-cli": [
+      {
+        "cask": "logdna-cli",
+        "count": "57"
+      }
+    ],
+    "logicsniffer": [
+      {
+        "cask": "logicsniffer",
+        "count": "8"
+      }
+    ],
+    "loginputmac": [
+      {
+        "cask": "loginputmac",
+        "count": "47"
+      }
+    ],
+    "logisim": [
+      {
+        "cask": "logisim",
+        "count": "197"
+      }
+    ],
+    "logisim-evolution": [
+      {
+        "cask": "logisim-evolution",
+        "count": "25"
+      }
+    ],
+    "logisim-ita": [
+      {
+        "cask": "logisim-ita",
+        "count": "2"
+      }
+    ],
+    "logitech-camera-settings": [
+      {
+        "cask": "logitech-camera-settings",
+        "count": "201"
+      }
+    ],
+    "logitech-control-center": [
+      {
+        "cask": "logitech-control-center",
+        "count": "173"
+      }
+    ],
+    "logitech-firmware": [
+      {
+        "cask": "logitech-firmware",
+        "count": "1"
+      }
+    ],
+    "logitech-firmware-update-tool": [
+      {
+        "cask": "logitech-firmware-update-tool",
+        "count": "1"
+      }
+    ],
+    "logitech-firmwareupdatetool": [
+      {
+        "cask": "logitech-firmwareupdatetool",
+        "count": "72"
+      }
+    ],
+    "logitech-gaming-software": [
+      {
+        "cask": "logitech-gaming-software",
+        "count": "166"
+      }
+    ],
+    "logitech-harmony-remote": [
+      {
+        "cask": "logitech-harmony-remote",
+        "count": "1"
+      }
+    ],
+    "logitech-myharmony": [
+      {
+        "cask": "logitech-myharmony",
+        "count": "30"
+      }
+    ],
+    "logitech-options": [
+      {
+        "cask": "logitech-options",
+        "count": "1,392"
+      }
+    ],
+    "logitech-presentation": [
+      {
+        "cask": "logitech-presentation",
+        "count": "66"
+      }
+    ],
+    "logitech-unifying": [
+      {
+        "cask": "logitech-unifying",
+        "count": "184"
+      }
+    ],
+    "logmein-client": [
+      {
+        "cask": "logmein-client",
+        "count": "28"
+      }
+    ],
+    "logmein-hamachi": [
+      {
+        "cask": "logmein-hamachi",
+        "count": "159"
+      }
+    ],
+    "logoist": [
+      {
+        "cask": "logoist",
+        "count": "1"
+      }
+    ],
+    "logos": [
+      {
+        "cask": "logos",
+        "count": "21"
+      }
+    ],
+    "lookin": [
+      {
+        "cask": "lookin",
+        "count": "8"
+      }
+    ],
+    "loom": [
+      {
+        "cask": "loom",
+        "count": "270"
+      }
+    ],
+    "loopback": [
+      {
+        "cask": "loopback",
+        "count": "435"
+      }
+    ],
+    "loopback1": [
+      {
+        "cask": "loopback1",
+        "count": "1"
+      }
+    ],
+    "losslesscut": [
+      {
+        "cask": "losslesscut",
+        "count": "264"
+      }
+    ],
+    "lottie": [
+      {
+        "cask": "lottie",
+        "count": "1"
+      }
+    ],
+    "love": [
+      {
+        "cask": "love",
+        "count": "232"
+      }
+    ],
+    "lrtimelapse": [
+      {
+        "cask": "lrtimelapse",
+        "count": "8"
+      }
+    ],
+    "ltspice": [
+      {
+        "cask": "ltspice",
+        "count": "170"
+      }
+    ],
+    "luftdateninfo-flashing-tool": [
+      {
+        "cask": "luftdateninfo-flashing-tool",
+        "count": "2"
+      }
+    ],
+    "lulu": [
+      {
+        "cask": "lulu",
+        "count": "695"
+      }
+    ],
+    "lumen": [
+      {
+        "cask": "lumen",
+        "count": "123"
+      }
+    ],
+    "luminance-hdr": [
+      {
+        "cask": "luminance-hdr",
+        "count": "22"
+      }
+    ],
+    "luna-display": [
+      {
+        "cask": "luna-display",
+        "count": "39"
+      }
+    ],
+    "luna-secondary": [
+      {
+        "cask": "luna-secondary",
+        "count": "17"
+      }
+    ],
+    "lunar": [
+      {
+        "cask": "lunar",
+        "count": "399"
+      }
+    ],
+    "lunastudio": [
+      {
+        "cask": "lunastudio",
+        "count": "16"
+      }
+    ],
+    "lunchy": [
+      {
+        "cask": "lunchy",
+        "count": "82"
+      }
+    ],
+    "luxmark": [
+      {
+        "cask": "luxmark",
+        "count": "25"
+      }
+    ],
+    "luyten": [
+      {
+        "cask": "luyten",
+        "count": "52"
+      }
+    ],
+    "lyn": [
+      {
+        "cask": "lyn",
+        "count": "14"
+      }
+    ],
+    "lynkeos": [
+      {
+        "cask": "lynkeos",
+        "count": "8"
+      }
+    ],
+    "lynx": [
+      {
+        "cask": "lynx",
+        "count": "77"
+      }
+    ],
+    "lynxlet": [
+      {
+        "cask": "lynxlet",
+        "count": "36"
+      }
+    ],
+    "lyrics-master": [
+      {
+        "cask": "lyrics-master",
+        "count": "24"
+      }
+    ],
+    "lyricsx": [
+      {
+        "cask": "lyricsx",
+        "count": "188"
+      }
+    ],
+    "lyx": [
+      {
+        "cask": "lyx",
+        "count": "491"
+      }
+    ],
+    "m-iina": [
+      {
+        "cask": "m-iina",
+        "count": "1"
+      }
+    ],
+    "m3unify": [
+      {
+        "cask": "m3unify",
+        "count": "9"
+      }
+    ],
+    "mac-chromium": [
+      {
+        "cask": "mac-chromium",
+        "count": "46"
+      }
+    ],
+    "mac2imgur": [
+      {
+        "cask": "mac2imgur",
+        "count": "31"
+      }
+    ],
+    "macbreakz": [
+      {
+        "cask": "macbreakz",
+        "count": "25"
+      }
+    ],
+    "macclean": [
+      {
+        "cask": "macclean",
+        "count": "33"
+      }
+    ],
+    "maccpuid": [
+      {
+        "cask": "maccpuid",
+        "count": "47"
+      }
+    ],
+    "maccy": [
+      {
+        "cask": "maccy",
+        "count": "776"
+      }
+    ],
+    "macdependency": [
+      {
+        "cask": "macdependency",
+        "count": "6"
+      }
+    ],
+    "macdive": [
+      {
+        "cask": "macdive",
+        "count": "6"
+      }
+    ],
+    "macdjview": [
+      {
+        "cask": "macdjview",
+        "count": "18"
+      }
+    ],
+    "macdown": [
+      {
+        "cask": "macdown",
+        "count": "4,519"
+      }
+    ],
+    "macdropany": [
+      {
+        "cask": "macdropany",
+        "count": "13"
+      }
+    ],
+    "macfeh": [
+      {
+        "cask": "macfeh",
+        "count": "9"
+      }
+    ],
+    "macforge": [
+      {
+        "cask": "macforge",
+        "count": "1"
+      }
+    ],
+    "macfusion": [
+      {
+        "cask": "macfusion",
+        "count": "62"
+      }
+    ],
+    "macfusion-ng": [
+      {
+        "cask": "macfusion-ng",
+        "count": "36"
+      }
+    ],
+    "macgamestore": [
+      {
+        "cask": "macgamestore",
+        "count": "39"
+      }
+    ],
+    "macgdbp": [
+      {
+        "cask": "macgdbp",
+        "count": "35"
+      }
+    ],
+    "macgesture": [
+      {
+        "cask": "macgesture",
+        "count": "36"
+      }
+    ],
+    "machacha": [
+      {
+        "cask": "machacha",
+        "count": "3"
+      }
+    ],
+    "machg": [
+      {
+        "cask": "machg",
+        "count": "7"
+      }
+    ],
+    "machoexplorer": [
+      {
+        "cask": "machoexplorer",
+        "count": "19"
+      }
+    ],
+    "machoview": [
+      {
+        "cask": "machoview",
+        "count": "36"
+      }
+    ],
+    "maciasl": [
+      {
+        "cask": "maciasl",
+        "count": "142"
+      }
+    ],
+    "macintosh-explorer": [
+      {
+        "cask": "macintosh-explorer",
+        "count": "6"
+      }
+    ],
+    "macmediakeyforwarder": [
+      {
+        "cask": "macmediakeyforwarder",
+        "count": "516"
+      }
+    ],
+    "macos-catalina-patcher": [
+      {
+        "cask": "macos-catalina-patcher",
+        "count": "17"
+      }
+    ],
+    "macos-catalina-patcher@1.3.0": [
+      {
+        "cask": "macos-catalina-patcher@1.3.0",
+        "count": "6"
+      }
+    ],
+    "macpar-deluxe": [
+      {
+        "cask": "macpar-deluxe",
+        "count": "23"
+      }
+    ],
+    "macpass": [
+      {
+        "cask": "macpass",
+        "count": "1,241"
+      }
+    ],
+    "macpilot": [
+      {
+        "cask": "macpilot",
+        "count": "28"
+      }
+    ],
+    "macs-fan-control": [
+      {
+        "cask": "macs-fan-control",
+        "count": "1,705"
+      }
+    ],
+    "macspice": [
+      {
+        "cask": "macspice",
+        "count": "46"
+      }
+    ],
+    "macstroke": [
+      {
+        "cask": "macstroke",
+        "count": "1"
+      }
+    ],
+    "macsvg": [
+      {
+        "cask": "macsvg",
+        "count": "185"
+      }
+    ],
+    "macterm": [
+      {
+        "cask": "macterm",
+        "count": "89"
+      }
+    ],
+    "mactex": [
+      {
+        "cask": "mactex",
+        "count": "9,635"
+      }
+    ],
+    "mactex-no-gui": [
+      {
+        "cask": "mactex-no-gui",
+        "count": "2,665"
+      }
+    ],
+    "mactracker": [
+      {
+        "cask": "mactracker",
+        "count": "275"
+      }
+    ],
+    "macupdate": [
+      {
+        "cask": "macupdate",
+        "count": "29"
+      }
+    ],
+    "macupdater": [
+      {
+        "cask": "macupdater",
+        "count": "273"
+      }
+    ],
+    "macvim": [
+      {
+        "cask": "macvim",
+        "count": "3,187"
+      }
+    ],
+    "macvim-kaoriya": [
+      {
+        "cask": "macvim-kaoriya",
+        "count": "1"
+      }
+    ],
+    "macwinzipper": [
+      {
+        "cask": "macwinzipper",
+        "count": "200"
+      }
+    ],
+    "macx-dvd-ripper-mac-free-edition": [
+      {
+        "cask": "macx-dvd-ripper-mac-free-edition",
+        "count": "36"
+      }
+    ],
+    "macx-dvd-ripper-pro": [
+      {
+        "cask": "macx-dvd-ripper-pro",
+        "count": "13"
+      }
+    ],
+    "macx-video-converter-pro": [
+      {
+        "cask": "macx-video-converter-pro",
+        "count": "49"
+      }
+    ],
+    "macx-youtube-downloader": [
+      {
+        "cask": "macx-youtube-downloader",
+        "count": "237"
+      }
+    ],
+    "maczip4win": [
+      {
+        "cask": "maczip4win",
+        "count": "59"
+      }
+    ],
+    "madruby": [
+      {
+        "cask": "madruby",
+        "count": "1"
+      }
+    ],
+    "maelstrom": [
+      {
+        "cask": "maelstrom",
+        "count": "4"
+      }
+    ],
+    "magic-launch": [
+      {
+        "cask": "magic-launch",
+        "count": "7"
+      }
+    ],
+    "magicavoxel": [
+      {
+        "cask": "magicavoxel",
+        "count": "105"
+      }
+    ],
+    "magiccap": [
+      {
+        "cask": "magiccap",
+        "count": "5"
+      }
+    ],
+    "magicplot-pro": [
+      {
+        "cask": "magicplot-pro",
+        "count": "1"
+      }
+    ],
+    "magicplot-student": [
+      {
+        "cask": "magicplot-student",
+        "count": "3"
+      }
+    ],
+    "magicplotpro": [
+      {
+        "cask": "magicplotpro",
+        "count": "2"
+      }
+    ],
+    "magicplotstudent": [
+      {
+        "cask": "magicplotstudent",
+        "count": "1"
+      }
+    ],
+    "magicprefs": [
+      {
+        "cask": "magicprefs",
+        "count": "72"
+      }
+    ],
+    "mailbutler": [
+      {
+        "cask": "mailbutler",
+        "count": "70"
+      }
+    ],
+    "mailmaster": [
+      {
+        "cask": "mailmaster",
+        "count": "62"
+      }
+    ],
+    "mailmate": [
+      {
+        "cask": "mailmate",
+        "count": "105"
+      }
+    ],
+    "mailplane": [
+      {
+        "cask": "mailplane",
+        "count": "133"
+      }
+    ],
+    "mailspring": [
+      {
+        "cask": "mailspring",
+        "count": "280"
+      }
+    ],
+    "maintenance": [
+      {
+        "cask": "maintenance",
+        "count": "75"
+      }
+    ],
+    "majestic": [
+      {
+        "cask": "majestic",
+        "count": "1"
+      }
+    ],
+    "majsoul-plus": [
+      {
+        "cask": "majsoul-plus",
+        "count": "6"
+      }
+    ],
+    "makehuman": [
+      {
+        "cask": "makehuman",
+        "count": "35"
+      }
+    ],
+    "makemkv": [
+      {
+        "cask": "makemkv",
+        "count": "745"
+      }
+    ],
+    "makerbot-print": [
+      {
+        "cask": "makerbot-print",
+        "count": "1"
+      }
+    ],
+    "maltego": [
+      {
+        "cask": "maltego",
+        "count": "199"
+      }
+    ],
+    "malus": [
+      {
+        "cask": "malus",
+        "count": "15"
+      }
+    ],
+    "malwarebytes": [
+      {
+        "cask": "malwarebytes",
+        "count": "839"
+      }
+    ],
+    "mame": [
+      {
+        "cask": "mame",
+        "count": "129"
+      }
+    ],
+    "mammon": [
+      {
+        "cask": "mammon",
+        "count": "2"
+      }
+    ],
+    "mamp": [
+      {
+        "cask": "mamp",
+        "count": "815"
+      }
+    ],
+    "mamp4": [
+      {
+        "cask": "mamp4",
+        "count": "1"
+      }
+    ],
+    "manageengine-mibbrowser": [
+      {
+        "cask": "manageengine-mibbrowser",
+        "count": "22"
+      }
+    ],
+    "manico": [
+      {
+        "cask": "manico",
+        "count": "64"
+      }
+    ],
+    "manictime": [
+      {
+        "cask": "manictime",
+        "count": "11"
+      }
+    ],
+    "manopen": [
+      {
+        "cask": "manopen",
+        "count": "5"
+      }
+    ],
+    "manta": [
+      {
+        "cask": "manta",
+        "count": "10"
+      }
+    ],
+    "manuscripts": [
+      {
+        "cask": "manuscripts",
+        "count": "36"
+      }
+    ],
+    "manuskript": [
+      {
+        "cask": "manuskript",
+        "count": "30"
+      }
+    ],
+    "mapillary-uploader": [
+      {
+        "cask": "mapillary-uploader",
+        "count": "1"
+      }
+    ],
+    "mapture": [
+      {
+        "cask": "mapture",
+        "count": "33"
+      }
+    ],
+    "marathon": [
+      {
+        "cask": "marathon",
+        "count": "10"
+      }
+    ],
+    "marble": [
+      {
+        "cask": "marble",
+        "count": "20"
+      }
+    ],
+    "marcedit": [
+      {
+        "cask": "marcedit",
+        "count": "1"
+      }
+    ],
+    "marginnote": [
+      {
+        "cask": "marginnote",
+        "count": "68"
+      }
+    ],
+    "mari0": [
+      {
+        "cask": "mari0",
+        "count": "8"
+      }
+    ],
+    "maria": [
+      {
+        "cask": "maria",
+        "count": "15"
+      }
+    ],
+    "mark-text": [
+      {
+        "cask": "mark-text",
+        "count": "786"
+      }
+    ],
+    "markdown": [
+      {
+        "cask": "markdown",
+        "count": "2"
+      }
+    ],
+    "markdown-service-tools": [
+      {
+        "cask": "markdown-service-tools",
+        "count": "39"
+      }
+    ],
+    "markdownmdimporter": [
+      {
+        "cask": "markdownmdimporter",
+        "count": "13"
+      }
+    ],
+    "marked": [
+      {
+        "cask": "marked",
+        "count": "278"
+      }
+    ],
+    "marker-import": [
+      {
+        "cask": "marker-import",
+        "count": "1"
+      }
+    ],
+    "markright": [
+      {
+        "cask": "markright",
+        "count": "5"
+      }
+    ],
+    "marmaduke-chromium": [
+      {
+        "cask": "marmaduke-chromium",
+        "count": "61"
+      }
+    ],
+    "marmaduke-chromium-nosync": [
+      {
+        "cask": "marmaduke-chromium-nosync",
+        "count": "10"
+      }
+    ],
+    "marmaduke-chromium-ungoogled": [
+      {
+        "cask": "marmaduke-chromium-ungoogled",
+        "count": "24"
+      }
+    ],
+    "mars": [
+      {
+        "cask": "mars",
+        "count": "34"
+      }
+    ],
+    "marsedit": [
+      {
+        "cask": "marsedit",
+        "count": "16"
+      }
+    ],
+    "marshallofsound-google-play-music-player": [
+      {
+        "cask": "marshallofsound-google-play-music-player",
+        "count": "199"
+      }
+    ],
+    "marta": [
+      {
+        "cask": "marta",
+        "count": "519"
+      }
+    ],
+    "marvel": [
+      {
+        "cask": "marvel",
+        "count": "33"
+      }
+    ],
+    "marvin": [
+      {
+        "cask": "marvin",
+        "count": "15"
+      }
+    ],
+    "masscode": [
+      {
+        "cask": "masscode",
+        "count": "71"
+      }
+    ],
+    "massreplaceit": [
+      {
+        "cask": "massreplaceit",
+        "count": "9"
+      }
+    ],
+    "master-password": [
+      {
+        "cask": "master-password",
+        "count": "25"
+      }
+    ],
+    "master-pdf-editor": [
+      {
+        "cask": "master-pdf-editor",
+        "count": "93"
+      }
+    ],
+    "masterway-note": [
+      {
+        "cask": "masterway-note",
+        "count": "3"
+      }
+    ],
+    "mat": [
+      {
+        "cask": "mat",
+        "count": "215"
+      }
+    ],
+    "mate-translate": [
+      {
+        "cask": "mate-translate",
+        "count": "30"
+      }
+    ],
+    "mater": [
+      {
+        "cask": "mater",
+        "count": "6"
+      }
+    ],
+    "material-colors": [
+      {
+        "cask": "material-colors",
+        "count": "8"
+      }
+    ],
+    "mathpix-snipping-tool": [
+      {
+        "cask": "mathpix-snipping-tool",
+        "count": "226"
+      }
+    ],
+    "mathtype": [
+      {
+        "cask": "mathtype",
+        "count": "71"
+      }
+    ],
+    "matterhorn": [
+      {
+        "cask": "matterhorn",
+        "count": "74"
+      }
+    ],
+    "mattermost": [
+      {
+        "cask": "mattermost",
+        "count": "1,634"
+      }
+    ],
+    "mattr-slate": [
+      {
+        "cask": "mattr-slate",
+        "count": "74"
+      }
+    ],
+    "mauve": [
+      {
+        "cask": "mauve",
+        "count": "4"
+      }
+    ],
+    "mavensmate": [
+      {
+        "cask": "mavensmate",
+        "count": "9"
+      }
+    ],
+    "max": [
+      {
+        "cask": "max",
+        "count": "68"
+      }
+    ],
+    "mazda-toolbox": [
+      {
+        "cask": "mazda-toolbox",
+        "count": "4"
+      }
+    ],
+    "mbed-studio": [
+      {
+        "cask": "mbed-studio",
+        "count": "10"
+      }
+    ],
+    "mblock": [
+      {
+        "cask": "mblock",
+        "count": "8"
+      }
+    ],
+    "mcbopomofo": [
+      {
+        "cask": "mcbopomofo",
+        "count": "12"
+      }
+    ],
+    "mcedit": [
+      {
+        "cask": "mcedit",
+        "count": "70"
+      }
+    ],
+    "mcgimp": [
+      {
+        "cask": "mcgimp",
+        "count": "120"
+      }
+    ],
+    "mcuxpresso": [
+      {
+        "cask": "mcuxpresso",
+        "count": "2"
+      }
+    ],
+    "mdimagesizemdimporter": [
+      {
+        "cask": "mdimagesizemdimporter",
+        "count": "179"
+      }
+    ],
+    "mdrp": [
+      {
+        "cask": "mdrp",
+        "count": "24"
+      }
+    ],
+    "media-center": [
+      {
+        "cask": "media-center",
+        "count": "6"
+      }
+    ],
+    "media-converter": [
+      {
+        "cask": "media-converter",
+        "count": "40"
+      }
+    ],
+    "mediaelch": [
+      {
+        "cask": "mediaelch",
+        "count": "56"
+      }
+    ],
+    "mediahuman-audio-converter": [
+      {
+        "cask": "mediahuman-audio-converter",
+        "count": "105"
+      }
+    ],
+    "mediahuman-youtube-downloader": [
+      {
+        "cask": "mediahuman-youtube-downloader",
+        "count": "71"
+      }
+    ],
+    "mediainfo": [
+      {
+        "cask": "mediainfo",
+        "count": "403"
+      }
+    ],
+    "mediathekview": [
+      {
+        "cask": "mediathekview",
+        "count": "231"
+      }
+    ],
+    "medleytext": [
+      {
+        "cask": "medleytext",
+        "count": "2"
+      }
+    ],
+    "mega": [
+      {
+        "cask": "mega",
+        "count": "53"
+      }
+    ],
+    "megacmd": [
+      {
+        "cask": "megacmd",
+        "count": "30"
+      }
+    ],
+    "megahertz-knotes": [
+      {
+        "cask": "megahertz-knotes",
+        "count": "5"
+      }
+    ],
+    "megasync": [
+      {
+        "cask": "megasync",
+        "count": "646"
+      }
+    ],
+    "meld": [
+      {
+        "cask": "meld",
+        "count": "6,835"
+      }
+    ],
+    "mellow": [
+      {
+        "cask": "mellow",
+        "count": "342"
+      }
+    ],
+    "mellowplayer": [
+      {
+        "cask": "mellowplayer",
+        "count": "22"
+      }
+    ],
+    "melodics": [
+      {
+        "cask": "melodics",
+        "count": "44"
+      }
+    ],
+    "melonbooksviewer": [
+      {
+        "cask": "melonbooksviewer",
+        "count": "4"
+      }
+    ],
+    "memo": [
+      {
+        "cask": "memo",
+        "count": "7"
+      }
+    ],
+    "memoio": [
+      {
+        "cask": "memoio",
+        "count": "6"
+      }
+    ],
+    "memory": [
+      {
+        "cask": "memory",
+        "count": "21"
+      }
+    ],
+    "memory-map": [
+      {
+        "cask": "memory-map",
+        "count": "9"
+      }
+    ],
+    "mendeley": [
+      {
+        "cask": "mendeley",
+        "count": "299"
+      }
+    ],
+    "mendeley-desktop": [
+      {
+        "cask": "mendeley-desktop",
+        "count": "221"
+      }
+    ],
+    "mendeley-reference-manager": [
+      {
+        "cask": "mendeley-reference-manager",
+        "count": "141"
+      }
+    ],
+    "menubar-colors": [
+      {
+        "cask": "menubar-colors",
+        "count": "37"
+      }
+    ],
+    "menubar-countdown": [
+      {
+        "cask": "menubar-countdown",
+        "count": "14"
+      }
+    ],
+    "menubar-stats": [
+      {
+        "cask": "menubar-stats",
+        "count": "34"
+      }
+    ],
+    "menubargmail": [
+      {
+        "cask": "menubargmail",
+        "count": "6"
+      }
+    ],
+    "menucalendarclock-ical": [
+      {
+        "cask": "menucalendarclock-ical",
+        "count": "13"
+      }
+    ],
+    "menumeters": [
+      {
+        "cask": "menumeters",
+        "count": "745"
+      }
+    ],
+    "menutube": [
+      {
+        "cask": "menutube",
+        "count": "33"
+      }
+    ],
+    "merlin-project": [
+      {
+        "cask": "merlin-project",
+        "count": "28"
+      }
+    ],
+    "mesasqlite": [
+      {
+        "cask": "mesasqlite",
+        "count": "19"
+      }
+    ],
+    "meshcommander": [
+      {
+        "cask": "meshcommander",
+        "count": "13"
+      }
+    ],
+    "meshlab": [
+      {
+        "cask": "meshlab",
+        "count": "256"
+      }
+    ],
+    "meshmixer": [
+      {
+        "cask": "meshmixer",
+        "count": "81"
+      }
+    ],
+    "messenger": [
+      {
+        "cask": "messenger",
+        "count": "444"
+      }
+    ],
+    "messenger-desktop": [
+      {
+        "cask": "messenger-desktop",
+        "count": "1"
+      }
+    ],
+    "messenger-native": [
+      {
+        "cask": "messenger-native",
+        "count": "31"
+      }
+    ],
+    "meta": [
+      {
+        "cask": "meta",
+        "count": "36"
+      }
+    ],
+    "metabase": [
+      {
+        "cask": "metabase",
+        "count": "120"
+      }
+    ],
+    "metasequoia": [
+      {
+        "cask": "metasequoia",
+        "count": "1"
+      }
+    ],
+    "metashape": [
+      {
+        "cask": "metashape",
+        "count": "3"
+      }
+    ],
+    "metashapepro": [
+      {
+        "cask": "metashapepro",
+        "count": "1"
+      }
+    ],
+    "metasploit": [
+      {
+        "cask": "metasploit",
+        "count": "816"
+      }
+    ],
+    "metaz": [
+      {
+        "cask": "metaz",
+        "count": "119"
+      }
+    ],
+    "meteorologist": [
+      {
+        "cask": "meteorologist",
+        "count": "49"
+      }
+    ],
+    "mgba": [
+      {
+        "cask": "mgba",
+        "count": "50"
+      }
+    ],
+    "mi": [
+      {
+        "cask": "mi",
+        "count": "131"
+      }
+    ],
+    "mia-for-gmail": [
+      {
+        "cask": "mia-for-gmail",
+        "count": "21"
+      }
+    ],
+    "michaelvillar-timer": [
+      {
+        "cask": "michaelvillar-timer",
+        "count": "951"
+      }
+    ],
+    "micro-snitch": [
+      {
+        "cask": "micro-snitch",
+        "count": "221"
+      }
+    ],
+    "microblog": [
+      {
+        "cask": "microblog",
+        "count": "27"
+      }
+    ],
+    "microk8s": [
+      {
+        "cask": "microk8s",
+        "count": "8"
+      }
+    ],
+    "microsoft-azure-storage-explorer": [
+      {
+        "cask": "microsoft-azure-storage-explorer",
+        "count": "426"
+      }
+    ],
+    "microsoft-edge": [
+      {
+        "cask": "microsoft-edge",
+        "count": "5,810"
+      }
+    ],
+    "microsoft-edge-beta": [
+      {
+        "cask": "microsoft-edge-beta",
+        "count": "391"
+      }
+    ],
+    "microsoft-edge-canary": [
+      {
+        "cask": "microsoft-edge-canary",
+        "count": "1"
+      }
+    ],
+    "microsoft-edge-dev": [
+      {
+        "cask": "microsoft-edge-dev",
+        "count": "458"
+      }
+    ],
+    "microsoft-excel": [
+      {
+        "cask": "microsoft-excel",
+        "count": "740"
+      }
+    ],
+    "microsoft-intellipoint": [
+      {
+        "cask": "microsoft-intellipoint",
+        "count": "15"
+      }
+    ],
+    "microsoft-intellitype": [
+      {
+        "cask": "microsoft-intellitype",
+        "count": "2"
+      }
+    ],
+    "microsoft-lync": [
+      {
+        "cask": "microsoft-lync",
+        "count": "104"
+      }
+    ],
+    "microsoft-office": [
+      {
+        "cask": "microsoft-office",
+        "count": "7,893"
+      }
+    ],
+    "microsoft-office-2011": [
+      {
+        "cask": "microsoft-office-2011",
+        "count": "12"
+      }
+    ],
+    "microsoft-office-2016": [
+      {
+        "cask": "microsoft-office-2016",
+        "count": "69"
+      }
+    ],
+    "microsoft-openjdk": [
+      {
+        "cask": "microsoft-openjdk",
+        "count": "2"
+      }
+    ],
+    "microsoft-outlook": [
+      {
+        "cask": "microsoft-outlook",
+        "count": "312"
+      }
+    ],
+    "microsoft-powerpoint": [
+      {
+        "cask": "microsoft-powerpoint",
+        "count": "478"
+      }
+    ],
+    "microsoft-r-open": [
+      {
+        "cask": "microsoft-r-open",
+        "count": "29"
+      }
+    ],
+    "microsoft-remote-desktop-beta": [
+      {
+        "cask": "microsoft-remote-desktop-beta",
+        "count": "1,031"
+      }
+    ],
+    "microsoft-teams": [
+      {
+        "cask": "microsoft-teams",
+        "count": "8,820"
+      }
+    ],
+    "microsoft-word": [
+      {
+        "cask": "microsoft-word",
+        "count": "726"
+      }
+    ],
+    "microsoft_updater": [
+      {
+        "cask": "microsoft_updater",
+        "count": "14"
+      }
+    ],
+    "midclick": [
+      {
+        "cask": "midclick",
+        "count": "2"
+      }
+    ],
+    "middleclick": [
+      {
+        "cask": "middleclick",
+        "count": "1,043"
+      }
+    ],
+    "midi-monitor": [
+      {
+        "cask": "midi-monitor",
+        "count": "55"
+      }
+    ],
+    "midikeys": [
+      {
+        "cask": "midikeys",
+        "count": "47"
+      }
+    ],
+    "midistroke": [
+      {
+        "cask": "midistroke",
+        "count": "15"
+      }
+    ],
+    "miditrail": [
+      {
+        "cask": "miditrail",
+        "count": "11"
+      }
+    ],
+    "mikogo": [
+      {
+        "cask": "mikogo",
+        "count": "10"
+      }
+    ],
+    "miktex-console": [
+      {
+        "cask": "miktex-console",
+        "count": "123"
+      }
+    ],
+    "milanote": [
+      {
+        "cask": "milanote",
+        "count": "45"
+      }
+    ],
+    "milkman": [
+      {
+        "cask": "milkman",
+        "count": "89"
+      }
+    ],
+    "milkytracker": [
+      {
+        "cask": "milkytracker",
+        "count": "34"
+      }
+    ],
+    "mimecast": [
+      {
+        "cask": "mimecast",
+        "count": "5"
+      }
+    ],
+    "mimiq": [
+      {
+        "cask": "mimiq",
+        "count": "1"
+      }
+    ],
+    "mimiq-gui": [
+      {
+        "cask": "mimiq-gui",
+        "count": "1"
+      }
+    ],
+    "min": [
+      {
+        "cask": "min",
+        "count": "114"
+      }
+    ],
+    "mindforger": [
+      {
+        "cask": "mindforger",
+        "count": "60"
+      }
+    ],
+    "mindjet-mindmanager": [
+      {
+        "cask": "mindjet-mindmanager",
+        "count": "53"
+      }
+    ],
+    "mindmaster": [
+      {
+        "cask": "mindmaster",
+        "count": "88"
+      }
+    ],
+    "minecraft": [
+      {
+        "cask": "minecraft",
+        "count": "1,483"
+      }
+    ],
+    "minecraft-server": [
+      {
+        "cask": "minecraft-server",
+        "count": "88"
+      }
+    ],
+    "minecraftpe": [
+      {
+        "cask": "minecraftpe",
+        "count": "46"
+      }
+    ],
+    "mini-program-studio": [
+      {
+        "cask": "mini-program-studio",
+        "count": "8"
+      }
+    ],
+    "mini-vmac": [
+      {
+        "cask": "mini-vmac",
+        "count": "33"
+      }
+    ],
+    "miniconda": [
+      {
+        "cask": "miniconda",
+        "count": "4,126"
+      }
+    ],
+    "miniconda2": [
+      {
+        "cask": "miniconda2",
+        "count": "35"
+      }
+    ],
+    "minikube": [
+      {
+        "cask": "minikube",
+        "count": "115"
+      }
+    ],
+    "minimalmidiplayer": [
+      {
+        "cask": "minimalmidiplayer",
+        "count": "2"
+      }
+    ],
+    "minishift": [
+      {
+        "cask": "minishift",
+        "count": "3,971"
+      }
+    ],
+    "minitimer": [
+      {
+        "cask": "minitimer",
+        "count": "30"
+      }
+    ],
+    "minitube": [
+      {
+        "cask": "minitube",
+        "count": "10"
+      }
+    ],
+    "minizincide": [
+      {
+        "cask": "minizincide",
+        "count": "13"
+      }
+    ],
+    "mint-lang": [
+      {
+        "cask": "mint-lang",
+        "count": "1"
+      }
+    ],
+    "mipony": [
+      {
+        "cask": "mipony",
+        "count": "26"
+      }
+    ],
+    "miro-formerly-realtimeboard": [
+      {
+        "cask": "miro-formerly-realtimeboard",
+        "count": "434"
+      }
+    ],
+    "mirrordisplays": [
+      {
+        "cask": "mirrordisplays",
+        "count": "14"
+      }
+    ],
+    "mirrorop": [
+      {
+        "cask": "mirrorop",
+        "count": "11"
+      }
+    ],
+    "mirrors-font-firacode-nerdfont": [
+      {
+        "cask": "mirrors-font-firacode-nerdfont",
+        "count": "1"
+      }
+    ],
+    "mission-control-plus": [
+      {
+        "cask": "mission-control-plus",
+        "count": "38"
+      }
+    ],
+    "missive": [
+      {
+        "cask": "missive",
+        "count": "20"
+      }
+    ],
+    "mist": [
+      {
+        "cask": "mist",
+        "count": "12"
+      }
+    ],
+    "misu": [
+      {
+        "cask": "misu",
+        "count": "1"
+      }
+    ],
+    "mitsuba": [
+      {
+        "cask": "mitsuba",
+        "count": "1"
+      }
+    ],
+    "mixxx": [
+      {
+        "cask": "mixxx",
+        "count": "69"
+      }
+    ],
+    "mjml": [
+      {
+        "cask": "mjml",
+        "count": "71"
+      }
+    ],
+    "mjolnir": [
+      {
+        "cask": "mjolnir",
+        "count": "34"
+      }
+    ],
+    "mkchromecast": [
+      {
+        "cask": "mkchromecast",
+        "count": "218"
+      }
+    ],
+    "mks": [
+      {
+        "cask": "mks",
+        "count": "38"
+      }
+    ],
+    "mkvtoolnix": [
+      {
+        "cask": "mkvtoolnix",
+        "count": "906"
+      }
+    ],
+    "mkvtools": [
+      {
+        "cask": "mkvtools",
+        "count": "99"
+      }
+    ],
+    "mmex": [
+      {
+        "cask": "mmex",
+        "count": "24"
+      }
+    ],
+    "mnemosyne": [
+      {
+        "cask": "mnemosyne",
+        "count": "21"
+      }
+    ],
+    "mob": [
+      {
+        "cask": "mob",
+        "count": "9"
+      }
+    ],
+    "mobile-cop": [
+      {
+        "cask": "mobile-cop",
+        "count": "6"
+      }
+    ],
+    "mobile-mouse-server": [
+      {
+        "cask": "mobile-mouse-server",
+        "count": "2"
+      }
+    ],
+    "mobile-tools": [
+      {
+        "cask": "mobile-tools",
+        "count": "5"
+      }
+    ],
+    "mobirise": [
+      {
+        "cask": "mobirise",
+        "count": "28"
+      }
+    ],
+    "mobster": [
+      {
+        "cask": "mobster",
+        "count": "58"
+      }
+    ],
+    "mochi": [
+      {
+        "cask": "mochi",
+        "count": "36"
+      }
+    ],
+    "mockolo": [
+      {
+        "cask": "mockolo",
+        "count": "1"
+      }
+    ],
+    "mockoon": [
+      {
+        "cask": "mockoon",
+        "count": "861"
+      }
+    ],
+    "mockplus": [
+      {
+        "cask": "mockplus",
+        "count": "23"
+      }
+    ],
+    "mockuuups-studio": [
+      {
+        "cask": "mockuuups-studio",
+        "count": "7"
+      }
+    ],
+    "modelio": [
+      {
+        "cask": "modelio",
+        "count": "74"
+      }
+    ],
+    "modmove": [
+      {
+        "cask": "modmove",
+        "count": "10"
+      }
+    ],
+    "modulair": [
+      {
+        "cask": "modulair",
+        "count": "1"
+      }
+    ],
+    "moefe-google-translate": [
+      {
+        "cask": "moefe-google-translate",
+        "count": "29"
+      }
+    ],
+    "mojibar": [
+      {
+        "cask": "mojibar",
+        "count": "26"
+      }
+    ],
+    "mollyguard": [
+      {
+        "cask": "mollyguard",
+        "count": "4"
+      }
+    ],
+    "molot": [
+      {
+        "cask": "molot",
+        "count": "2"
+      }
+    ],
+    "molotov": [
+      {
+        "cask": "molotov",
+        "count": "100"
+      }
+    ],
+    "molsoft-browser": [
+      {
+        "cask": "molsoft-browser",
+        "count": "1"
+      }
+    ],
+    "molsoftbrowser": [
+      {
+        "cask": "molsoftbrowser",
+        "count": "1"
+      }
+    ],
+    "monal": [
+      {
+        "cask": "monal",
+        "count": "17"
+      }
+    ],
+    "monero-wallet": [
+      {
+        "cask": "monero-wallet",
+        "count": "89"
+      }
+    ],
+    "moneydance": [
+      {
+        "cask": "moneydance",
+        "count": "19"
+      }
+    ],
+    "moneymoney": [
+      {
+        "cask": "moneymoney",
+        "count": "91"
+      }
+    ],
+    "moneymoney-amazon": [
+      {
+        "cask": "moneymoney-amazon",
+        "count": "1"
+      }
+    ],
+    "moneymoney-coinbase": [
+      {
+        "cask": "moneymoney-coinbase",
+        "count": "2"
+      }
+    ],
+    "moneymoney-paylife": [
+      {
+        "cask": "moneymoney-paylife",
+        "count": "1"
+      }
+    ],
+    "moneymoney-ripple": [
+      {
+        "cask": "moneymoney-ripple",
+        "count": "1"
+      }
+    ],
+    "moneywiz": [
+      {
+        "cask": "moneywiz",
+        "count": "63"
+      }
+    ],
+    "mongodb": [
+      {
+        "cask": "mongodb",
+        "count": "66"
+      }
+    ],
+    "mongodb-compass": [
+      {
+        "cask": "mongodb-compass",
+        "count": "1,667"
+      }
+    ],
+    "mongodb-compass-beta": [
+      {
+        "cask": "mongodb-compass-beta",
+        "count": "16"
+      }
+    ],
+    "mongodb-compass-community": [
+      {
+        "cask": "mongodb-compass-community",
+        "count": "831"
+      }
+    ],
+    "mongodb-compass-isolated-edition": [
+      {
+        "cask": "mongodb-compass-isolated-edition",
+        "count": "10"
+      }
+    ],
+    "mongodb-compass-readonly": [
+      {
+        "cask": "mongodb-compass-readonly",
+        "count": "12"
+      }
+    ],
+    "mongodbpreferencepane": [
+      {
+        "cask": "mongodbpreferencepane",
+        "count": "12"
+      }
+    ],
+    "mongotron": [
+      {
+        "cask": "mongotron",
+        "count": "42"
+      }
+    ],
+    "monitorcontrol": [
+      {
+        "cask": "monitorcontrol",
+        "count": "2,742"
+      }
+    ],
+    "monitorearth": [
+      {
+        "cask": "monitorearth",
+        "count": "6"
+      }
+    ],
+    "monity-helper": [
+      {
+        "cask": "monity-helper",
+        "count": "21"
+      }
+    ],
+    "mono-mdk": [
+      {
+        "cask": "mono-mdk",
+        "count": "1,996"
+      }
+    ],
+    "mono-mdk-for-visual-studio": [
+      {
+        "cask": "mono-mdk-for-visual-studio",
+        "count": "1,392"
+      }
+    ],
+    "mono-mdk516": [
+      {
+        "cask": "mono-mdk516",
+        "count": "3"
+      }
+    ],
+    "monodraw": [
+      {
+        "cask": "monodraw",
+        "count": "135"
+      }
+    ],
+    "monofury": [
+      {
+        "cask": "monofury",
+        "count": "2"
+      }
+    ],
+    "monogame": [
+      {
+        "cask": "monogame",
+        "count": "45"
+      }
+    ],
+    "monolingual": [
+      {
+        "cask": "monolingual",
+        "count": "103"
+      }
+    ],
+    "moodo": [
+      {
+        "cask": "moodo",
+        "count": "1"
+      }
+    ],
+    "moom": [
+      {
+        "cask": "moom",
+        "count": "435"
+      }
+    ],
+    "moonitor": [
+      {
+        "cask": "moonitor",
+        "count": "2"
+      }
+    ],
+    "moonlight": [
+      {
+        "cask": "moonlight",
+        "count": "130"
+      }
+    ],
+    "morkro-papyrus": [
+      {
+        "cask": "morkro-papyrus",
+        "count": "17"
+      }
+    ],
+    "morpheus": [
+      {
+        "cask": "morpheus",
+        "count": "2"
+      }
+    ],
+    "mos": [
+      {
+        "cask": "mos",
+        "count": "1,263"
+      }
+    ],
+    "mos3": [
+      {
+        "cask": "mos3",
+        "count": "4"
+      }
+    ],
+    "mosaic": [
+      {
+        "cask": "mosaic",
+        "count": "69"
+      }
+    ],
+    "moscow-ml": [
+      {
+        "cask": "moscow-ml",
+        "count": "10"
+      }
+    ],
+    "moter": [
+      {
+        "cask": "moter",
+        "count": "1"
+      }
+    ],
+    "motion": [
+      {
+        "cask": "motion",
+        "count": "30"
+      }
+    ],
+    "motrix": [
+      {
+        "cask": "motrix",
+        "count": "1,084"
+      }
+    ],
+    "mount-efi": [
+      {
+        "cask": "mount-efi",
+        "count": "2"
+      }
+    ],
+    "mountain": [
+      {
+        "cask": "mountain",
+        "count": "14"
+      }
+    ],
+    "mountain-duck": [
+      {
+        "cask": "mountain-duck",
+        "count": "270"
+      }
+    ],
+    "mounty": [
+      {
+        "cask": "mounty",
+        "count": "5,477"
+      }
+    ],
+    "mouse-locator": [
+      {
+        "cask": "mouse-locator",
+        "count": "18"
+      }
+    ],
+    "mousecape": [
+      {
+        "cask": "mousecape",
+        "count": "1"
+      }
+    ],
+    "mousepose": [
+      {
+        "cask": "mousepose",
+        "count": "10"
+      }
+    ],
+    "movist": [
+      {
+        "cask": "movist",
+        "count": "42"
+      }
+    ],
+    "movist-pro": [
+      {
+        "cask": "movist-pro",
+        "count": "48"
+      }
+    ],
+    "mozart": [
+      {
+        "cask": "mozart",
+        "count": "1"
+      }
+    ],
+    "mozart2": [
+      {
+        "cask": "mozart2",
+        "count": "20"
+      }
+    ],
+    "mp3gain-express": [
+      {
+        "cask": "mp3gain-express",
+        "count": "15"
+      }
+    ],
+    "mp3tag": [
+      {
+        "cask": "mp3tag",
+        "count": "57"
+      }
+    ],
+    "mp4tools": [
+      {
+        "cask": "mp4tools",
+        "count": "105"
+      }
+    ],
+    "mpeg-streamclip": [
+      {
+        "cask": "mpeg-streamclip",
+        "count": "50"
+      }
+    ],
+    "mplab-xc32": [
+      {
+        "cask": "mplab-xc32",
+        "count": "8"
+      }
+    ],
+    "mplayer-osx-extended": [
+      {
+        "cask": "mplayer-osx-extended",
+        "count": "127"
+      }
+    ],
+    "mplayerx": [
+      {
+        "cask": "mplayerx",
+        "count": "455"
+      }
+    ],
+    "mps": [
+      {
+        "cask": "mps",
+        "count": "23"
+      }
+    ],
+    "mpv": [
+      {
+        "cask": "mpv",
+        "count": "3,215"
+      }
+    ],
+    "mqtt-explorer": [
+      {
+        "cask": "mqtt-explorer",
+        "count": "151"
+      }
+    ],
+    "mqttfx": [
+      {
+        "cask": "mqttfx",
+        "count": "123"
+      }
+    ],
+    "mribeiro-timetracker": [
+      {
+        "cask": "mribeiro-timetracker",
+        "count": "1"
+      }
+    ],
+    "msoft-remote-desktop-beta": [
+      {
+        "cask": "msoft-remote-desktop-beta",
+        "count": "3"
+      }
+    ],
+    "mtmr": [
+      {
+        "cask": "mtmr",
+        "count": "726"
+      }
+    ],
+    "mu-editor": [
+      {
+        "cask": "mu-editor",
+        "count": "55"
+      }
+    ],
+    "mucommander": [
+      {
+        "cask": "mucommander",
+        "count": "313"
+      }
+    ],
+    "mudlet": [
+      {
+        "cask": "mudlet",
+        "count": "58"
+      }
+    ],
+    "mullvadvpn": [
+      {
+        "cask": "mullvadvpn",
+        "count": "289"
+      }
+    ],
+    "mullvadvpn-beta": [
+      {
+        "cask": "mullvadvpn-beta",
+        "count": "10"
+      }
+    ],
+    "multibit-hd": [
+      {
+        "cask": "multibit-hd",
+        "count": "10"
+      }
+    ],
+    "multifirefox": [
+      {
+        "cask": "multifirefox",
+        "count": "76"
+      }
+    ],
+    "multimc": [
+      {
+        "cask": "multimc",
+        "count": "136"
+      }
+    ],
+    "multipass": [
+      {
+        "cask": "multipass",
+        "count": "3,722"
+      }
+    ],
+    "multipatch": [
+      {
+        "cask": "multipatch",
+        "count": "19"
+      }
+    ],
+    "multiscan-3b": [
+      {
+        "cask": "multiscan-3b",
+        "count": "7"
+      }
+    ],
+    "multitouch": [
+      {
+        "cask": "multitouch",
+        "count": "29"
+      }
+    ],
+    "mumble": [
+      {
+        "cask": "mumble",
+        "count": "602"
+      }
+    ],
+    "munki": [
+      {
+        "cask": "munki",
+        "count": "85"
+      }
+    ],
+    "murus": [
+      {
+        "cask": "murus",
+        "count": "88"
+      }
+    ],
+    "murus-menulet": [
+      {
+        "cask": "murus-menulet",
+        "count": "10"
+      }
+    ],
+    "muruslogsvisualizer": [
+      {
+        "cask": "muruslogsvisualizer",
+        "count": "7"
+      }
+    ],
+    "musaicfm": [
+      {
+        "cask": "musaicfm",
+        "count": "110"
+      }
+    ],
+    "muse": [
+      {
+        "cask": "muse",
+        "count": "30"
+      }
+    ],
+    "museeks": [
+      {
+        "cask": "museeks",
+        "count": "14"
+      }
+    ],
+    "musescore": [
+      {
+        "cask": "musescore",
+        "count": "485"
+      }
+    ],
+    "music-manager": [
+      {
+        "cask": "music-manager",
+        "count": "73"
+      }
+    ],
+    "musicbrainz-picard": [
+      {
+        "cask": "musicbrainz-picard",
+        "count": "520"
+      }
+    ],
+    "musictube": [
+      {
+        "cask": "musictube",
+        "count": "4"
+      }
+    ],
+    "mutespotifyads": [
+      {
+        "cask": "mutespotifyads",
+        "count": "463"
+      }
+    ],
+    "mutify": [
+      {
+        "cask": "mutify",
+        "count": "47"
+      }
+    ],
+    "muzie": [
+      {
+        "cask": "muzie",
+        "count": "1"
+      }
+    ],
+    "muzzle": [
+      {
+        "cask": "muzzle",
+        "count": "305"
+      }
+    ],
+    "mweb": [
+      {
+        "cask": "mweb",
+        "count": "156"
+      }
+    ],
+    "my-budget": [
+      {
+        "cask": "my-budget",
+        "count": "3"
+      }
+    ],
+    "my-image-garden": [
+      {
+        "cask": "my-image-garden",
+        "count": "3"
+      }
+    ],
+    "my-new-cask": [
+      {
+        "cask": "my-new-cask",
+        "count": "1"
+      }
+    ],
+    "my-splashtop-wired-xdisplay": [
+      {
+        "cask": "my-splashtop-wired-xdisplay",
+        "count": "2"
+      }
+    ],
+    "mycloud": [
+      {
+        "cask": "mycloud",
+        "count": "10"
+      }
+    ],
+    "mycrypto": [
+      {
+        "cask": "mycrypto",
+        "count": "29"
+      }
+    ],
+    "mylio": [
+      {
+        "cask": "mylio",
+        "count": "15"
+      }
+    ],
+    "mymonero": [
+      {
+        "cask": "mymonero",
+        "count": "21"
+      }
+    ],
+    "myphone": [
+      {
+        "cask": "myphone",
+        "count": "3"
+      }
+    ],
+    "mysafaribasedbrowser": [
+      {
+        "cask": "mysafaribasedbrowser",
+        "count": "5"
+      }
+    ],
+    "mysides": [
+      {
+        "cask": "mysides",
+        "count": "157"
+      }
+    ],
+    "mysql-connector-python": [
+      {
+        "cask": "mysql-connector-python",
+        "count": "249"
+      }
+    ],
+    "mysql-shell": [
+      {
+        "cask": "mysql-shell",
+        "count": "668"
+      }
+    ],
+    "mysql-utilities": [
+      {
+        "cask": "mysql-utilities",
+        "count": "105"
+      }
+    ],
+    "mysqlworkbench": [
+      {
+        "cask": "mysqlworkbench",
+        "count": "4,783"
+      }
+    ],
+    "myworkspace": [
+      {
+        "cask": "myworkspace",
+        "count": "15"
+      }
+    ],
+    "nabla": [
+      {
+        "cask": "nabla",
+        "count": "2"
+      }
+    ],
+    "nagbar": [
+      {
+        "cask": "nagbar",
+        "count": "6"
+      }
+    ],
+    "nagstamon": [
+      {
+        "cask": "nagstamon",
+        "count": "152"
+      }
+    ],
+    "nalaprop": [
+      {
+        "cask": "nalaprop",
+        "count": "2"
+      }
+    ],
+    "nally": [
+      {
+        "cask": "nally",
+        "count": "21"
+      }
+    ],
+    "name-mangler": [
+      {
+        "cask": "name-mangler",
+        "count": "25"
+      }
+    ],
+    "namebench": [
+      {
+        "cask": "namebench",
+        "count": "93"
+      }
+    ],
+    "namechanger": [
+      {
+        "cask": "namechanger",
+        "count": "136"
+      }
+    ],
+    "nano": [
+      {
+        "cask": "nano",
+        "count": "60"
+      }
+    ],
+    "nanostudio": [
+      {
+        "cask": "nanostudio",
+        "count": "5"
+      }
+    ],
+    "nasas-eyes": [
+      {
+        "cask": "nasas-eyes",
+        "count": "10"
+      }
+    ],
+    "native-access": [
+      {
+        "cask": "native-access",
+        "count": "85"
+      }
+    ],
+    "nativedisplaybrightness": [
+      {
+        "cask": "nativedisplaybrightness",
+        "count": "30"
+      }
+    ],
+    "natron": [
+      {
+        "cask": "natron",
+        "count": "39"
+      }
+    ],
+    "nautilus": [
+      {
+        "cask": "nautilus",
+        "count": "18"
+      }
+    ],
+    "navicat-data-modeler": [
+      {
+        "cask": "navicat-data-modeler",
+        "count": "19"
+      }
+    ],
+    "navicat-data-modeler-essentials": [
+      {
+        "cask": "navicat-data-modeler-essentials",
+        "count": "56"
+      }
+    ],
+    "navicat-for-mariadb": [
+      {
+        "cask": "navicat-for-mariadb",
+        "count": "29"
+      }
+    ],
+    "navicat-for-mysql": [
+      {
+        "cask": "navicat-for-mysql",
+        "count": "130"
+      }
+    ],
+    "navicat-for-oracle": [
+      {
+        "cask": "navicat-for-oracle",
+        "count": "19"
+      }
+    ],
+    "navicat-for-postgresql": [
+      {
+        "cask": "navicat-for-postgresql",
+        "count": "87"
+      }
+    ],
+    "navicat-for-sql-server": [
+      {
+        "cask": "navicat-for-sql-server",
+        "count": "14"
+      }
+    ],
+    "navicat-for-sqlite": [
+      {
+        "cask": "navicat-for-sqlite",
+        "count": "31"
+      }
+    ],
+    "navicat-premium": [
+      {
+        "cask": "navicat-premium",
+        "count": "137"
+      }
+    ],
+    "navicat-premium-cn": [
+      {
+        "cask": "navicat-premium-cn",
+        "count": "1"
+      }
+    ],
+    "navicat-premium-essentials": [
+      {
+        "cask": "navicat-premium-essentials",
+        "count": "26"
+      }
+    ],
+    "navicat-premium@12": [
+      {
+        "cask": "navicat-premium@12",
+        "count": "1"
+      }
+    ],
+    "nbtexplorer": [
+      {
+        "cask": "nbtexplorer",
+        "count": "18"
+      }
+    ],
+    "ncar-ncl": [
+      {
+        "cask": "ncar-ncl",
+        "count": "104"
+      }
+    ],
+    "ndm": [
+      {
+        "cask": "ndm",
+        "count": "56"
+      }
+    ],
+    "near-lock": [
+      {
+        "cask": "near-lock",
+        "count": "52"
+      }
+    ],
+    "neo4j": [
+      {
+        "cask": "neo4j",
+        "count": "174"
+      }
+    ],
+    "neofinder": [
+      {
+        "cask": "neofinder",
+        "count": "27"
+      }
+    ],
+    "neovide": [
+      {
+        "cask": "neovide",
+        "count": "1"
+      }
+    ],
+    "neovim-nightly": [
+      {
+        "cask": "neovim-nightly",
+        "count": "12"
+      }
+    ],
+    "nestopia": [
+      {
+        "cask": "nestopia",
+        "count": "49"
+      }
+    ],
+    "netbeans": [
+      {
+        "cask": "netbeans",
+        "count": "750"
+      }
+    ],
+    "netbeans-cpp": [
+      {
+        "cask": "netbeans-cpp",
+        "count": "25"
+      }
+    ],
+    "netbeans-java-ee": [
+      {
+        "cask": "netbeans-java-ee",
+        "count": "54"
+      }
+    ],
+    "netbeans-java-se": [
+      {
+        "cask": "netbeans-java-se",
+        "count": "40"
+      }
+    ],
+    "netbeans-php": [
+      {
+        "cask": "netbeans-php",
+        "count": "60"
+      }
+    ],
+    "netdownloadhelpercoapp": [
+      {
+        "cask": "netdownloadhelpercoapp",
+        "count": "19"
+      }
+    ],
+    "neteasemusic": [
+      {
+        "cask": "neteasemusic",
+        "count": "741"
+      }
+    ],
+    "netgear-switch-discovery-tool": [
+      {
+        "cask": "netgear-switch-discovery-tool",
+        "count": "5"
+      }
+    ],
+    "nethackcocoa": [
+      {
+        "cask": "nethackcocoa",
+        "count": "30"
+      }
+    ],
+    "netiquette": [
+      {
+        "cask": "netiquette",
+        "count": "92"
+      }
+    ],
+    "netlogo": [
+      {
+        "cask": "netlogo",
+        "count": "47"
+      }
+    ],
+    "netnewswire": [
+      {
+        "cask": "netnewswire",
+        "count": "565"
+      }
+    ],
+    "netron": [
+      {
+        "cask": "netron",
+        "count": "882"
+      }
+    ],
+    "netspot": [
+      {
+        "cask": "netspot",
+        "count": "394"
+      }
+    ],
+    "netsurf": [
+      {
+        "cask": "netsurf",
+        "count": "30"
+      }
+    ],
+    "netxms-console": [
+      {
+        "cask": "netxms-console",
+        "count": "5"
+      }
+    ],
+    "neurongpu": [
+      {
+        "cask": "neurongpu",
+        "count": "20"
+      }
+    ],
+    "next": [
+      {
+        "cask": "next",
+        "count": "109"
+      }
+    ],
+    "nextcloud": [
+      {
+        "cask": "nextcloud",
+        "count": "1,344"
+      }
+    ],
+    "nfov": [
+      {
+        "cask": "nfov",
+        "count": "18"
+      }
+    ],
+    "ngrok": [
+      {
+        "cask": "ngrok",
+        "count": "16,449"
+      }
+    ],
+    "nheko": [
+      {
+        "cask": "nheko",
+        "count": "33"
+      }
+    ],
+    "ni-488-2": [
+      {
+        "cask": "ni-488-2",
+        "count": "6"
+      }
+    ],
+    "night-owl": [
+      {
+        "cask": "night-owl",
+        "count": "79"
+      }
+    ],
+    "nightfall": [
+      {
+        "cask": "nightfall",
+        "count": "77"
+      }
+    ],
+    "nightingale": [
+      {
+        "cask": "nightingale",
+        "count": "10"
+      }
+    ],
+    "nightowl": [
+      {
+        "cask": "nightowl",
+        "count": "389"
+      }
+    ],
+    "nimble": [
+      {
+        "cask": "nimble",
+        "count": "36"
+      }
+    ],
+    "nimble-commander": [
+      {
+        "cask": "nimble-commander",
+        "count": "30"
+      }
+    ],
+    "nimbus": [
+      {
+        "cask": "nimbus",
+        "count": "20"
+      }
+    ],
+    "ninja-download-manager-ndm": [
+      {
+        "cask": "ninja-download-manager-ndm",
+        "count": "19"
+      }
+    ],
+    "nisus-thesaurus": [
+      {
+        "cask": "nisus-thesaurus",
+        "count": "10"
+      }
+    ],
+    "nitrokey": [
+      {
+        "cask": "nitrokey",
+        "count": "40"
+      }
+    ],
+    "nitroshare": [
+      {
+        "cask": "nitroshare",
+        "count": "36"
+      }
+    ],
+    "nndd": [
+      {
+        "cask": "nndd",
+        "count": "1"
+      }
+    ],
+    "no-ip-duc": [
+      {
+        "cask": "no-ip-duc",
+        "count": "47"
+      }
+    ],
+    "nocturnal": [
+      {
+        "cask": "nocturnal",
+        "count": "27"
+      }
+    ],
+    "nocturne": [
+      {
+        "cask": "nocturne",
+        "count": "13"
+      }
+    ],
+    "node@12": [
+      {
+        "cask": "node@12",
+        "count": "2"
+      }
+    ],
+    "nodebox": [
+      {
+        "cask": "nodebox",
+        "count": "16"
+      }
+    ],
+    "nodeclipse": [
+      {
+        "cask": "nodeclipse",
+        "count": "8"
+      }
+    ],
+    "noisebuddy": [
+      {
+        "cask": "noisebuddy",
+        "count": "25"
+      }
+    ],
+    "noisy": [
+      {
+        "cask": "noisy",
+        "count": "10"
+      }
+    ],
+    "noisytyper": [
+      {
+        "cask": "noisytyper",
+        "count": "4"
+      }
+    ],
+    "nomachine": [
+      {
+        "cask": "nomachine",
+        "count": "667"
+      }
+    ],
+    "nomad": [
+      {
+        "cask": "nomad",
+        "count": "89"
+      }
+    ],
+    "nordic-nrf-command-line-tools": [
+      {
+        "cask": "nordic-nrf-command-line-tools",
+        "count": "118"
+      }
+    ],
+    "nordic-nrf-connect": [
+      {
+        "cask": "nordic-nrf-connect",
+        "count": "46"
+      }
+    ],
+    "nordlocker": [
+      {
+        "cask": "nordlocker",
+        "count": "3"
+      }
+    ],
+    "nordvpn": [
+      {
+        "cask": "nordvpn",
+        "count": "1,576"
+      }
+    ],
+    "nosleep": [
+      {
+        "cask": "nosleep",
+        "count": "208"
+      }
+    ],
+    "nosql-workbench-for-amazon-dynamodb": [
+      {
+        "cask": "nosql-workbench-for-amazon-dynamodb",
+        "count": "217"
+      }
+    ],
+    "nosqlbooster-for-mongodb": [
+      {
+        "cask": "nosqlbooster-for-mongodb",
+        "count": "224"
+      }
+    ],
+    "nosqlclient": [
+      {
+        "cask": "nosqlclient",
+        "count": "23"
+      }
+    ],
+    "not-pacman": [
+      {
+        "cask": "not-pacman",
+        "count": "14"
+      }
+    ],
+    "not-tetris": [
+      {
+        "cask": "not-tetris",
+        "count": "22"
+      }
+    ],
+    "notable": [
+      {
+        "cask": "notable",
+        "count": "361"
+      }
+    ],
+    "notational-velocity": [
+      {
+        "cask": "notational-velocity",
+        "count": "42"
+      }
+    ],
+    "notebooks": [
+      {
+        "cask": "notebooks",
+        "count": "24"
+      }
+    ],
+    "notedup": [
+      {
+        "cask": "notedup",
+        "count": "6"
+      }
+    ],
+    "noteplan": [
+      {
+        "cask": "noteplan",
+        "count": "11"
+      }
+    ],
+    "noti": [
+      {
+        "cask": "noti",
+        "count": "81"
+      }
+    ],
+    "notion": [
+      {
+        "cask": "notion",
+        "count": "3,666"
+      }
+    ],
+    "noto": [
+      {
+        "cask": "noto",
+        "count": "10"
+      }
+    ],
+    "noun-project": [
+      {
+        "cask": "noun-project",
+        "count": "37"
+      }
+    ],
+    "nova67p": [
+      {
+        "cask": "nova67p",
+        "count": "2"
+      }
+    ],
+    "novabench": [
+      {
+        "cask": "novabench",
+        "count": "45"
+      }
+    ],
+    "now": [
+      {
+        "cask": "now",
+        "count": "272"
+      }
+    ],
+    "now-tv-player": [
+      {
+        "cask": "now-tv-player",
+        "count": "18"
+      }
+    ],
+    "nowplayingitunes": [
+      {
+        "cask": "nowplayingitunes",
+        "count": "1"
+      }
+    ],
+    "nowplayingtweet": [
+      {
+        "cask": "nowplayingtweet",
+        "count": "17"
+      }
+    ],
+    "nox-app-player": [
+      {
+        "cask": "nox-app-player",
+        "count": "1"
+      }
+    ],
+    "noxappplayer": [
+      {
+        "cask": "noxappplayer",
+        "count": "275"
+      }
+    ],
+    "nozbe": [
+      {
+        "cask": "nozbe",
+        "count": "12"
+      }
+    ],
+    "nrlquaker-winbox": [
+      {
+        "cask": "nrlquaker-winbox",
+        "count": "2,276"
+      }
+    ],
+    "nrr1": [
+      {
+        "cask": "nrr1",
+        "count": "2"
+      }
+    ],
+    "nslogger": [
+      {
+        "cask": "nslogger",
+        "count": "8"
+      }
+    ],
+    "nsregextester": [
+      {
+        "cask": "nsregextester",
+        "count": "10"
+      }
+    ],
+    "nteract": [
+      {
+        "cask": "nteract",
+        "count": "216"
+      }
+    ],
+    "nucc": [
+      {
+        "cask": "nucc",
+        "count": "20"
+      }
+    ],
+    "nuccdev": [
+      {
+        "cask": "nuccdev",
+        "count": "4"
+      }
+    ],
+    "nuclear": [
+      {
+        "cask": "nuclear",
+        "count": "39"
+      }
+    ],
+    "nucleo": [
+      {
+        "cask": "nucleo",
+        "count": "35"
+      }
+    ],
+    "nuclino": [
+      {
+        "cask": "nuclino",
+        "count": "7"
+      }
+    ],
+    "nulloy": [
+      {
+        "cask": "nulloy",
+        "count": "5"
+      }
+    ],
+    "nullpomino": [
+      {
+        "cask": "nullpomino",
+        "count": "6"
+      }
+    ],
+    "numi": [
+      {
+        "cask": "numi",
+        "count": "895"
+      }
+    ],
+    "nutstore": [
+      {
+        "cask": "nutstore",
+        "count": "125"
+      }
+    ],
+    "nvalt": [
+      {
+        "cask": "nvalt",
+        "count": "307"
+      }
+    ],
+    "nvidia-cuda": [
+      {
+        "cask": "nvidia-cuda",
+        "count": "69"
+      }
+    ],
+    "nvidia-geforce-now": [
+      {
+        "cask": "nvidia-geforce-now",
+        "count": "796"
+      }
+    ],
+    "nwjs": [
+      {
+        "cask": "nwjs",
+        "count": "74"
+      }
+    ],
+    "nzbget": [
+      {
+        "cask": "nzbget",
+        "count": "61"
+      }
+    ],
+    "nzbvortex": [
+      {
+        "cask": "nzbvortex",
+        "count": "18"
+      }
+    ],
+    "ob-xd": [
+      {
+        "cask": "ob-xd",
+        "count": "9"
+      }
+    ],
+    "obinslab-starter": [
+      {
+        "cask": "obinslab-starter",
+        "count": "68"
+      }
+    ],
+    "objectivesharpie": [
+      {
+        "cask": "objectivesharpie",
+        "count": "11"
+      }
+    ],
+    "obs": [
+      {
+        "cask": "obs",
+        "count": "4,029"
+      }
+    ],
+    "obyte": [
+      {
+        "cask": "obyte",
+        "count": "3"
+      }
+    ],
+    "ocenaudio": [
+      {
+        "cask": "ocenaudio",
+        "count": "241"
+      }
+    ],
+    "oclint": [
+      {
+        "cask": "oclint",
+        "count": "524"
+      }
+    ],
+    "octave-app": [
+      {
+        "cask": "octave-app",
+        "count": "343"
+      }
+    ],
+    "octomouse": [
+      {
+        "cask": "octomouse",
+        "count": "12"
+      }
+    ],
+    "octoscreen": [
+      {
+        "cask": "octoscreen",
+        "count": "3"
+      }
+    ],
+    "odio": [
+      {
+        "cask": "odio",
+        "count": "22"
+      }
+    ],
+    "odrive": [
+      {
+        "cask": "odrive",
+        "count": "82"
+      }
+    ],
+    "ogdesign-eagle": [
+      {
+        "cask": "ogdesign-eagle",
+        "count": "60"
+      }
+    ],
+    "okapi": [
+      {
+        "cask": "okapi",
+        "count": "1"
+      }
+    ],
+    "okuna-desktop": [
+      {
+        "cask": "okuna-desktop",
+        "count": "2"
+      }
+    ],
+    "olive": [
+      {
+        "cask": "olive",
+        "count": "35"
+      }
+    ],
+    "omegat": [
+      {
+        "cask": "omegat",
+        "count": "22"
+      }
+    ],
+    "omnidazzle": [
+      {
+        "cask": "omnidazzle",
+        "count": "23"
+      }
+    ],
+    "omnidb": [
+      {
+        "cask": "omnidb",
+        "count": "45"
+      }
+    ],
+    "omnidisksweeper": [
+      {
+        "cask": "omnidisksweeper",
+        "count": "742"
+      }
+    ],
+    "omnifocus": [
+      {
+        "cask": "omnifocus",
+        "count": "518"
+      }
+    ],
+    "omnifocus2": [
+      {
+        "cask": "omnifocus2",
+        "count": "4"
+      }
+    ],
+    "omnigraffle": [
+      {
+        "cask": "omnigraffle",
+        "count": "810"
+      }
+    ],
+    "omnigraffle6": [
+      {
+        "cask": "omnigraffle6",
+        "count": "7"
+      }
+    ],
+    "omnioutliner": [
+      {
+        "cask": "omnioutliner",
+        "count": "224"
+      }
+    ],
+    "omniplan": [
+      {
+        "cask": "omniplan",
+        "count": "185"
+      }
+    ],
+    "omnipresence": [
+      {
+        "cask": "omnipresence",
+        "count": "27"
+      }
+    ],
+    "omniweb": [
+      {
+        "cask": "omniweb",
+        "count": "6"
+      }
+    ],
+    "omx-ebooks": [
+      {
+        "cask": "omx-ebooks",
+        "count": "3"
+      }
+    ],
+    "ondesoft-audiobook-converter": [
+      {
+        "cask": "ondesoft-audiobook-converter",
+        "count": "10"
+      }
+    ],
+    "one-switch": [
+      {
+        "cask": "one-switch",
+        "count": "152"
+      }
+    ],
+    "onecast": [
+      {
+        "cask": "onecast",
+        "count": "27"
+      }
+    ],
+    "onedrive": [
+      {
+        "cask": "onedrive",
+        "count": "1,292"
+      }
+    ],
+    "onenote-importer-preview": [
+      {
+        "cask": "onenote-importer-preview",
+        "count": "18"
+      }
+    ],
+    "onepile": [
+      {
+        "cask": "onepile",
+        "count": "3"
+      }
+    ],
+    "oni": [
+      {
+        "cask": "oni",
+        "count": "286"
+      }
+    ],
+    "onionshare": [
+      {
+        "cask": "onionshare",
+        "count": "77"
+      }
+    ],
+    "onivim2": [
+      {
+        "cask": "onivim2",
+        "count": "3"
+      }
+    ],
+    "onlyoffice": [
+      {
+        "cask": "onlyoffice",
+        "count": "112"
+      }
+    ],
+    "onyx": [
+      {
+        "cask": "onyx",
+        "count": "2,752"
+      }
+    ],
+    "oolite": [
+      {
+        "cask": "oolite",
+        "count": "10"
+      }
+    ],
+    "open-ecard": [
+      {
+        "cask": "open-ecard",
+        "count": "1"
+      }
+    ],
+    "open-in-code": [
+      {
+        "cask": "open-in-code",
+        "count": "223"
+      }
+    ],
+    "open-jupyter": [
+      {
+        "cask": "open-jupyter",
+        "count": "2"
+      }
+    ],
+    "open-with-player": [
+      {
+        "cask": "open-with-player",
+        "count": "1"
+      }
+    ],
+    "openarena": [
+      {
+        "cask": "openarena",
+        "count": "124"
+      }
+    ],
+    "openaudible": [
+      {
+        "cask": "openaudible",
+        "count": "64"
+      }
+    ],
+    "openbazaar": [
+      {
+        "cask": "openbazaar",
+        "count": "17"
+      }
+    ],
+    "openbci-gui": [
+      {
+        "cask": "openbci-gui",
+        "count": "1"
+      }
+    ],
+    "openboard": [
+      {
+        "cask": "openboard",
+        "count": "108"
+      }
+    ],
+    "openboardview": [
+      {
+        "cask": "openboardview",
+        "count": "21"
+      }
+    ],
+    "openconnect-gui": [
+      {
+        "cask": "openconnect-gui",
+        "count": "1,748"
+      }
+    ],
+    "opencore-configurator": [
+      {
+        "cask": "opencore-configurator",
+        "count": "95"
+      }
+    ],
+    "opencpn": [
+      {
+        "cask": "opencpn",
+        "count": "9"
+      }
+    ],
+    "opendnsupdater": [
+      {
+        "cask": "opendnsupdater",
+        "count": "28"
+      }
+    ],
+    "openemu": [
+      {
+        "cask": "openemu",
+        "count": "1,166"
+      }
+    ],
+    "openemu-experimental": [
+      {
+        "cask": "openemu-experimental",
+        "count": "101"
+      }
+    ],
+    "openemulator": [
+      {
+        "cask": "openemulator",
+        "count": "3"
+      }
+    ],
+    "openfile": [
+      {
+        "cask": "openfile",
+        "count": "1"
+      }
+    ],
+    "openfluid": [
+      {
+        "cask": "openfluid",
+        "count": "4"
+      }
+    ],
+    "openframeworks": [
+      {
+        "cask": "openframeworks",
+        "count": "26"
+      }
+    ],
+    "openineditor-lite": [
+      {
+        "cask": "openineditor-lite",
+        "count": "174"
+      }
+    ],
+    "openinterminal": [
+      {
+        "cask": "openinterminal",
+        "count": "1,230"
+      }
+    ],
+    "openinterminal-lite": [
+      {
+        "cask": "openinterminal-lite",
+        "count": "506"
+      }
+    ],
+    "openkey": [
+      {
+        "cask": "openkey",
+        "count": "109"
+      }
+    ],
+    "openlp": [
+      {
+        "cask": "openlp",
+        "count": "10"
+      }
+    ],
+    "openmsx": [
+      {
+        "cask": "openmsx",
+        "count": "9"
+      }
+    ],
+    "openmtp": [
+      {
+        "cask": "openmtp",
+        "count": "399"
+      }
+    ],
+    "openmw": [
+      {
+        "cask": "openmw",
+        "count": "22"
+      }
+    ],
+    "opennx": [
+      {
+        "cask": "opennx",
+        "count": "3"
+      }
+    ],
+    "openoffice": [
+      {
+        "cask": "openoffice",
+        "count": "772"
+      }
+    ],
+    "openpht": [
+      {
+        "cask": "openpht",
+        "count": "14"
+      }
+    ],
+    "openra": [
+      {
+        "cask": "openra",
+        "count": "511"
+      }
+    ],
+    "openra-playtest": [
+      {
+        "cask": "openra-playtest",
+        "count": "1"
+      }
+    ],
+    "openrct2": [
+      {
+        "cask": "openrct2",
+        "count": "50"
+      }
+    ],
+    "openrefine": [
+      {
+        "cask": "openrefine",
+        "count": "262"
+      }
+    ],
+    "opensc": [
+      {
+        "cask": "opensc",
+        "count": "291"
+      }
+    ],
+    "openscad": [
+      {
+        "cask": "openscad",
+        "count": "522"
+      }
+    ],
+    "openscad-snapshot": [
+      {
+        "cask": "openscad-snapshot",
+        "count": "5"
+      }
+    ],
+    "opensesame": [
+      {
+        "cask": "opensesame",
+        "count": "7"
+      }
+    ],
+    "openshot-video-editor": [
+      {
+        "cask": "openshot-video-editor",
+        "count": "486"
+      }
+    ],
+    "opensim": [
+      {
+        "cask": "opensim",
+        "count": "201"
+      }
+    ],
+    "opensong": [
+      {
+        "cask": "opensong",
+        "count": "4"
+      }
+    ],
+    "opentoonz": [
+      {
+        "cask": "opentoonz",
+        "count": "26"
+      }
+    ],
+    "openttd": [
+      {
+        "cask": "openttd",
+        "count": "196"
+      }
+    ],
+    "openvanilla": [
+      {
+        "cask": "openvanilla",
+        "count": "25"
+      }
+    ],
+    "openvisualtraceroute": [
+      {
+        "cask": "openvisualtraceroute",
+        "count": "68"
+      }
+    ],
+    "openvpn-connect": [
+      {
+        "cask": "openvpn-connect",
+        "count": "1,190"
+      }
+    ],
+    "openvpn-connect-beta": [
+      {
+        "cask": "openvpn-connect-beta",
+        "count": "40"
+      }
+    ],
+    "openwebstart": [
+      {
+        "cask": "openwebstart",
+        "count": "107"
+      }
+    ],
+    "openxcom": [
+      {
+        "cask": "openxcom",
+        "count": "16"
+      }
+    ],
+    "openzfs": [
+      {
+        "cask": "openzfs",
+        "count": "139"
+      }
+    ],
+    "opera": [
+      {
+        "cask": "opera",
+        "count": "3,262"
+      }
+    ],
+    "opera-beta": [
+      {
+        "cask": "opera-beta",
+        "count": "59"
+      }
+    ],
+    "opera-developer": [
+      {
+        "cask": "opera-developer",
+        "count": "112"
+      }
+    ],
+    "opera-mail": [
+      {
+        "cask": "opera-mail",
+        "count": "13"
+      }
+    ],
+    "opera-mobile-emulator": [
+      {
+        "cask": "opera-mobile-emulator",
+        "count": "18"
+      }
+    ],
+    "opera-neon": [
+      {
+        "cask": "opera-neon",
+        "count": "48"
+      }
+    ],
+    "operadriver": [
+      {
+        "cask": "operadriver",
+        "count": "47"
+      }
+    ],
+    "optimage": [
+      {
+        "cask": "optimage",
+        "count": "31"
+      }
+    ],
+    "optimal-layout": [
+      {
+        "cask": "optimal-layout",
+        "count": "18"
+      }
+    ],
+    "oracle-jdk": [
+      {
+        "cask": "oracle-jdk",
+        "count": "3,057"
+      }
+    ],
+    "oracle-jdk-11.0.3": [
+      {
+        "cask": "oracle-jdk-11.0.3",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-7u80": [
+      {
+        "cask": "oracle-jdk-7u80",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u101": [
+      {
+        "cask": "oracle-jdk-8u101",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u40": [
+      {
+        "cask": "oracle-jdk-8u40",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u45": [
+      {
+        "cask": "oracle-jdk-8u45",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u51": [
+      {
+        "cask": "oracle-jdk-8u51",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u60": [
+      {
+        "cask": "oracle-jdk-8u60",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-8u74": [
+      {
+        "cask": "oracle-jdk-8u74",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk-javadoc": [
+      {
+        "cask": "oracle-jdk-javadoc",
+        "count": "150"
+      }
+    ],
+    "oracle-jdk11": [
+      {
+        "cask": "oracle-jdk11",
+        "count": "1"
+      }
+    ],
+    "oracle-jdk7": [
+      {
+        "cask": "oracle-jdk7",
+        "count": "1"
+      }
+    ],
+    "orange": [
+      {
+        "cask": "orange",
+        "count": "42"
+      }
+    ],
+    "origami-studio": [
+      {
+        "cask": "origami-studio",
+        "count": "47"
+      }
+    ],
+    "origin": [
+      {
+        "cask": "origin",
+        "count": "309"
+      }
+    ],
+    "orka": [
+      {
+        "cask": "orka",
+        "count": "23"
+      }
+    ],
+    "oryoki": [
+      {
+        "cask": "oryoki",
+        "count": "3"
+      }
+    ],
+    "osbuddy": [
+      {
+        "cask": "osbuddy",
+        "count": "5"
+      }
+    ],
+    "oscar": [
+      {
+        "cask": "oscar",
+        "count": "13"
+      }
+    ],
+    "oscilloscope": [
+      {
+        "cask": "oscilloscope",
+        "count": "5"
+      }
+    ],
+    "osctester": [
+      {
+        "cask": "osctester",
+        "count": "13"
+      }
+    ],
+    "osctl": [
+      {
+        "cask": "osctl",
+        "count": "2"
+      }
+    ],
+    "osirix-quicklook": [
+      {
+        "cask": "osirix-quicklook",
+        "count": "67"
+      }
+    ],
+    "osmc": [
+      {
+        "cask": "osmc",
+        "count": "26"
+      }
+    ],
+    "osquery": [
+      {
+        "cask": "osquery",
+        "count": "8"
+      }
+    ],
+    "osu-development": [
+      {
+        "cask": "osu-development",
+        "count": "41"
+      }
+    ],
+    "osxfuse": [
+      {
+        "cask": "osxfuse",
+        "count": "29,667"
+      }
+    ],
+    "osxfuse-dev": [
+      {
+        "cask": "osxfuse-dev",
+        "count": "1"
+      }
+    ],
+    "otp-auth": [
+      {
+        "cask": "otp-auth",
+        "count": "108"
+      }
+    ],
+    "otter-browser": [
+      {
+        "cask": "otter-browser",
+        "count": "18"
+      }
+    ],
+    "otx": [
+      {
+        "cask": "otx",
+        "count": "99"
+      }
+    ],
+    "outguess": [
+      {
+        "cask": "outguess",
+        "count": "76"
+      }
+    ],
+    "outline": [
+      {
+        "cask": "outline",
+        "count": "45"
+      }
+    ],
+    "outline-manager": [
+      {
+        "cask": "outline-manager",
+        "count": "110"
+      }
+    ],
+    "outset": [
+      {
+        "cask": "outset",
+        "count": "22"
+      }
+    ],
+    "outwit-hub": [
+      {
+        "cask": "outwit-hub",
+        "count": "4"
+      }
+    ],
+    "overdrive-media-console": [
+      {
+        "cask": "overdrive-media-console",
+        "count": "23"
+      }
+    ],
+    "overflow": [
+      {
+        "cask": "overflow",
+        "count": "10"
+      }
+    ],
+    "overkill": [
+      {
+        "cask": "overkill",
+        "count": "54"
+      }
+    ],
+    "oversight": [
+      {
+        "cask": "oversight",
+        "count": "186"
+      }
+    ],
+    "ovito": [
+      {
+        "cask": "ovito",
+        "count": "1"
+      }
+    ],
+    "owasp-zap": [
+      {
+        "cask": "owasp-zap",
+        "count": "822"
+      }
+    ],
+    "owncloud": [
+      {
+        "cask": "owncloud",
+        "count": "236"
+      }
+    ],
+    "oxygen-xml-editor": [
+      {
+        "cask": "oxygen-xml-editor",
+        "count": "61"
+      }
+    ],
+    "p4merge": [
+      {
+        "cask": "p4merge",
+        "count": "1"
+      }
+    ],
+    "p4v": [
+      {
+        "cask": "p4v",
+        "count": "552"
+      }
+    ],
+    "p6sync": [
+      {
+        "cask": "p6sync",
+        "count": "4"
+      }
+    ],
+    "pablodraw": [
+      {
+        "cask": "pablodraw",
+        "count": "10"
+      }
+    ],
+    "pacifist": [
+      {
+        "cask": "pacifist",
+        "count": "106"
+      }
+    ],
+    "packages": [
+      {
+        "cask": "packages",
+        "count": "203"
+      }
+    ],
+    "packet-cli": [
+      {
+        "cask": "packet-cli",
+        "count": "2"
+      }
+    ],
+    "packet-peeper": [
+      {
+        "cask": "packet-peeper",
+        "count": "17"
+      }
+    ],
+    "packetproxy": [
+      {
+        "cask": "packetproxy",
+        "count": "12"
+      }
+    ],
+    "packetsender": [
+      {
+        "cask": "packetsender",
+        "count": "611"
+      }
+    ],
+    "pages-data-merge": [
+      {
+        "cask": "pages-data-merge",
+        "count": "4"
+      }
+    ],
+    "pagico": [
+      {
+        "cask": "pagico",
+        "count": "18"
+      }
+    ],
+    "paintbrush": [
+      {
+        "cask": "paintbrush",
+        "count": "702"
+      }
+    ],
+    "paintcode": [
+      {
+        "cask": "paintcode",
+        "count": "30"
+      }
+    ],
+    "pallotron-yubiswitch": [
+      {
+        "cask": "pallotron-yubiswitch",
+        "count": "27"
+      }
+    ],
+    "panda": [
+      {
+        "cask": "panda",
+        "count": "19"
+      }
+    ],
+    "pandora": [
+      {
+        "cask": "pandora",
+        "count": "72"
+      }
+    ],
+    "panic-unison": [
+      {
+        "cask": "panic-unison",
+        "count": "11"
+      }
+    ],
+    "panoply": [
+      {
+        "cask": "panoply",
+        "count": "61"
+      }
+    ],
+    "paparazzi": [
+      {
+        "cask": "paparazzi",
+        "count": "42"
+      }
+    ],
+    "paper": [
+      {
+        "cask": "paper",
+        "count": "128"
+      }
+    ],
+    "papers": [
+      {
+        "cask": "papers",
+        "count": "171"
+      }
+    ],
+    "paperspace": [
+      {
+        "cask": "paperspace",
+        "count": "20"
+      }
+    ],
+    "papyrus": [
+      {
+        "cask": "papyrus",
+        "count": "32"
+      }
+    ],
+    "paragon-extfs": [
+      {
+        "cask": "paragon-extfs",
+        "count": "145"
+      }
+    ],
+    "paragon-ntfs": [
+      {
+        "cask": "paragon-ntfs",
+        "count": "465"
+      }
+    ],
+    "paragon-vmdk-mounter": [
+      {
+        "cask": "paragon-vmdk-mounter",
+        "count": "81"
+      }
+    ],
+    "parallels": [
+      {
+        "cask": "parallels",
+        "count": "2,371"
+      }
+    ],
+    "parallels-access": [
+      {
+        "cask": "parallels-access",
+        "count": "43"
+      }
+    ],
+    "parallels-client": [
+      {
+        "cask": "parallels-client",
+        "count": "86"
+      }
+    ],
+    "parallels-toolbox": [
+      {
+        "cask": "parallels-toolbox",
+        "count": "128"
+      }
+    ],
+    "parallels-virtualization-sdk": [
+      {
+        "cask": "parallels-virtualization-sdk",
+        "count": "102"
+      }
+    ],
+    "parallels12": [
+      {
+        "cask": "parallels12",
+        "count": "6"
+      }
+    ],
+    "parallels13": [
+      {
+        "cask": "parallels13",
+        "count": "12"
+      }
+    ],
+    "paraview": [
+      {
+        "cask": "paraview",
+        "count": "276"
+      }
+    ],
+    "parse": [
+      {
+        "cask": "parse",
+        "count": "13"
+      }
+    ],
+    "parsec": [
+      {
+        "cask": "parsec",
+        "count": "340"
+      }
+    ],
+    "parsehub": [
+      {
+        "cask": "parsehub",
+        "count": "14"
+      }
+    ],
+    "particle-dev": [
+      {
+        "cask": "particle-dev",
+        "count": "5"
+      }
+    ],
+    "pashua": [
+      {
+        "cask": "pashua",
+        "count": "14"
+      }
+    ],
+    "passformacos": [
+      {
+        "cask": "passformacos",
+        "count": "12"
+      }
+    ],
+    "password-assistant": [
+      {
+        "cask": "password-assistant",
+        "count": "13"
+      }
+    ],
+    "password-gorilla": [
+      {
+        "cask": "password-gorilla",
+        "count": "69"
+      }
+    ],
+    "paste": [
+      {
+        "cask": "paste",
+        "count": "34"
+      }
+    ],
+    "pastebot": [
+      {
+        "cask": "pastebot",
+        "count": "104"
+      }
+    ],
+    "pastor": [
+      {
+        "cask": "pastor",
+        "count": "1"
+      }
+    ],
+    "patchwork": [
+      {
+        "cask": "patchwork",
+        "count": "104"
+      }
+    ],
+    "path-finder": [
+      {
+        "cask": "path-finder",
+        "count": "273"
+      }
+    ],
+    "path-finder7": [
+      {
+        "cask": "path-finder7",
+        "count": "1"
+      }
+    ],
+    "paw": [
+      {
+        "cask": "paw",
+        "count": "684"
+      }
+    ],
+    "pb-for-desktop": [
+      {
+        "cask": "pb-for-desktop",
+        "count": "1"
+      }
+    ],
+    "pcloud-drive": [
+      {
+        "cask": "pcloud-drive",
+        "count": "9"
+      }
+    ],
+    "pd": [
+      {
+        "cask": "pd",
+        "count": "73"
+      }
+    ],
+    "pd-extended": [
+      {
+        "cask": "pd-extended",
+        "count": "22"
+      }
+    ],
+    "pd-l2ork": [
+      {
+        "cask": "pd-l2ork",
+        "count": "14"
+      }
+    ],
+    "pdf-converter-master": [
+      {
+        "cask": "pdf-converter-master",
+        "count": "23"
+      }
+    ],
+    "pdf-expert": [
+      {
+        "cask": "pdf-expert",
+        "count": "1,061"
+      }
+    ],
+    "pdf-expert-beta": [
+      {
+        "cask": "pdf-expert-beta",
+        "count": "15"
+      }
+    ],
+    "pdf-images": [
+      {
+        "cask": "pdf-images",
+        "count": "67"
+      }
+    ],
+    "pdf-squeezer": [
+      {
+        "cask": "pdf-squeezer",
+        "count": "34"
+      }
+    ],
+    "pdf-toolbox": [
+      {
+        "cask": "pdf-toolbox",
+        "count": "47"
+      }
+    ],
+    "pdfelement": [
+      {
+        "cask": "pdfelement",
+        "count": "175"
+      }
+    ],
+    "pdfelement-express": [
+      {
+        "cask": "pdfelement-express",
+        "count": "20"
+      }
+    ],
+    "pdfextractor": [
+      {
+        "cask": "pdfextractor",
+        "count": "17"
+      }
+    ],
+    "pdfinfo": [
+      {
+        "cask": "pdfinfo",
+        "count": "329"
+      }
+    ],
+    "pdfkey-pro": [
+      {
+        "cask": "pdfkey-pro",
+        "count": "1"
+      }
+    ],
+    "pdfpen": [
+      {
+        "cask": "pdfpen",
+        "count": "49"
+      }
+    ],
+    "pdfpenpro": [
+      {
+        "cask": "pdfpenpro",
+        "count": "79"
+      }
+    ],
+    "pdfsam-basic": [
+      {
+        "cask": "pdfsam-basic",
+        "count": "219"
+      }
+    ],
+    "pdfshaver": [
+      {
+        "cask": "pdfshaver",
+        "count": "14"
+      }
+    ],
+    "pdftk-server": [
+      {
+        "cask": "pdftk-server",
+        "count": "1"
+      }
+    ],
+    "pdftotext": [
+      {
+        "cask": "pdftotext",
+        "count": "979"
+      }
+    ],
+    "pdk": [
+      {
+        "cask": "pdk",
+        "count": "768"
+      }
+    ],
+    "pe-client-tools": [
+      {
+        "cask": "pe-client-tools",
+        "count": "44"
+      }
+    ],
+    "pe-client-tools-2018.1": [
+      {
+        "cask": "pe-client-tools-2018.1",
+        "count": "4"
+      }
+    ],
+    "pe-client-tools-2019.3": [
+      {
+        "cask": "pe-client-tools-2019.3",
+        "count": "2"
+      }
+    ],
+    "peakhour": [
+      {
+        "cask": "peakhour",
+        "count": "13"
+      }
+    ],
+    "penc": [
+      {
+        "cask": "penc",
+        "count": "42"
+      }
+    ],
+    "pencil": [
+      {
+        "cask": "pencil",
+        "count": "221"
+      }
+    ],
+    "pencil2d": [
+      {
+        "cask": "pencil2d",
+        "count": "41"
+      }
+    ],
+    "pennywise": [
+      {
+        "cask": "pennywise",
+        "count": "323"
+      }
+    ],
+    "people-plus-content-ip": [
+      {
+        "cask": "people-plus-content-ip",
+        "count": "8"
+      }
+    ],
+    "perforce": [
+      {
+        "cask": "perforce",
+        "count": "169"
+      }
+    ],
+    "periphery": [
+      {
+        "cask": "periphery",
+        "count": "957"
+      }
+    ],
+    "permissionscanner": [
+      {
+        "cask": "permissionscanner",
+        "count": "5"
+      }
+    ],
+    "permute": [
+      {
+        "cask": "permute",
+        "count": "146"
+      }
+    ],
+    "persepolis-download-manager": [
+      {
+        "cask": "persepolis-download-manager",
+        "count": "92"
+      }
+    ],
+    "perspec": [
+      {
+        "cask": "perspec",
+        "count": "5"
+      }
+    ],
+    "pester": [
+      {
+        "cask": "pester",
+        "count": "21"
+      }
+    ],
+    "pext": [
+      {
+        "cask": "pext",
+        "count": "7"
+      }
+    ],
+    "pext-nightly": [
+      {
+        "cask": "pext-nightly",
+        "count": "13"
+      }
+    ],
+    "peyton-xbox360-controller-driver-unofficial": [
+      {
+        "cask": "peyton-xbox360-controller-driver-unofficial",
+        "count": "1"
+      }
+    ],
+    "pflists": [
+      {
+        "cask": "pflists",
+        "count": "7"
+      }
+    ],
+    "pg-8x": [
+      {
+        "cask": "pg-8x",
+        "count": "4"
+      }
+    ],
+    "pg-commander": [
+      {
+        "cask": "pg-commander",
+        "count": "53"
+      }
+    ],
+    "pgadmin3": [
+      {
+        "cask": "pgadmin3",
+        "count": "175"
+      }
+    ],
+    "pgadmin4": [
+      {
+        "cask": "pgadmin4",
+        "count": "5,239"
+      }
+    ],
+    "pgmodeler": [
+      {
+        "cask": "pgmodeler",
+        "count": "9"
+      }
+    ],
+    "phantomjs": [
+      {
+        "cask": "phantomjs",
+        "count": "5,460"
+      }
+    ],
+    "phantomjs-sakura": [
+      {
+        "cask": "phantomjs-sakura",
+        "count": "1"
+      }
+    ],
+    "pharo-launcher": [
+      {
+        "cask": "pharo-launcher",
+        "count": "20"
+      }
+    ],
+    "phew": [
+      {
+        "cask": "phew",
+        "count": "15"
+      }
+    ],
+    "phiewer": [
+      {
+        "cask": "phiewer",
+        "count": "23"
+      }
+    ],
+    "philips-hue-sync": [
+      {
+        "cask": "philips-hue-sync",
+        "count": "71"
+      }
+    ],
+    "phocus": [
+      {
+        "cask": "phocus",
+        "count": "8"
+      }
+    ],
+    "phoenix": [
+      {
+        "cask": "phoenix",
+        "count": "173"
+      }
+    ],
+    "phoenix-slides": [
+      {
+        "cask": "phoenix-slides",
+        "count": "12"
+      }
+    ],
+    "phonebrowse": [
+      {
+        "cask": "phonebrowse",
+        "count": "4"
+      }
+    ],
+    "phoneclean": [
+      {
+        "cask": "phoneclean",
+        "count": "8"
+      }
+    ],
+    "phonegap": [
+      {
+        "cask": "phonegap",
+        "count": "67"
+      }
+    ],
+    "phonerescue": [
+      {
+        "cask": "phonerescue",
+        "count": "8"
+      }
+    ],
+    "phonetrans": [
+      {
+        "cask": "phonetrans",
+        "count": "7"
+      }
+    ],
+    "photo-supreme-single-user": [
+      {
+        "cask": "photo-supreme-single-user",
+        "count": "2"
+      }
+    ],
+    "photoninja": [
+      {
+        "cask": "photoninja",
+        "count": "5"
+      }
+    ],
+    "photosweeper-x": [
+      {
+        "cask": "photosweeper-x",
+        "count": "13"
+      }
+    ],
+    "photosync": [
+      {
+        "cask": "photosync",
+        "count": "14"
+      }
+    ],
+    "photozoom-pro": [
+      {
+        "cask": "photozoom-pro",
+        "count": "4"
+      }
+    ],
+    "phpstorm": [
+      {
+        "cask": "phpstorm",
+        "count": "1,853"
+      }
+    ],
+    "phpstorm-perpetual": [
+      {
+        "cask": "phpstorm-perpetual",
+        "count": "4"
+      }
+    ],
+    "phpstorm2016": [
+      {
+        "cask": "phpstorm2016",
+        "count": "6"
+      }
+    ],
+    "physicseditor": [
+      {
+        "cask": "physicseditor",
+        "count": "9"
+      }
+    ],
+    "pibakery": [
+      {
+        "cask": "pibakery",
+        "count": "51"
+      }
+    ],
+    "picgo": [
+      {
+        "cask": "picgo",
+        "count": "378"
+      }
+    ],
+    "piezo": [
+      {
+        "cask": "piezo",
+        "count": "39"
+      }
+    ],
+    "pikopixel": [
+      {
+        "cask": "pikopixel",
+        "count": "12"
+      }
+    ],
+    "pine": [
+      {
+        "cask": "pine",
+        "count": "170"
+      }
+    ],
+    "pineapple": [
+      {
+        "cask": "pineapple",
+        "count": "12"
+      }
+    ],
+    "pinegrow": [
+      {
+        "cask": "pinegrow",
+        "count": "12"
+      }
+    ],
+    "pingid": [
+      {
+        "cask": "pingid",
+        "count": "15"
+      }
+    ],
+    "pingmenu": [
+      {
+        "cask": "pingmenu",
+        "count": "7"
+      }
+    ],
+    "pingplotter": [
+      {
+        "cask": "pingplotter",
+        "count": "88"
+      }
+    ],
+    "pins": [
+      {
+        "cask": "pins",
+        "count": "2"
+      }
+    ],
+    "pinta": [
+      {
+        "cask": "pinta",
+        "count": "155"
+      }
+    ],
+    "pitchperfect": [
+      {
+        "cask": "pitchperfect",
+        "count": "3"
+      }
+    ],
+    "pixel-check": [
+      {
+        "cask": "pixel-check",
+        "count": "14"
+      }
+    ],
+    "pixel-picker": [
+      {
+        "cask": "pixel-picker",
+        "count": "57"
+      }
+    ],
+    "pixelmator": [
+      {
+        "cask": "pixelmator",
+        "count": "2"
+      }
+    ],
+    "pixelpeeper": [
+      {
+        "cask": "pixelpeeper",
+        "count": "4"
+      }
+    ],
+    "pixelsnap": [
+      {
+        "cask": "pixelsnap",
+        "count": "51"
+      }
+    ],
+    "pixelstick": [
+      {
+        "cask": "pixelstick",
+        "count": "10"
+      }
+    ],
+    "pjslint": [
+      {
+        "cask": "pjslint",
+        "count": "8"
+      }
+    ],
+    "plain-clip": [
+      {
+        "cask": "plain-clip",
+        "count": "13"
+      }
+    ],
+    "plan": [
+      {
+        "cask": "plan",
+        "count": "17"
+      }
+    ],
+    "plantronics-hub": [
+      {
+        "cask": "plantronics-hub",
+        "count": "49"
+      }
+    ],
+    "platelet": [
+      {
+        "cask": "platelet",
+        "count": "8"
+      }
+    ],
+    "platypus": [
+      {
+        "cask": "platypus",
+        "count": "332"
+      }
+    ],
+    "play": [
+      {
+        "cask": "play",
+        "count": "138"
+      }
+    ],
+    "playback": [
+      {
+        "cask": "playback",
+        "count": "4"
+      }
+    ],
+    "playmemories-home": [
+      {
+        "cask": "playmemories-home",
+        "count": "22"
+      }
+    ],
+    "playnow": [
+      {
+        "cask": "playnow",
+        "count": "110"
+      }
+    ],
+    "playonmac": [
+      {
+        "cask": "playonmac",
+        "count": "923"
+      }
+    ],
+    "plecs-standalone": [
+      {
+        "cask": "plecs-standalone",
+        "count": "3"
+      }
+    ],
+    "plex": [
+      {
+        "cask": "plex",
+        "count": "1,338"
+      }
+    ],
+    "plex-media-player": [
+      {
+        "cask": "plex-media-player",
+        "count": "946"
+      }
+    ],
+    "plex-media-server": [
+      {
+        "cask": "plex-media-server",
+        "count": "1,303"
+      }
+    ],
+    "plex-music": [
+      {
+        "cask": "plex-music",
+        "count": "1"
+      }
+    ],
+    "plexamp": [
+      {
+        "cask": "plexamp",
+        "count": "183"
+      }
+    ],
+    "pliim": [
+      {
+        "cask": "pliim",
+        "count": "13"
+      }
+    ],
+    "plistedit-pro": [
+      {
+        "cask": "plistedit-pro",
+        "count": "193"
+      }
+    ],
+    "plotdigitizer": [
+      {
+        "cask": "plotdigitizer",
+        "count": "15"
+      }
+    ],
+    "plover": [
+      {
+        "cask": "plover",
+        "count": "48"
+      }
+    ],
+    "plug": [
+      {
+        "cask": "plug",
+        "count": "105"
+      }
+    ],
+    "pluralsight": [
+      {
+        "cask": "pluralsight",
+        "count": "114"
+      }
+    ],
+    "plyr": [
+      {
+        "cask": "plyr",
+        "count": "3"
+      }
+    ],
+    "pngyu": [
+      {
+        "cask": "pngyu",
+        "count": "9"
+      }
+    ],
+    "pock": [
+      {
+        "cask": "pock",
+        "count": "722"
+      }
+    ],
+    "pocket-casts": [
+      {
+        "cask": "pocket-casts",
+        "count": "271"
+      }
+    ],
+    "podcastmenu": [
+      {
+        "cask": "podcastmenu",
+        "count": "36"
+      }
+    ],
+    "podman": [
+      {
+        "cask": "podman",
+        "count": "1,427"
+      }
+    ],
+    "podofyllin": [
+      {
+        "cask": "podofyllin",
+        "count": "3"
+      }
+    ],
+    "podolski": [
+      {
+        "cask": "podolski",
+        "count": "2"
+      }
+    ],
+    "poedit": [
+      {
+        "cask": "poedit",
+        "count": "251"
+      }
+    ],
+    "poi": [
+      {
+        "cask": "poi",
+        "count": "13"
+      }
+    ],
+    "pokemon-showdown": [
+      {
+        "cask": "pokemon-showdown",
+        "count": "21"
+      }
+    ],
+    "pokemon-trading-card-game-online": [
+      {
+        "cask": "pokemon-trading-card-game-online",
+        "count": "1"
+      }
+    ],
+    "pokerstars": [
+      {
+        "cask": "pokerstars",
+        "count": "140"
+      }
+    ],
+    "pokerth": [
+      {
+        "cask": "pokerth",
+        "count": "48"
+      }
+    ],
+    "polar-bookshelf": [
+      {
+        "cask": "polar-bookshelf",
+        "count": "77"
+      }
+    ],
+    "polycom-content": [
+      {
+        "cask": "polycom-content",
+        "count": "5"
+      }
+    ],
+    "polycom-realpresence": [
+      {
+        "cask": "polycom-realpresence",
+        "count": "29"
+      }
+    ],
+    "polymail": [
+      {
+        "cask": "polymail",
+        "count": "31"
+      }
+    ],
+    "polyphone": [
+      {
+        "cask": "polyphone",
+        "count": "7"
+      }
+    ],
+    "pomello": [
+      {
+        "cask": "pomello",
+        "count": "27"
+      }
+    ],
+    "pomodone": [
+      {
+        "cask": "pomodone",
+        "count": "59"
+      }
+    ],
+    "pomolectron": [
+      {
+        "cask": "pomolectron",
+        "count": "28"
+      }
+    ],
+    "pomotodo": [
+      {
+        "cask": "pomotodo",
+        "count": "83"
+      }
+    ],
+    "pomotroid": [
+      {
+        "cask": "pomotroid",
+        "count": "210"
+      }
+    ],
+    "pongsaver": [
+      {
+        "cask": "pongsaver",
+        "count": "10"
+      }
+    ],
+    "popchar": [
+      {
+        "cask": "popchar",
+        "count": "9"
+      }
+    ],
+    "popclip": [
+      {
+        "cask": "popclip",
+        "count": "124"
+      }
+    ],
+    "popcorn-time": [
+      {
+        "cask": "popcorn-time",
+        "count": "775"
+      }
+    ],
+    "popcorn-time-beta": [
+      {
+        "cask": "popcorn-time-beta",
+        "count": "119"
+      }
+    ],
+    "popmaker": [
+      {
+        "cask": "popmaker",
+        "count": "5"
+      }
+    ],
+    "popo": [
+      {
+        "cask": "popo",
+        "count": "11"
+      }
+    ],
+    "popsql": [
+      {
+        "cask": "popsql",
+        "count": "62"
+      }
+    ],
+    "port-map": [
+      {
+        "cask": "port-map",
+        "count": "1"
+      }
+    ],
+    "portfolioperformance": [
+      {
+        "cask": "portfolioperformance",
+        "count": "99"
+      }
+    ],
+    "porting-kit": [
+      {
+        "cask": "porting-kit",
+        "count": "124"
+      }
+    ],
+    "portingkit": [
+      {
+        "cask": "portingkit",
+        "count": "4"
+      }
+    ],
+    "post-haste": [
+      {
+        "cask": "post-haste",
+        "count": "10"
+      }
+    ],
+    "postbird": [
+      {
+        "cask": "postbird",
+        "count": "127"
+      }
+    ],
+    "postbox": [
+      {
+        "cask": "postbox",
+        "count": "154"
+      }
+    ],
+    "posterazor": [
+      {
+        "cask": "posterazor",
+        "count": "19"
+      }
+    ],
+    "postgres": [
+      {
+        "cask": "postgres",
+        "count": "1,331"
+      }
+    ],
+    "postgres-beta": [
+      {
+        "cask": "postgres-beta",
+        "count": "1"
+      }
+    ],
+    "postgrespreferencepane": [
+      {
+        "cask": "postgrespreferencepane",
+        "count": "56"
+      }
+    ],
+    "postico": [
+      {
+        "cask": "postico",
+        "count": "1,651"
+      }
+    ],
+    "postman": [
+      {
+        "cask": "postman",
+        "count": "23,991"
+      }
+    ],
+    "powder": [
+      {
+        "cask": "powder",
+        "count": "28"
+      }
+    ],
+    "powder-player": [
+      {
+        "cask": "powder-player",
+        "count": "2"
+      }
+    ],
+    "power-manager": [
+      {
+        "cask": "power-manager",
+        "count": "31"
+      }
+    ],
+    "powerpanel": [
+      {
+        "cask": "powerpanel",
+        "count": "9"
+      }
+    ],
+    "powerphotos": [
+      {
+        "cask": "powerphotos",
+        "count": "68"
+      }
+    ],
+    "powerselect": [
+      {
+        "cask": "powerselect",
+        "count": "1"
+      }
+    ],
+    "powershell": [
+      {
+        "cask": "powershell",
+        "count": "23,038"
+      }
+    ],
+    "powershell-preview": [
+      {
+        "cask": "powershell-preview",
+        "count": "1,007"
+      }
+    ],
+    "powershell6": [
+      {
+        "cask": "powershell6",
+        "count": "14"
+      }
+    ],
+    "powershell60": [
+      {
+        "cask": "powershell60",
+        "count": "11"
+      }
+    ],
+    "powerword": [
+      {
+        "cask": "powerword",
+        "count": "8"
+      }
+    ],
+    "ppamorim-fruit": [
+      {
+        "cask": "ppamorim-fruit",
+        "count": "1"
+      }
+    ],
+    "ppduck": [
+      {
+        "cask": "ppduck",
+        "count": "7"
+      }
+    ],
+    "pphelper": [
+      {
+        "cask": "pphelper",
+        "count": "4"
+      }
+    ],
+    "praat": [
+      {
+        "cask": "praat",
+        "count": "72"
+      }
+    ],
+    "pragmatapro": [
+      {
+        "cask": "pragmatapro",
+        "count": "11"
+      }
+    ],
+    "pratique": [
+      {
+        "cask": "pratique",
+        "count": "4"
+      }
+    ],
+    "precize": [
+      {
+        "cask": "precize",
+        "count": "4"
+      }
+    ],
+    "pref-setter": [
+      {
+        "cask": "pref-setter",
+        "count": "182"
+      }
+    ],
+    "preference-manager": [
+      {
+        "cask": "preference-manager",
+        "count": "6"
+      }
+    ],
+    "preferencecleaner": [
+      {
+        "cask": "preferencecleaner",
+        "count": "4"
+      }
+    ],
+    "preform": [
+      {
+        "cask": "preform",
+        "count": "24"
+      }
+    ],
+    "prefs-editor": [
+      {
+        "cask": "prefs-editor",
+        "count": "35"
+      }
+    ],
+    "prepros": [
+      {
+        "cask": "prepros",
+        "count": "48"
+      }
+    ],
+    "presentation": [
+      {
+        "cask": "presentation",
+        "count": "133"
+      }
+    ],
+    "pretzel": [
+      {
+        "cask": "pretzel",
+        "count": "20"
+      }
+    ],
+    "prey": [
+      {
+        "cask": "prey",
+        "count": "32"
+      }
+    ],
+    "prezi-classic": [
+      {
+        "cask": "prezi-classic",
+        "count": "11"
+      }
+    ],
+    "prezi-next": [
+      {
+        "cask": "prezi-next",
+        "count": "16"
+      }
+    ],
+    "prince": [
+      {
+        "cask": "prince",
+        "count": "311"
+      }
+    ],
+    "principle": [
+      {
+        "cask": "principle",
+        "count": "34"
+      }
+    ],
+    "printopia": [
+      {
+        "cask": "printopia",
+        "count": "25"
+      }
+    ],
+    "printrun": [
+      {
+        "cask": "printrun",
+        "count": "76"
+      }
+    ],
+    "prismatik": [
+      {
+        "cask": "prismatik",
+        "count": "19"
+      }
+    ],
+    "pritunl": [
+      {
+        "cask": "pritunl",
+        "count": "631"
+      }
+    ],
+    "privacy-services-manager": [
+      {
+        "cask": "privacy-services-manager",
+        "count": "2"
+      }
+    ],
+    "private-eye": [
+      {
+        "cask": "private-eye",
+        "count": "72"
+      }
+    ],
+    "private-internet-access": [
+      {
+        "cask": "private-internet-access",
+        "count": "626"
+      }
+    ],
+    "privatetunnel": [
+      {
+        "cask": "privatetunnel",
+        "count": "19"
+      }
+    ],
+    "prizmo": [
+      {
+        "cask": "prizmo",
+        "count": "118"
+      }
+    ],
+    "processing": [
+      {
+        "cask": "processing",
+        "count": "455"
+      }
+    ],
+    "processing2": [
+      {
+        "cask": "processing2",
+        "count": "27"
+      }
+    ],
+    "procexp": [
+      {
+        "cask": "procexp",
+        "count": "13"
+      }
+    ],
+    "proclaim": [
+      {
+        "cask": "proclaim",
+        "count": "4"
+      }
+    ],
+    "product-hunt": [
+      {
+        "cask": "product-hunt",
+        "count": "15"
+      }
+    ],
+    "profet": [
+      {
+        "cask": "profet",
+        "count": "6"
+      }
+    ],
+    "profilecreator": [
+      {
+        "cask": "profilecreator",
+        "count": "36"
+      }
+    ],
+    "profilemanager": [
+      {
+        "cask": "profilemanager",
+        "count": "5"
+      }
+    ],
+    "profilesmanager": [
+      {
+        "cask": "profilesmanager",
+        "count": "2"
+      }
+    ],
+    "profind": [
+      {
+        "cask": "profind",
+        "count": "2"
+      }
+    ],
+    "programmer-dvorak": [
+      {
+        "cask": "programmer-dvorak",
+        "count": "18"
+      }
+    ],
+    "progressive-downloader": [
+      {
+        "cask": "progressive-downloader",
+        "count": "50"
+      }
+    ],
+    "projectlibre": [
+      {
+        "cask": "projectlibre",
+        "count": "137"
+      }
+    ],
+    "prolific-pl2303": [
+      {
+        "cask": "prolific-pl2303",
+        "count": "65"
+      }
+    ],
+    "propresenter": [
+      {
+        "cask": "propresenter",
+        "count": "19"
+      }
+    ],
+    "pros-editor": [
+      {
+        "cask": "pros-editor",
+        "count": "180"
+      }
+    ],
+    "prosys-opc-ua-browser": [
+      {
+        "cask": "prosys-opc-ua-browser",
+        "count": "3"
+      }
+    ],
+    "prosys-opc-ua-client": [
+      {
+        "cask": "prosys-opc-ua-client",
+        "count": "3"
+      }
+    ],
+    "protege": [
+      {
+        "cask": "protege",
+        "count": "72"
+      }
+    ],
+    "protonmail-bridge": [
+      {
+        "cask": "protonmail-bridge",
+        "count": "235"
+      }
+    ],
+    "protonmail-unofficial": [
+      {
+        "cask": "protonmail-unofficial",
+        "count": "48"
+      }
+    ],
+    "protonvpn": [
+      {
+        "cask": "protonvpn",
+        "count": "707"
+      }
+    ],
+    "protopie": [
+      {
+        "cask": "protopie",
+        "count": "28"
+      }
+    ],
+    "protoverb": [
+      {
+        "cask": "protoverb",
+        "count": "4"
+      }
+    ],
+    "provisioning": [
+      {
+        "cask": "provisioning",
+        "count": "22"
+      }
+    ],
+    "provisionql": [
+      {
+        "cask": "provisionql",
+        "count": "1,661"
+      }
+    ],
+    "prowritingaid": [
+      {
+        "cask": "prowritingaid",
+        "count": "5"
+      }
+    ],
+    "prowritingaid-for-safari": [
+      {
+        "cask": "prowritingaid-for-safari",
+        "count": "1"
+      }
+    ],
+    "proxifier": [
+      {
+        "cask": "proxifier",
+        "count": "198"
+      }
+    ],
+    "proximity": [
+      {
+        "cask": "proximity",
+        "count": "27"
+      }
+    ],
+    "proxpn": [
+      {
+        "cask": "proxpn",
+        "count": "1"
+      }
+    ],
+    "proxyman": [
+      {
+        "cask": "proxyman",
+        "count": "780"
+      }
+    ],
+    "prudent": [
+      {
+        "cask": "prudent",
+        "count": "5"
+      }
+    ],
+    "prusaslicer": [
+      {
+        "cask": "prusaslicer",
+        "count": "202"
+      }
+    ],
+    "psequel": [
+      {
+        "cask": "psequel",
+        "count": "505"
+      }
+    ],
+    "psi": [
+      {
+        "cask": "psi",
+        "count": "10"
+      }
+    ],
+    "psi-plus": [
+      {
+        "cask": "psi-plus",
+        "count": "20"
+      }
+    ],
+    "psychopy": [
+      {
+        "cask": "psychopy",
+        "count": "121"
+      }
+    ],
+    "pteq-x": [
+      {
+        "cask": "pteq-x",
+        "count": "2"
+      }
+    ],
+    "publii": [
+      {
+        "cask": "publii",
+        "count": "8"
+      }
+    ],
+    "publish-or-perish": [
+      {
+        "cask": "publish-or-perish",
+        "count": "10"
+      }
+    ],
+    "pullover": [
+      {
+        "cask": "pullover",
+        "count": "4"
+      }
+    ],
+    "pulse-sms": [
+      {
+        "cask": "pulse-sms",
+        "count": "10"
+      }
+    ],
+    "punto-switcher": [
+      {
+        "cask": "punto-switcher",
+        "count": "148"
+      }
+    ],
+    "puppet-agent": [
+      {
+        "cask": "puppet-agent",
+        "count": "244"
+      }
+    ],
+    "puppet-agent-5": [
+      {
+        "cask": "puppet-agent-5",
+        "count": "27"
+      }
+    ],
+    "puppet-agent-6": [
+      {
+        "cask": "puppet-agent-6",
+        "count": "47"
+      }
+    ],
+    "puppet-bolt": [
+      {
+        "cask": "puppet-bolt",
+        "count": "476"
+      }
+    ],
+    "puppetry": [
+      {
+        "cask": "puppetry",
+        "count": "39"
+      }
+    ],
+    "purevpn": [
+      {
+        "cask": "purevpn",
+        "count": "81"
+      }
+    ],
+    "pusher": [
+      {
+        "cask": "pusher",
+        "count": "1,529"
+      }
+    ],
+    "pushtotalk": [
+      {
+        "cask": "pushtotalk",
+        "count": "1"
+      }
+    ],
+    "putio-adder": [
+      {
+        "cask": "putio-adder",
+        "count": "4"
+      }
+    ],
+    "puush": [
+      {
+        "cask": "puush",
+        "count": "9"
+      }
+    ],
+    "puzzles": [
+      {
+        "cask": "puzzles",
+        "count": "25"
+      }
+    ],
+    "pwnagetool": [
+      {
+        "cask": "pwnagetool",
+        "count": "6"
+      }
+    ],
+    "pxplus-ibm-vga8": [
+      {
+        "cask": "pxplus-ibm-vga8",
+        "count": "7"
+      }
+    ],
+    "pycharm": [
+      {
+        "cask": "pycharm",
+        "count": "4,374"
+      }
+    ],
+    "pycharm-ce": [
+      {
+        "cask": "pycharm-ce",
+        "count": "3,045"
+      }
+    ],
+    "pycharm-ce-with-anaconda-plugin": [
+      {
+        "cask": "pycharm-ce-with-anaconda-plugin",
+        "count": "40"
+      }
+    ],
+    "pycharm-edu": [
+      {
+        "cask": "pycharm-edu",
+        "count": "127"
+      }
+    ],
+    "pycharm-with-anaconda-plugin": [
+      {
+        "cask": "pycharm-with-anaconda-plugin",
+        "count": "13"
+      }
+    ],
+    "pyfa": [
+      {
+        "cask": "pyfa",
+        "count": "90"
+      }
+    ],
+    "pym-player": [
+      {
+        "cask": "pym-player",
+        "count": "4"
+      }
+    ],
+    "pynsource": [
+      {
+        "cask": "pynsource",
+        "count": "11"
+      }
+    ],
+    "python-framework-27": [
+      {
+        "cask": "python-framework-27",
+        "count": "1"
+      }
+    ],
+    "python-framework-36": [
+      {
+        "cask": "python-framework-36",
+        "count": "3"
+      }
+    ],
+    "python-framework-37": [
+      {
+        "cask": "python-framework-37",
+        "count": "1"
+      }
+    ],
+    "python-framework-38": [
+      {
+        "cask": "python-framework-38",
+        "count": "4"
+      }
+    ],
+    "pyzo": [
+      {
+        "cask": "pyzo",
+        "count": "15"
+      }
+    ],
+    "qbittorrent": [
+      {
+        "cask": "qbittorrent",
+        "count": "3,596"
+      }
+    ],
+    "qbittorrent-cli": [
+      {
+        "cask": "qbittorrent-cli",
+        "count": "2"
+      }
+    ],
+    "qbittorrent-ee": [
+      {
+        "cask": "qbittorrent-ee",
+        "count": "4"
+      }
+    ],
+    "qblocker": [
+      {
+        "cask": "qblocker",
+        "count": "14"
+      }
+    ],
+    "qbserve": [
+      {
+        "cask": "qbserve",
+        "count": "31"
+      }
+    ],
+    "qcad": [
+      {
+        "cask": "qcad",
+        "count": "90"
+      }
+    ],
+    "qcma": [
+      {
+        "cask": "qcma",
+        "count": "10"
+      }
+    ],
+    "qctools": [
+      {
+        "cask": "qctools",
+        "count": "25"
+      }
+    ],
+    "qdesktop": [
+      {
+        "cask": "qdesktop",
+        "count": "47"
+      }
+    ],
+    "qdslrdashboard": [
+      {
+        "cask": "qdslrdashboard",
+        "count": "10"
+      }
+    ],
+    "qfinder-pro": [
+      {
+        "cask": "qfinder-pro",
+        "count": "75"
+      }
+    ],
+    "qgis": [
+      {
+        "cask": "qgis",
+        "count": "636"
+      }
+    ],
+    "qgroundcontrol": [
+      {
+        "cask": "qgroundcontrol",
+        "count": "16"
+      }
+    ],
+    "qingg": [
+      {
+        "cask": "qingg",
+        "count": "38"
+      }
+    ],
+    "qiyimedia": [
+      {
+        "cask": "qiyimedia",
+        "count": "179"
+      }
+    ],
+    "ql-ansilove": [
+      {
+        "cask": "ql-ansilove",
+        "count": "46"
+      }
+    ],
+    "qlab": [
+      {
+        "cask": "qlab",
+        "count": "35"
+      }
+    ],
+    "qladdict": [
+      {
+        "cask": "qladdict",
+        "count": "192"
+      }
+    ],
+    "qlc-plus": [
+      {
+        "cask": "qlc-plus",
+        "count": "13"
+      }
+    ],
+    "qlcolorcode": [
+      {
+        "cask": "qlcolorcode",
+        "count": "5,671"
+      }
+    ],
+    "qlcommonmark": [
+      {
+        "cask": "qlcommonmark",
+        "count": "115"
+      }
+    ],
+    "qldds": [
+      {
+        "cask": "qldds",
+        "count": "27"
+      }
+    ],
+    "qlfits": [
+      {
+        "cask": "qlfits",
+        "count": "46"
+      }
+    ],
+    "qlgradle": [
+      {
+        "cask": "qlgradle",
+        "count": "109"
+      }
+    ],
+    "qlimagesize": [
+      {
+        "cask": "qlimagesize",
+        "count": "4,241"
+      }
+    ],
+    "qlmarkdown": [
+      {
+        "cask": "qlmarkdown",
+        "count": "6,840"
+      }
+    ],
+    "qlmarkdown-gfm": [
+      {
+        "cask": "qlmarkdown-gfm",
+        "count": "18"
+      }
+    ],
+    "qlmobi": [
+      {
+        "cask": "qlmobi",
+        "count": "123"
+      }
+    ],
+    "qlnetcdf": [
+      {
+        "cask": "qlnetcdf",
+        "count": "29"
+      }
+    ],
+    "qlplayground": [
+      {
+        "cask": "qlplayground",
+        "count": "101"
+      }
+    ],
+    "qlprettypatch": [
+      {
+        "cask": "qlprettypatch",
+        "count": "1,122"
+      }
+    ],
+    "qlrest": [
+      {
+        "cask": "qlrest",
+        "count": "38"
+      }
+    ],
+    "qlscpt": [
+      {
+        "cask": "qlscpt",
+        "count": "7"
+      }
+    ],
+    "qlstephen": [
+      {
+        "cask": "qlstephen",
+        "count": "7,422"
+      }
+    ],
+    "qlswift": [
+      {
+        "cask": "qlswift",
+        "count": "56"
+      }
+    ],
+    "qlvideo": [
+      {
+        "cask": "qlvideo",
+        "count": "4,066"
+      }
+    ],
+    "qlwaveform": [
+      {
+        "cask": "qlwaveform",
+        "count": "1"
+      }
+    ],
+    "qmk-toolbox": [
+      {
+        "cask": "qmk-toolbox",
+        "count": "665"
+      }
+    ],
+    "qmoji": [
+      {
+        "cask": "qmoji",
+        "count": "12"
+      }
+    ],
+    "qnap-external-raid-manager": [
+      {
+        "cask": "qnap-external-raid-manager",
+        "count": "1"
+      }
+    ],
+    "qnapi": [
+      {
+        "cask": "qnapi",
+        "count": "196"
+      }
+    ],
+    "qobuz": [
+      {
+        "cask": "qobuz",
+        "count": "22"
+      }
+    ],
+    "qownnotes": [
+      {
+        "cask": "qownnotes",
+        "count": "169"
+      }
+    ],
+    "qp": [
+      {
+        "cask": "qp",
+        "count": "5"
+      }
+    ],
+    "qq": [
+      {
+        "cask": "qq",
+        "count": "1,446"
+      }
+    ],
+    "qqbrowser": [
+      {
+        "cask": "qqbrowser",
+        "count": "47"
+      }
+    ],
+    "qqlive": [
+      {
+        "cask": "qqlive",
+        "count": "376"
+      }
+    ],
+    "qqmacmgr": [
+      {
+        "cask": "qqmacmgr",
+        "count": "17"
+      }
+    ],
+    "qqmusic": [
+      {
+        "cask": "qqmusic",
+        "count": "547"
+      }
+    ],
+    "qqplayer": [
+      {
+        "cask": "qqplayer",
+        "count": "32"
+      }
+    ],
+    "qr-journal": [
+      {
+        "cask": "qr-journal",
+        "count": "24"
+      }
+    ],
+    "qrange": [
+      {
+        "cask": "qrange",
+        "count": "5"
+      }
+    ],
+    "qsync-client": [
+      {
+        "cask": "qsync-client",
+        "count": "54"
+      }
+    ],
+    "qsyncthingtray": [
+      {
+        "cask": "qsyncthingtray",
+        "count": "63"
+      }
+    ],
+    "qt-creator": [
+      {
+        "cask": "qt-creator",
+        "count": "2,049"
+      }
+    ],
+    "qt-creator-dev": [
+      {
+        "cask": "qt-creator-dev",
+        "count": "23"
+      }
+    ],
+    "qt-design-studio": [
+      {
+        "cask": "qt-design-studio",
+        "count": "75"
+      }
+    ],
+    "qt3dstudio": [
+      {
+        "cask": "qt3dstudio",
+        "count": "7"
+      }
+    ],
+    "qtmips": [
+      {
+        "cask": "qtmips",
+        "count": "1"
+      }
+    ],
+    "qtmips_gui": [
+      {
+        "cask": "qtmips_gui",
+        "count": "1"
+      }
+    ],
+    "qtox": [
+      {
+        "cask": "qtox",
+        "count": "85"
+      }
+    ],
+    "qtpass": [
+      {
+        "cask": "qtpass",
+        "count": "261"
+      }
+    ],
+    "qtspim": [
+      {
+        "cask": "qtspim",
+        "count": "103"
+      }
+    ],
+    "qtum-qt": [
+      {
+        "cask": "qtum-qt",
+        "count": "1"
+      }
+    ],
+    "quail": [
+      {
+        "cask": "quail",
+        "count": "10"
+      }
+    ],
+    "quakespasm": [
+      {
+        "cask": "quakespasm",
+        "count": "31"
+      }
+    ],
+    "quassel": [
+      {
+        "cask": "quassel",
+        "count": "9"
+      }
+    ],
+    "quassel-client": [
+      {
+        "cask": "quassel-client",
+        "count": "29"
+      }
+    ],
+    "quaternion": [
+      {
+        "cask": "quaternion",
+        "count": "19"
+      }
+    ],
+    "querious": [
+      {
+        "cask": "querious",
+        "count": "70"
+      }
+    ],
+    "questrade-iq-edge": [
+      {
+        "cask": "questrade-iq-edge",
+        "count": "7"
+      }
+    ],
+    "quickbooks": [
+      {
+        "cask": "quickbooks",
+        "count": "19"
+      }
+    ],
+    "quickbooks-online": [
+      {
+        "cask": "quickbooks-online",
+        "count": "48"
+      }
+    ],
+    "quickboot": [
+      {
+        "cask": "quickboot",
+        "count": "4"
+      }
+    ],
+    "quicken": [
+      {
+        "cask": "quicken",
+        "count": "44"
+      }
+    ],
+    "quickeys": [
+      {
+        "cask": "quickeys",
+        "count": "1"
+      }
+    ],
+    "quickgeojson": [
+      {
+        "cask": "quickgeojson",
+        "count": "25"
+      }
+    ],
+    "quickhash": [
+      {
+        "cask": "quickhash",
+        "count": "25"
+      }
+    ],
+    "quickhue": [
+      {
+        "cask": "quickhue",
+        "count": "14"
+      }
+    ],
+    "quickjson": [
+      {
+        "cask": "quickjson",
+        "count": "39"
+      }
+    ],
+    "quicklook-csv": [
+      {
+        "cask": "quicklook-csv",
+        "count": "1,782"
+      }
+    ],
+    "quicklook-json": [
+      {
+        "cask": "quicklook-json",
+        "count": "5,654"
+      }
+    ],
+    "quicklook-pat": [
+      {
+        "cask": "quicklook-pat",
+        "count": "151"
+      }
+    ],
+    "quicklook-pfm": [
+      {
+        "cask": "quicklook-pfm",
+        "count": "29"
+      }
+    ],
+    "quicklookapk": [
+      {
+        "cask": "quicklookapk",
+        "count": "589"
+      }
+    ],
+    "quicklookase": [
+      {
+        "cask": "quicklookase",
+        "count": "2,135"
+      }
+    ],
+    "quicknfo": [
+      {
+        "cask": "quicknfo",
+        "count": "74"
+      }
+    ],
+    "quicksilver": [
+      {
+        "cask": "quicksilver",
+        "count": "205"
+      }
+    ],
+    "quicksync": [
+      {
+        "cask": "quicksync",
+        "count": "4"
+      }
+    ],
+    "quicktime-player7": [
+      {
+        "cask": "quicktime-player7",
+        "count": "15"
+      }
+    ],
+    "quickwords": [
+      {
+        "cask": "quickwords",
+        "count": "4"
+      }
+    ],
+    "quik": [
+      {
+        "cask": "quik",
+        "count": "103"
+      }
+    ],
+    "quip": [
+      {
+        "cask": "quip",
+        "count": "207"
+      }
+    ],
+    "quiterss": [
+      {
+        "cask": "quiterss",
+        "count": "40"
+      }
+    ],
+    "quitter": [
+      {
+        "cask": "quitter",
+        "count": "73"
+      }
+    ],
+    "quodlibet": [
+      {
+        "cask": "quodlibet",
+        "count": "97"
+      }
+    ],
+    "qutebrowser": [
+      {
+        "cask": "qutebrowser",
+        "count": "799"
+      }
+    ],
+    "quupa-bridge": [
+      {
+        "cask": "quupa-bridge",
+        "count": "1"
+      }
+    ],
+    "quuppa-bridge": [
+      {
+        "cask": "quuppa-bridge",
+        "count": "1"
+      }
+    ],
+    "quuppa-data-player": [
+      {
+        "cask": "quuppa-data-player",
+        "count": "10"
+      }
+    ],
+    "quuppa-site-planner": [
+      {
+        "cask": "quuppa-site-planner",
+        "count": "14"
+      }
+    ],
+    "qv2ray": [
+      {
+        "cask": "qv2ray",
+        "count": "71"
+      }
+    ],
+    "qview": [
+      {
+        "cask": "qview",
+        "count": "348"
+      }
+    ],
+    "qxmledit": [
+      {
+        "cask": "qxmledit",
+        "count": "42"
+      }
+    ],
+    "qyooo": [
+      {
+        "cask": "qyooo",
+        "count": "1"
+      }
+    ],
+    "r": [
+      {
+        "cask": "r",
+        "count": "2,799"
+      }
+    ],
+    "r-name": [
+      {
+        "cask": "r-name",
+        "count": "5"
+      }
+    ],
+    "rabbitmq": [
+      {
+        "cask": "rabbitmq",
+        "count": "107"
+      }
+    ],
+    "race-into-space": [
+      {
+        "cask": "race-into-space",
+        "count": "2"
+      }
+    ],
+    "racket": [
+      {
+        "cask": "racket",
+        "count": "678"
+      }
+    ],
+    "racket-cs": [
+      {
+        "cask": "racket-cs",
+        "count": "40"
+      }
+    ],
+    "radar": [
+      {
+        "cask": "radar",
+        "count": "56"
+      }
+    ],
+    "radarr": [
+      {
+        "cask": "radarr",
+        "count": "234"
+      }
+    ],
+    "radiant-player": [
+      {
+        "cask": "radiant-player",
+        "count": "18"
+      }
+    ],
+    "radio-silence": [
+      {
+        "cask": "radio-silence",
+        "count": "71"
+      }
+    ],
+    "ragnarok": [
+      {
+        "cask": "ragnarok",
+        "count": "2"
+      }
+    ],
+    "raindropio": [
+      {
+        "cask": "raindropio",
+        "count": "159"
+      }
+    ],
+    "rambox": [
+      {
+        "cask": "rambox",
+        "count": "530"
+      }
+    ],
+    "ramme": [
+      {
+        "cask": "ramme",
+        "count": "15"
+      }
+    ],
+    "ransomwhere": [
+      {
+        "cask": "ransomwhere",
+        "count": "82"
+      }
+    ],
+    "rapidminer-studio": [
+      {
+        "cask": "rapidminer-studio",
+        "count": "31"
+      }
+    ],
+    "rapidweaver": [
+      {
+        "cask": "rapidweaver",
+        "count": "13"
+      }
+    ],
+    "rar": [
+      {
+        "cask": "rar",
+        "count": "1,487"
+      }
+    ],
+    "raspberry-pi-imager": [
+      {
+        "cask": "raspberry-pi-imager",
+        "count": "325"
+      }
+    ],
+    "raven": [
+      {
+        "cask": "raven",
+        "count": "10"
+      }
+    ],
+    "raven-reader": [
+      {
+        "cask": "raven-reader",
+        "count": "11"
+      }
+    ],
+    "raw-photo-processor": [
+      {
+        "cask": "raw-photo-processor",
+        "count": "12"
+      }
+    ],
+    "rawdigger": [
+      {
+        "cask": "rawdigger",
+        "count": "1"
+      }
+    ],
+    "rawtherapee": [
+      {
+        "cask": "rawtherapee",
+        "count": "248"
+      }
+    ],
+    "razer-synapse": [
+      {
+        "cask": "razer-synapse",
+        "count": "163"
+      }
+    ],
+    "razorsql": [
+      {
+        "cask": "razorsql",
+        "count": "84"
+      }
+    ],
+    "rcdefaultapp": [
+      {
+        "cask": "rcdefaultapp",
+        "count": "99"
+      }
+    ],
+    "rclone-browser": [
+      {
+        "cask": "rclone-browser",
+        "count": "44"
+      }
+    ],
+    "rcloneosx": [
+      {
+        "cask": "rcloneosx",
+        "count": "137"
+      }
+    ],
+    "rcse": [
+      {
+        "cask": "rcse",
+        "count": "1"
+      }
+    ],
+    "react-native-debugger": [
+      {
+        "cask": "react-native-debugger",
+        "count": "12,610"
+      }
+    ],
+    "react-proto": [
+      {
+        "cask": "react-proto",
+        "count": "11"
+      }
+    ],
+    "react-studio": [
+      {
+        "cask": "react-studio",
+        "count": "105"
+      }
+    ],
+    "reactotron": [
+      {
+        "cask": "reactotron",
+        "count": "557"
+      }
+    ],
+    "readandwrite": [
+      {
+        "cask": "readandwrite",
+        "count": "1"
+      }
+    ],
+    "realforce": [
+      {
+        "cask": "realforce",
+        "count": "15"
+      }
+    ],
+    "realm-studio": [
+      {
+        "cask": "realm-studio",
+        "count": "125"
+      }
+    ],
+    "reaper": [
+      {
+        "cask": "reaper",
+        "count": "391"
+      }
+    ],
+    "receiptquicklook": [
+      {
+        "cask": "receiptquicklook",
+        "count": "20"
+      }
+    ],
+    "receipts": [
+      {
+        "cask": "receipts",
+        "count": "10"
+      }
+    ],
+    "recents": [
+      {
+        "cask": "recents",
+        "count": "20"
+      }
+    ],
+    "recordit": [
+      {
+        "cask": "recordit",
+        "count": "85"
+      }
+    ],
+    "recovery-disk-assistant": [
+      {
+        "cask": "recovery-disk-assistant",
+        "count": "13"
+      }
+    ],
+    "rectangle": [
+      {
+        "cask": "rectangle",
+        "count": "8,280"
+      }
+    ],
+    "red": [
+      {
+        "cask": "red",
+        "count": "17"
+      }
+    ],
+    "red-eye": [
+      {
+        "cask": "red-eye",
+        "count": "7"
+      }
+    ],
+    "redcine-x-pro": [
+      {
+        "cask": "redcine-x-pro",
+        "count": "29"
+      }
+    ],
+    "redeclipse": [
+      {
+        "cask": "redeclipse",
+        "count": "3"
+      }
+    ],
+    "redis": [
+      {
+        "cask": "redis",
+        "count": "273"
+      }
+    ],
+    "refined-github-safari": [
+      {
+        "cask": "refined-github-safari",
+        "count": "73"
+      }
+    ],
+    "reflector": [
+      {
+        "cask": "reflector",
+        "count": "133"
+      }
+    ],
+    "reflector2": [
+      {
+        "cask": "reflector2",
+        "count": "10"
+      }
+    ],
+    "regexhibit": [
+      {
+        "cask": "regexhibit",
+        "count": "16"
+      }
+    ],
+    "reggy": [
+      {
+        "cask": "reggy",
+        "count": "28"
+      }
+    ],
+    "regrader": [
+      {
+        "cask": "regrader",
+        "count": "3"
+      }
+    ],
+    "reikey": [
+      {
+        "cask": "reikey",
+        "count": "94"
+      }
+    ],
+    "rekordbox": [
+      {
+        "cask": "rekordbox",
+        "count": "103"
+      }
+    ],
+    "relaunch64": [
+      {
+        "cask": "relaunch64",
+        "count": "1"
+      }
+    ],
+    "reload-scorm-player": [
+      {
+        "cask": "reload-scorm-player",
+        "count": "8"
+      }
+    ],
+    "rember": [
+      {
+        "cask": "rember",
+        "count": "25"
+      }
+    ],
+    "remembear": [
+      {
+        "cask": "remembear",
+        "count": "1"
+      }
+    ],
+    "remember-the-milk": [
+      {
+        "cask": "remember-the-milk",
+        "count": "69"
+      }
+    ],
+    "remix": [
+      {
+        "cask": "remix",
+        "count": "1"
+      }
+    ],
+    "remote-buddy": [
+      {
+        "cask": "remote-buddy",
+        "count": "3"
+      }
+    ],
+    "remote-desktop-manager": [
+      {
+        "cask": "remote-desktop-manager",
+        "count": "322"
+      }
+    ],
+    "remote-desktop-manager-free": [
+      {
+        "cask": "remote-desktop-manager-free",
+        "count": "272"
+      }
+    ],
+    "remoteviewer": [
+      {
+        "cask": "remoteviewer",
+        "count": "90"
+      }
+    ],
+    "remotix-agent": [
+      {
+        "cask": "remotix-agent",
+        "count": "6"
+      }
+    ],
+    "renamer": [
+      {
+        "cask": "renamer",
+        "count": "73"
+      }
+    ],
+    "renpy": [
+      {
+        "cask": "renpy",
+        "count": "44"
+      }
+    ],
+    "reolink-client": [
+      {
+        "cask": "reolink-client",
+        "count": "6"
+      }
+    ],
+    "repairhomepermissions": [
+      {
+        "cask": "repairhomepermissions",
+        "count": "3"
+      }
+    ],
+    "repetier-host": [
+      {
+        "cask": "repetier-host",
+        "count": "38"
+      }
+    ],
+    "rescuetime": [
+      {
+        "cask": "rescuetime",
+        "count": "325"
+      }
+    ],
+    "resilio-sync": [
+      {
+        "cask": "resilio-sync",
+        "count": "299"
+      }
+    ],
+    "resolume-arena": [
+      {
+        "cask": "resolume-arena",
+        "count": "9"
+      }
+    ],
+    "resolutionator": [
+      {
+        "cask": "resolutionator",
+        "count": "56"
+      }
+    ],
+    "restart": [
+      {
+        "cask": "restart",
+        "count": "1"
+      }
+    ],
+    "restclient": [
+      {
+        "cask": "restclient",
+        "count": "29"
+      }
+    ],
+    "resxtreme": [
+      {
+        "cask": "resxtreme",
+        "count": "14"
+      }
+    ],
+    "retinizer": [
+      {
+        "cask": "retinizer",
+        "count": "28"
+      }
+    ],
+    "retro-virtual-machine": [
+      {
+        "cask": "retro-virtual-machine",
+        "count": "12"
+      }
+    ],
+    "retroactive": [
+      {
+        "cask": "retroactive",
+        "count": "12"
+      }
+    ],
+    "retroarch": [
+      {
+        "cask": "retroarch",
+        "count": "326"
+      }
+    ],
+    "retroarch-metal": [
+      {
+        "cask": "retroarch-metal",
+        "count": "71"
+      }
+    ],
+    "retrobatch": [
+      {
+        "cask": "retrobatch",
+        "count": "19"
+      }
+    ],
+    "retroshare": [
+      {
+        "cask": "retroshare",
+        "count": "20"
+      }
+    ],
+    "reunion": [
+      {
+        "cask": "reunion",
+        "count": "4"
+      }
+    ],
+    "reveal": [
+      {
+        "cask": "reveal",
+        "count": "62"
+      }
+    ],
+    "revisionist": [
+      {
+        "cask": "revisionist",
+        "count": "2"
+      }
+    ],
+    "rhinoceros": [
+      {
+        "cask": "rhinoceros",
+        "count": "33"
+      }
+    ],
+    "ricochet": [
+      {
+        "cask": "ricochet",
+        "count": "15"
+      }
+    ],
+    "ricoh-ps-printers-vol3-exp-driver": [
+      {
+        "cask": "ricoh-ps-printers-vol3-exp-driver",
+        "count": "4"
+      }
+    ],
+    "ricoh-ps-printers-vol4-exp-driver": [
+      {
+        "cask": "ricoh-ps-printers-vol4-exp-driver",
+        "count": "54"
+      }
+    ],
+    "ricoh-theta": [
+      {
+        "cask": "ricoh-theta",
+        "count": "6"
+      }
+    ],
+    "ricoh-theta-file-transfer": [
+      {
+        "cask": "ricoh-theta-file-transfer",
+        "count": "2"
+      }
+    ],
+    "ricoh-theta-movie-converter": [
+      {
+        "cask": "ricoh-theta-movie-converter",
+        "count": "2"
+      }
+    ],
+    "rider": [
+      {
+        "cask": "rider",
+        "count": "633"
+      }
+    ],
+    "ridibooks": [
+      {
+        "cask": "ridibooks",
+        "count": "72"
+      }
+    ],
+    "rightfont": [
+      {
+        "cask": "rightfont",
+        "count": "71"
+      }
+    ],
+    "rightzoom": [
+      {
+        "cask": "rightzoom",
+        "count": "15"
+      }
+    ],
+    "ring": [
+      {
+        "cask": "ring",
+        "count": "49"
+      }
+    ],
+    "ringcentral": [
+      {
+        "cask": "ringcentral",
+        "count": "120"
+      }
+    ],
+    "ringcentral-meetings": [
+      {
+        "cask": "ringcentral-meetings",
+        "count": "84"
+      }
+    ],
+    "ringtones": [
+      {
+        "cask": "ringtones",
+        "count": "5"
+      }
+    ],
+    "riot": [
+      {
+        "cask": "riot",
+        "count": "765"
+      }
+    ],
+    "ripcord": [
+      {
+        "cask": "ripcord",
+        "count": "56"
+      }
+    ],
+    "ripit": [
+      {
+        "cask": "ripit",
+        "count": "28"
+      }
+    ],
+    "roaringapps": [
+      {
+        "cask": "roaringapps",
+        "count": "3"
+      }
+    ],
+    "roblox": [
+      {
+        "cask": "roblox",
+        "count": "156"
+      }
+    ],
+    "robo-3t": [
+      {
+        "cask": "robo-3t",
+        "count": "2,191"
+      }
+    ],
+    "robofont": [
+      {
+        "cask": "robofont",
+        "count": "11"
+      }
+    ],
+    "roboform": [
+      {
+        "cask": "roboform",
+        "count": "21"
+      }
+    ],
+    "rocket": [
+      {
+        "cask": "rocket",
+        "count": "752"
+      }
+    ],
+    "rocket-chat": [
+      {
+        "cask": "rocket-chat",
+        "count": "637"
+      }
+    ],
+    "rocket-typist": [
+      {
+        "cask": "rocket-typist",
+        "count": "6"
+      }
+    ],
+    "rocks-n-diamonds": [
+      {
+        "cask": "rocks-n-diamonds",
+        "count": "5"
+      }
+    ],
+    "rodeo": [
+      {
+        "cask": "rodeo",
+        "count": "38"
+      }
+    ],
+    "roku-remote-tool": [
+      {
+        "cask": "roku-remote-tool",
+        "count": "17"
+      }
+    ],
+    "roland-quad-capture-usb-driver": [
+      {
+        "cask": "roland-quad-capture-usb-driver",
+        "count": "3"
+      }
+    ],
+    "rolisteam": [
+      {
+        "cask": "rolisteam",
+        "count": "2"
+      }
+    ],
+    "roon": [
+      {
+        "cask": "roon",
+        "count": "38"
+      }
+    ],
+    "rosaimagewriter": [
+      {
+        "cask": "rosaimagewriter",
+        "count": "10"
+      }
+    ],
+    "rotato": [
+      {
+        "cask": "rotato",
+        "count": "20"
+      }
+    ],
+    "routebuddy": [
+      {
+        "cask": "routebuddy",
+        "count": "3"
+      }
+    ],
+    "routeconverter": [
+      {
+        "cask": "routeconverter",
+        "count": "6"
+      }
+    ],
+    "routemap": [
+      {
+        "cask": "routemap",
+        "count": "3"
+      }
+    ],
+    "rowanj-gitx": [
+      {
+        "cask": "rowanj-gitx",
+        "count": "596"
+      }
+    ],
+    "rowmote-helper": [
+      {
+        "cask": "rowmote-helper",
+        "count": "6"
+      }
+    ],
+    "royal-tsx": [
+      {
+        "cask": "royal-tsx",
+        "count": "407"
+      }
+    ],
+    "royal-tsx@3": [
+      {
+        "cask": "royal-tsx@3",
+        "count": "3"
+      }
+    ],
+    "rpn-scientific": [
+      {
+        "cask": "rpn-scientific",
+        "count": "7"
+      }
+    ],
+    "rpvoip": [
+      {
+        "cask": "rpvoip",
+        "count": "14"
+      }
+    ],
+    "rq": [
+      {
+        "cask": "rq",
+        "count": "41"
+      }
+    ],
+    "rrcc": [
+      {
+        "cask": "rrcc",
+        "count": "7"
+      }
+    ],
+    "rss": [
+      {
+        "cask": "rss",
+        "count": "28"
+      }
+    ],
+    "rssowl": [
+      {
+        "cask": "rssowl",
+        "count": "37"
+      }
+    ],
+    "rstudio": [
+      {
+        "cask": "rstudio",
+        "count": "3,765"
+      }
+    ],
+    "rstudio-daily": [
+      {
+        "cask": "rstudio-daily",
+        "count": "41"
+      }
+    ],
+    "rstudio-preview": [
+      {
+        "cask": "rstudio-preview",
+        "count": "144"
+      }
+    ],
+    "rsyncosx": [
+      {
+        "cask": "rsyncosx",
+        "count": "252"
+      }
+    ],
+    "rubitrack-pro": [
+      {
+        "cask": "rubitrack-pro",
+        "count": "8"
+      }
+    ],
+    "rubymine": [
+      {
+        "cask": "rubymine",
+        "count": "714"
+      }
+    ],
+    "rubymotion": [
+      {
+        "cask": "rubymotion",
+        "count": "12"
+      }
+    ],
+    "runelite": [
+      {
+        "cask": "runelite",
+        "count": "1"
+      }
+    ],
+    "runescape": [
+      {
+        "cask": "runescape",
+        "count": "47"
+      }
+    ],
+    "runjs": [
+      {
+        "cask": "runjs",
+        "count": "165"
+      }
+    ],
+    "runway": [
+      {
+        "cask": "runway",
+        "count": "20"
+      }
+    ],
+    "ryver": [
+      {
+        "cask": "ryver",
+        "count": "11"
+      }
+    ],
+    "sabaki": [
+      {
+        "cask": "sabaki",
+        "count": "68"
+      }
+    ],
+    "sabnzbd": [
+      {
+        "cask": "sabnzbd",
+        "count": "115"
+      }
+    ],
+    "safari-technology-preview": [
+      {
+        "cask": "safari-technology-preview",
+        "count": "285"
+      }
+    ],
+    "safaricookiecutter": [
+      {
+        "cask": "safaricookiecutter",
+        "count": "18"
+      }
+    ],
+    "safarisort": [
+      {
+        "cask": "safarisort",
+        "count": "4"
+      }
+    ],
+    "safe-exam-browser": [
+      {
+        "cask": "safe-exam-browser",
+        "count": "2"
+      }
+    ],
+    "safeincloud-password-manager": [
+      {
+        "cask": "safeincloud-password-manager",
+        "count": "33"
+      }
+    ],
+    "sage": [
+      {
+        "cask": "sage",
+        "count": "402"
+      }
+    ],
+    "saleae-logic": [
+      {
+        "cask": "saleae-logic",
+        "count": "16"
+      }
+    ],
+    "sameboy": [
+      {
+        "cask": "sameboy",
+        "count": "18"
+      }
+    ],
+    "sands": [
+      {
+        "cask": "sands",
+        "count": "1"
+      }
+    ],
+    "sandstrip": [
+      {
+        "cask": "sandstrip",
+        "count": "4"
+      }
+    ],
+    "santa": [
+      {
+        "cask": "santa",
+        "count": "130"
+      }
+    ],
+    "saoimageds9": [
+      {
+        "cask": "saoimageds9",
+        "count": "40"
+      }
+    ],
+    "sapmachine-jdk": [
+      {
+        "cask": "sapmachine-jdk",
+        "count": "391"
+      }
+    ],
+    "sapmachine-jdk-lts": [
+      {
+        "cask": "sapmachine-jdk-lts",
+        "count": "2"
+      }
+    ],
+    "sapmachine11-ea-jdk": [
+      {
+        "cask": "sapmachine11-ea-jdk",
+        "count": "4"
+      }
+    ],
+    "sapmachine11-jdk": [
+      {
+        "cask": "sapmachine11-jdk",
+        "count": "229"
+      }
+    ],
+    "sapmachine11-jre": [
+      {
+        "cask": "sapmachine11-jre",
+        "count": "15"
+      }
+    ],
+    "sapmachine12-ea-jdk": [
+      {
+        "cask": "sapmachine12-ea-jdk",
+        "count": "1"
+      }
+    ],
+    "sapmachine12-jdk": [
+      {
+        "cask": "sapmachine12-jdk",
+        "count": "7"
+      }
+    ],
+    "sapmachine13-ea-jdk": [
+      {
+        "cask": "sapmachine13-ea-jdk",
+        "count": "6"
+      }
+    ],
+    "sapmachine13-ea-jre": [
+      {
+        "cask": "sapmachine13-ea-jre",
+        "count": "1"
+      }
+    ],
+    "sapmachine13-jdk": [
+      {
+        "cask": "sapmachine13-jdk",
+        "count": "8"
+      }
+    ],
+    "sapmachine13-jre": [
+      {
+        "cask": "sapmachine13-jre",
+        "count": "1"
+      }
+    ],
+    "sapmachine14-ea-jdk": [
+      {
+        "cask": "sapmachine14-ea-jdk",
+        "count": "2"
+      }
+    ],
+    "sapmachine14-jdk": [
+      {
+        "cask": "sapmachine14-jdk",
+        "count": "4"
+      }
+    ],
+    "sapmachine14-jre": [
+      {
+        "cask": "sapmachine14-jre",
+        "count": "3"
+      }
+    ],
+    "sapmachine15-ea-jdk": [
+      {
+        "cask": "sapmachine15-ea-jdk",
+        "count": "1"
+      }
+    ],
+    "sara": [
+      {
+        "cask": "sara",
+        "count": "2"
+      }
+    ],
+    "satellite-eyes": [
+      {
+        "cask": "satellite-eyes",
+        "count": "9"
+      }
+    ],
+    "sauce-connect": [
+      {
+        "cask": "sauce-connect",
+        "count": "56"
+      }
+    ],
+    "saucer": [
+      {
+        "cask": "saucer",
+        "count": "1"
+      }
+    ],
+    "sauerbraten": [
+      {
+        "cask": "sauerbraten",
+        "count": "29"
+      }
+    ],
+    "save-hollywood": [
+      {
+        "cask": "save-hollywood",
+        "count": "25"
+      }
+    ],
+    "scala-ide": [
+      {
+        "cask": "scala-ide",
+        "count": "128"
+      }
+    ],
+    "scalafmt-151": [
+      {
+        "cask": "scalafmt-151",
+        "count": "4"
+      }
+    ],
+    "scaleft": [
+      {
+        "cask": "scaleft",
+        "count": "46"
+      }
+    ],
+    "scalingo": [
+      {
+        "cask": "scalingo",
+        "count": "2"
+      }
+    ],
+    "scansion": [
+      {
+        "cask": "scansion",
+        "count": "14"
+      }
+    ],
+    "scap-workbench": [
+      {
+        "cask": "scap-workbench",
+        "count": "30"
+      }
+    ],
+    "scapple": [
+      {
+        "cask": "scapple",
+        "count": "56"
+      }
+    ],
+    "scenebuilder": [
+      {
+        "cask": "scenebuilder",
+        "count": "120"
+      }
+    ],
+    "schism-tracker": [
+      {
+        "cask": "schism-tracker",
+        "count": "13"
+      }
+    ],
+    "scidavis": [
+      {
+        "cask": "scidavis",
+        "count": "31"
+      }
+    ],
+    "scidvsmac": [
+      {
+        "cask": "scidvsmac",
+        "count": "15"
+      }
+    ],
+    "scihubeva": [
+      {
+        "cask": "scihubeva",
+        "count": "43"
+      }
+    ],
+    "scilab": [
+      {
+        "cask": "scilab",
+        "count": "152"
+      }
+    ],
+    "scope": [
+      {
+        "cask": "scope",
+        "count": "5"
+      }
+    ],
+    "scopebox": [
+      {
+        "cask": "scopebox",
+        "count": "1"
+      }
+    ],
+    "scout": [
+      {
+        "cask": "scout",
+        "count": "8"
+      }
+    ],
+    "scratch": [
+      {
+        "cask": "scratch",
+        "count": "134"
+      }
+    ],
+    "screaming-frog-seo-spider": [
+      {
+        "cask": "screaming-frog-seo-spider",
+        "count": "99"
+      }
+    ],
+    "screen": [
+      {
+        "cask": "screen",
+        "count": "194"
+      }
+    ],
+    "screen_ruler": [
+      {
+        "cask": "screen_ruler",
+        "count": "1"
+      }
+    ],
+    "screencast": [
+      {
+        "cask": "screencast",
+        "count": "18"
+      }
+    ],
+    "screenflick": [
+      {
+        "cask": "screenflick",
+        "count": "118"
+      }
+    ],
+    "screenflow": [
+      {
+        "cask": "screenflow",
+        "count": "236"
+      }
+    ],
+    "screenflow5": [
+      {
+        "cask": "screenflow5",
+        "count": "3"
+      }
+    ],
+    "screens": [
+      {
+        "cask": "screens",
+        "count": "148"
+      }
+    ],
+    "screens-connect": [
+      {
+        "cask": "screens-connect",
+        "count": "74"
+      }
+    ],
+    "screentray": [
+      {
+        "cask": "screentray",
+        "count": "1"
+      }
+    ],
+    "scribus": [
+      {
+        "cask": "scribus",
+        "count": "572"
+      }
+    ],
+    "scribus-dev": [
+      {
+        "cask": "scribus-dev",
+        "count": "10"
+      }
+    ],
+    "script-debugger": [
+      {
+        "cask": "script-debugger",
+        "count": "45"
+      }
+    ],
+    "scriptql": [
+      {
+        "cask": "scriptql",
+        "count": "61"
+      }
+    ],
+    "scrivener": [
+      {
+        "cask": "scrivener",
+        "count": "147"
+      }
+    ],
+    "scroll-reverser": [
+      {
+        "cask": "scroll-reverser",
+        "count": "833"
+      }
+    ],
+    "scrub": [
+      {
+        "cask": "scrub",
+        "count": "2"
+      }
+    ],
+    "scrutiny": [
+      {
+        "cask": "scrutiny",
+        "count": "33"
+      }
+    ],
+    "scummvm": [
+      {
+        "cask": "scummvm",
+        "count": "136"
+      }
+    ],
+    "sdcc": [
+      {
+        "cask": "sdcc",
+        "count": "2"
+      }
+    ],
+    "sdformatter": [
+      {
+        "cask": "sdformatter",
+        "count": "251"
+      }
+    ],
+    "sdm": [
+      {
+        "cask": "sdm",
+        "count": "2"
+      }
+    ],
+    "sdrdx": [
+      {
+        "cask": "sdrdx",
+        "count": "36"
+      }
+    ],
+    "seadrive": [
+      {
+        "cask": "seadrive",
+        "count": "31"
+      }
+    ],
+    "seafile-client": [
+      {
+        "cask": "seafile-client",
+        "count": "194"
+      }
+    ],
+    "seagate-dashboard": [
+      {
+        "cask": "seagate-dashboard",
+        "count": "6"
+      }
+    ],
+    "seaglass": [
+      {
+        "cask": "seaglass",
+        "count": "194"
+      }
+    ],
+    "seamonkey": [
+      {
+        "cask": "seamonkey",
+        "count": "102"
+      }
+    ],
+    "searchkey": [
+      {
+        "cask": "searchkey",
+        "count": "2"
+      }
+    ],
+    "searchkeylite": [
+      {
+        "cask": "searchkeylite",
+        "count": "1"
+      }
+    ],
+    "seashore": [
+      {
+        "cask": "seashore",
+        "count": "111"
+      }
+    ],
+    "second-life-viewer": [
+      {
+        "cask": "second-life-viewer",
+        "count": "37"
+      }
+    ],
+    "secure-pipes": [
+      {
+        "cask": "secure-pipes",
+        "count": "78"
+      }
+    ],
+    "securesafe": [
+      {
+        "cask": "securesafe",
+        "count": "3"
+      }
+    ],
+    "securid": [
+      {
+        "cask": "securid",
+        "count": "46"
+      }
+    ],
+    "security-growler": [
+      {
+        "cask": "security-growler",
+        "count": "10"
+      }
+    ],
+    "securityspy": [
+      {
+        "cask": "securityspy",
+        "count": "20"
+      }
+    ],
+    "segger-embedded-studio-for-arm": [
+      {
+        "cask": "segger-embedded-studio-for-arm",
+        "count": "28"
+      }
+    ],
+    "segger-jlink": [
+      {
+        "cask": "segger-jlink",
+        "count": "207"
+      }
+    ],
+    "segger-ozone": [
+      {
+        "cask": "segger-ozone",
+        "count": "10"
+      }
+    ],
+    "sejda-pdf": [
+      {
+        "cask": "sejda-pdf",
+        "count": "32"
+      }
+    ],
+    "sekey": [
+      {
+        "cask": "sekey",
+        "count": "117"
+      }
+    ],
+    "selfcontrol": [
+      {
+        "cask": "selfcontrol",
+        "count": "251"
+      }
+    ],
+    "semulov": [
+      {
+        "cask": "semulov",
+        "count": "29"
+      }
+    ],
+    "sencha": [
+      {
+        "cask": "sencha",
+        "count": "98"
+      }
+    ],
+    "send-anywhere": [
+      {
+        "cask": "send-anywhere",
+        "count": "37"
+      }
+    ],
+    "send-to-kindle": [
+      {
+        "cask": "send-to-kindle",
+        "count": "216"
+      }
+    ],
+    "sensei": [
+      {
+        "cask": "sensei",
+        "count": "139"
+      }
+    ],
+    "sensiblesidebuttons": [
+      {
+        "cask": "sensiblesidebuttons",
+        "count": "280"
+      }
+    ],
+    "sentinel": [
+      {
+        "cask": "sentinel",
+        "count": "71"
+      }
+    ],
+    "senuti": [
+      {
+        "cask": "senuti",
+        "count": "1"
+      }
+    ],
+    "sequel-pro": [
+      {
+        "cask": "sequel-pro",
+        "count": "4,553"
+      }
+    ],
+    "sequel-pro-nightly": [
+      {
+        "cask": "sequel-pro-nightly",
+        "count": "1,345"
+      }
+    ],
+    "sequencair": [
+      {
+        "cask": "sequencair",
+        "count": "2"
+      }
+    ],
+    "sequential": [
+      {
+        "cask": "sequential",
+        "count": "34"
+      }
+    ],
+    "serial": [
+      {
+        "cask": "serial",
+        "count": "88"
+      }
+    ],
+    "serial-tools": [
+      {
+        "cask": "serial-tools",
+        "count": "43"
+      }
+    ],
+    "serviio": [
+      {
+        "cask": "serviio",
+        "count": "81"
+      }
+    ],
+    "servo": [
+      {
+        "cask": "servo",
+        "count": "36"
+      }
+    ],
+    "servpane": [
+      {
+        "cask": "servpane",
+        "count": "23"
+      }
+    ],
+    "session": [
+      {
+        "cask": "session",
+        "count": "65"
+      }
+    ],
+    "session-manager-plugin": [
+      {
+        "cask": "session-manager-plugin",
+        "count": "956"
+      }
+    ],
+    "setapp": [
+      {
+        "cask": "setapp",
+        "count": "561"
+      }
+    ],
+    "sf-symbols": [
+      {
+        "cask": "sf-symbols",
+        "count": "227"
+      }
+    ],
+    "sfdx": [
+      {
+        "cask": "sfdx",
+        "count": "175"
+      }
+    ],
+    "shades": [
+      {
+        "cask": "shades",
+        "count": "40"
+      }
+    ],
+    "shadow": [
+      {
+        "cask": "shadow",
+        "count": "132"
+      }
+    ],
+    "shadow-beta": [
+      {
+        "cask": "shadow-beta",
+        "count": "18"
+      }
+    ],
+    "shadowsocksx": [
+      {
+        "cask": "shadowsocksx",
+        "count": "139"
+      }
+    ],
+    "shadowsocksx-ng": [
+      {
+        "cask": "shadowsocksx-ng",
+        "count": "611"
+      }
+    ],
+    "shadowsocksx-ng-r": [
+      {
+        "cask": "shadowsocksx-ng-r",
+        "count": "479"
+      }
+    ],
+    "shapes": [
+      {
+        "cask": "shapes",
+        "count": "4"
+      }
+    ],
+    "sharemouse": [
+      {
+        "cask": "sharemouse",
+        "count": "298"
+      }
+    ],
+    "sharepod": [
+      {
+        "cask": "sharepod",
+        "count": "1"
+      }
+    ],
+    "shb1": [
+      {
+        "cask": "shb1",
+        "count": "2"
+      }
+    ],
+    "sheepshaver": [
+      {
+        "cask": "sheepshaver",
+        "count": "3"
+      }
+    ],
+    "shellhere": [
+      {
+        "cask": "shellhere",
+        "count": "5"
+      }
+    ],
+    "sherlock": [
+      {
+        "cask": "sherlock",
+        "count": "43"
+      }
+    ],
+    "shiba": [
+      {
+        "cask": "shiba",
+        "count": "11"
+      }
+    ],
+    "shift": [
+      {
+        "cask": "shift",
+        "count": "165"
+      }
+    ],
+    "shiftit": [
+      {
+        "cask": "shiftit",
+        "count": "1,772"
+      }
+    ],
+    "shifty": [
+      {
+        "cask": "shifty",
+        "count": "85"
+      }
+    ],
+    "shimeike-formulatepro": [
+      {
+        "cask": "shimeike-formulatepro",
+        "count": "22"
+      }
+    ],
+    "shimo": [
+      {
+        "cask": "shimo",
+        "count": "106"
+      }
+    ],
+    "shiori": [
+      {
+        "cask": "shiori",
+        "count": "25"
+      }
+    ],
+    "shoes": [
+      {
+        "cask": "shoes",
+        "count": "9"
+      }
+    ],
+    "shoretel-connect": [
+      {
+        "cask": "shoretel-connect",
+        "count": "1"
+      }
+    ],
+    "shortcat": [
+      {
+        "cask": "shortcat",
+        "count": "46"
+      }
+    ],
+    "shortcutdetective": [
+      {
+        "cask": "shortcutdetective",
+        "count": "50"
+      }
+    ],
+    "shortcuts": [
+      {
+        "cask": "shortcuts",
+        "count": "18"
+      }
+    ],
+    "shotcut": [
+      {
+        "cask": "shotcut",
+        "count": "318"
+      }
+    ],
+    "showhiddenfiles": [
+      {
+        "cask": "showhiddenfiles",
+        "count": "7"
+      }
+    ],
+    "showyedge": [
+      {
+        "cask": "showyedge",
+        "count": "40"
+      }
+    ],
+    "shrinkit": [
+      {
+        "cask": "shrinkit",
+        "count": "14"
+      }
+    ],
+    "shupapan": [
+      {
+        "cask": "shupapan",
+        "count": "12"
+      }
+    ],
+    "shutdown": [
+      {
+        "cask": "shutdown",
+        "count": "1"
+      }
+    ],
+    "shuttle": [
+      {
+        "cask": "shuttle",
+        "count": "205"
+      }
+    ],
+    "sia-host-manager": [
+      {
+        "cask": "sia-host-manager",
+        "count": "1"
+      }
+    ],
+    "sia-ui": [
+      {
+        "cask": "sia-ui",
+        "count": "33"
+      }
+    ],
+    "sickbeard-anime": [
+      {
+        "cask": "sickbeard-anime",
+        "count": "7"
+      }
+    ],
+    "sidekick": [
+      {
+        "cask": "sidekick",
+        "count": "14"
+      }
+    ],
+    "sidenotes": [
+      {
+        "cask": "sidenotes",
+        "count": "53"
+      }
+    ],
+    "sidequest": [
+      {
+        "cask": "sidequest",
+        "count": "104"
+      }
+    ],
+    "sidestep": [
+      {
+        "cask": "sidestep",
+        "count": "6"
+      }
+    ],
+    "sigil": [
+      {
+        "cask": "sigil",
+        "count": "369"
+      }
+    ],
+    "signal": [
+      {
+        "cask": "signal",
+        "count": "3,916"
+      }
+    ],
+    "signal-beta": [
+      {
+        "cask": "signal-beta",
+        "count": "49"
+      }
+    ],
+    "signet": [
+      {
+        "cask": "signet",
+        "count": "6"
+      }
+    ],
+    "sigviewer": [
+      {
+        "cask": "sigviewer",
+        "count": "4"
+      }
+    ],
+    "silentknight": [
+      {
+        "cask": "silentknight",
+        "count": "46"
+      }
+    ],
+    "silhouette-saver": [
+      {
+        "cask": "silhouette-saver",
+        "count": "2"
+      }
+    ],
+    "silicon-labs-vcp-driver": [
+      {
+        "cask": "silicon-labs-vcp-driver",
+        "count": "278"
+      }
+    ],
+    "silnite": [
+      {
+        "cask": "silnite",
+        "count": "5"
+      }
+    ],
+    "silo": [
+      {
+        "cask": "silo",
+        "count": "4"
+      }
+    ],
+    "silverlight": [
+      {
+        "cask": "silverlight",
+        "count": "195"
+      }
+    ],
+    "sim-daltonism": [
+      {
+        "cask": "sim-daltonism",
+        "count": "26"
+      }
+    ],
+    "simpholders": [
+      {
+        "cask": "simpholders",
+        "count": "15"
+      }
+    ],
+    "simple-comic": [
+      {
+        "cask": "simple-comic",
+        "count": "232"
+      }
+    ],
+    "simplediagrams": [
+      {
+        "cask": "simplediagrams",
+        "count": "11"
+      }
+    ],
+    "simplefloatingclock": [
+      {
+        "cask": "simplefloatingclock",
+        "count": "12"
+      }
+    ],
+    "simplenote": [
+      {
+        "cask": "simplenote",
+        "count": "455"
+      }
+    ],
+    "simpless": [
+      {
+        "cask": "simpless",
+        "count": "1"
+      }
+    ],
+    "simplesynth": [
+      {
+        "cask": "simplesynth",
+        "count": "18"
+      }
+    ],
+    "simplistic": [
+      {
+        "cask": "simplistic",
+        "count": "17"
+      }
+    ],
+    "simply-fortran": [
+      {
+        "cask": "simply-fortran",
+        "count": "15"
+      }
+    ],
+    "simsim": [
+      {
+        "cask": "simsim",
+        "count": "15"
+      }
+    ],
+    "singularity": [
+      {
+        "cask": "singularity",
+        "count": "72"
+      }
+    ],
+    "sip": [
+      {
+        "cask": "sip",
+        "count": "223"
+      }
+    ],
+    "sirimote": [
+      {
+        "cask": "sirimote",
+        "count": "9"
+      }
+    ],
+    "sitebulb": [
+      {
+        "cask": "sitebulb",
+        "count": "3"
+      }
+    ],
+    "sixtyforce": [
+      {
+        "cask": "sixtyforce",
+        "count": "9"
+      }
+    ],
+    "sizeup": [
+      {
+        "cask": "sizeup",
+        "count": "267"
+      }
+    ],
+    "sizzy": [
+      {
+        "cask": "sizzy",
+        "count": "51"
+      }
+    ],
+    "skala-preview": [
+      {
+        "cask": "skala-preview",
+        "count": "3"
+      }
+    ],
+    "sketch": [
+      {
+        "cask": "sketch",
+        "count": "2,610"
+      }
+    ],
+    "sketch-toolbox": [
+      {
+        "cask": "sketch-toolbox",
+        "count": "64"
+      }
+    ],
+    "sketch@43.2": [
+      {
+        "cask": "sketch@43.2",
+        "count": "1"
+      }
+    ],
+    "sketchbook": [
+      {
+        "cask": "sketchbook",
+        "count": "153"
+      }
+    ],
+    "sketchpacks": [
+      {
+        "cask": "sketchpacks",
+        "count": "43"
+      }
+    ],
+    "sketchup": [
+      {
+        "cask": "sketchup",
+        "count": "389"
+      }
+    ],
+    "sketchup-pro": [
+      {
+        "cask": "sketchup-pro",
+        "count": "55"
+      }
+    ],
+    "skim": [
+      {
+        "cask": "skim",
+        "count": "2,284"
+      }
+    ],
+    "skitch": [
+      {
+        "cask": "skitch",
+        "count": "1,053"
+      }
+    ],
+    "skreenics": [
+      {
+        "cask": "skreenics",
+        "count": "4"
+      }
+    ],
+    "skybox": [
+      {
+        "cask": "skybox",
+        "count": "10"
+      }
+    ],
+    "skyfonts": [
+      {
+        "cask": "skyfonts",
+        "count": "183"
+      }
+    ],
+    "skype": [
+      {
+        "cask": "skype",
+        "count": "13,932"
+      }
+    ],
+    "skype-cn": [
+      {
+        "cask": "skype-cn",
+        "count": "1"
+      }
+    ],
+    "skype-for-business": [
+      {
+        "cask": "skype-for-business",
+        "count": "1,988"
+      }
+    ],
+    "skype-preview": [
+      {
+        "cask": "skype-preview",
+        "count": "33"
+      }
+    ],
+    "skype7": [
+      {
+        "cask": "skype7",
+        "count": "13"
+      }
+    ],
+    "skypewebplugin": [
+      {
+        "cask": "skypewebplugin",
+        "count": "41"
+      }
+    ],
+    "slack": [
+      {
+        "cask": "slack",
+        "count": "20,223"
+      }
+    ],
+    "slack-beta": [
+      {
+        "cask": "slack-beta",
+        "count": "261"
+      }
+    ],
+    "slash": [
+      {
+        "cask": "slash",
+        "count": "1"
+      }
+    ],
+    "slate": [
+      {
+        "cask": "slate",
+        "count": "212"
+      }
+    ],
+    "sleep": [
+      {
+        "cask": "sleep",
+        "count": "2"
+      }
+    ],
+    "sleepyhead": [
+      {
+        "cask": "sleepyhead",
+        "count": "3"
+      }
+    ],
+    "sleipnir": [
+      {
+        "cask": "sleipnir",
+        "count": "15"
+      }
+    ],
+    "slic3r": [
+      {
+        "cask": "slic3r",
+        "count": "93"
+      }
+    ],
+    "slicer": [
+      {
+        "cask": "slicer",
+        "count": "22"
+      }
+    ],
+    "slicer-nightly": [
+      {
+        "cask": "slicer-nightly",
+        "count": "6"
+      }
+    ],
+    "slik": [
+      {
+        "cask": "slik",
+        "count": "6"
+      }
+    ],
+    "slimbatterymonitor": [
+      {
+        "cask": "slimbatterymonitor",
+        "count": "23"
+      }
+    ],
+    "slingplayer": [
+      {
+        "cask": "slingplayer",
+        "count": "5"
+      }
+    ],
+    "slite": [
+      {
+        "cask": "slite",
+        "count": "36"
+      }
+    ],
+    "sloth": [
+      {
+        "cask": "sloth",
+        "count": "359"
+      }
+    ],
+    "slowquitapps": [
+      {
+        "cask": "slowquitapps",
+        "count": "346"
+      }
+    ],
+    "smallpdf": [
+      {
+        "cask": "smallpdf",
+        "count": "44"
+      }
+    ],
+    "sman": [
+      {
+        "cask": "sman",
+        "count": "1"
+      }
+    ],
+    "smaolab-tarabia": [
+      {
+        "cask": "smaolab-tarabia",
+        "count": "2"
+      }
+    ],
+    "smart-converter-pro": [
+      {
+        "cask": "smart-converter-pro",
+        "count": "11"
+      }
+    ],
+    "smartconverter": [
+      {
+        "cask": "smartconverter",
+        "count": "1"
+      }
+    ],
+    "smartgit": [
+      {
+        "cask": "smartgit",
+        "count": "392"
+      }
+    ],
+    "smartsvn": [
+      {
+        "cask": "smartsvn",
+        "count": "183"
+      }
+    ],
+    "smartsynchronize": [
+      {
+        "cask": "smartsynchronize",
+        "count": "24"
+      }
+    ],
+    "smcfancontrol": [
+      {
+        "cask": "smcfancontrol",
+        "count": "1,600"
+      }
+    ],
+    "smlnj": [
+      {
+        "cask": "smlnj",
+        "count": "700"
+      }
+    ],
+    "smoothscroll": [
+      {
+        "cask": "smoothscroll",
+        "count": "66"
+      }
+    ],
+    "smooze": [
+      {
+        "cask": "smooze",
+        "count": "40"
+      }
+    ],
+    "snagit": [
+      {
+        "cask": "snagit",
+        "count": "243"
+      }
+    ],
+    "snagit4": [
+      {
+        "cask": "snagit4",
+        "count": "4"
+      }
+    ],
+    "snapndrag": [
+      {
+        "cask": "snapndrag",
+        "count": "8"
+      }
+    ],
+    "snappy": [
+      {
+        "cask": "snappy",
+        "count": "83"
+      }
+    ],
+    "sneek": [
+      {
+        "cask": "sneek",
+        "count": "17"
+      }
+    ],
+    "snes9x": [
+      {
+        "cask": "snes9x",
+        "count": "111"
+      }
+    ],
+    "snip": [
+      {
+        "cask": "snip",
+        "count": "149"
+      }
+    ],
+    "snipaste": [
+      {
+        "cask": "snipaste",
+        "count": "549"
+      }
+    ],
+    "sno": [
+      {
+        "cask": "sno",
+        "count": "10"
+      }
+    ],
+    "snowflake-odbc": [
+      {
+        "cask": "snowflake-odbc",
+        "count": "2"
+      }
+    ],
+    "snowflake-snowsql": [
+      {
+        "cask": "snowflake-snowsql",
+        "count": "681"
+      }
+    ],
+    "snwe": [
+      {
+        "cask": "snwe",
+        "count": "5"
+      }
+    ],
+    "soapui": [
+      {
+        "cask": "soapui",
+        "count": "882"
+      }
+    ],
+    "socket-io-tester": [
+      {
+        "cask": "socket-io-tester",
+        "count": "10"
+      }
+    ],
+    "sococo": [
+      {
+        "cask": "sococo",
+        "count": "77"
+      }
+    ],
+    "soda-player": [
+      {
+        "cask": "soda-player",
+        "count": "134"
+      }
+    ],
+    "soduto": [
+      {
+        "cask": "soduto",
+        "count": "24"
+      }
+    ],
+    "sofa-server": [
+      {
+        "cask": "sofa-server",
+        "count": "2"
+      }
+    ],
+    "softmaker-freeoffice": [
+      {
+        "cask": "softmaker-freeoffice",
+        "count": "50"
+      }
+    ],
+    "softorino-youtube-converter": [
+      {
+        "cask": "softorino-youtube-converter",
+        "count": "26"
+      }
+    ],
+    "softraid": [
+      {
+        "cask": "softraid",
+        "count": "23"
+      }
+    ],
+    "softu2f": [
+      {
+        "cask": "softu2f",
+        "count": "31"
+      }
+    ],
+    "softube-central": [
+      {
+        "cask": "softube-central",
+        "count": "7"
+      }
+    ],
+    "sogouinput": [
+      {
+        "cask": "sogouinput",
+        "count": "669"
+      }
+    ],
+    "soluble": [
+      {
+        "cask": "soluble",
+        "count": "7"
+      }
+    ],
+    "solvespace": [
+      {
+        "cask": "solvespace",
+        "count": "37"
+      }
+    ],
+    "somafm": [
+      {
+        "cask": "somafm",
+        "count": "2"
+      }
+    ],
+    "sonarr": [
+      {
+        "cask": "sonarr",
+        "count": "1,105"
+      }
+    ],
+    "sonarr-menu": [
+      {
+        "cask": "sonarr-menu",
+        "count": "16"
+      }
+    ],
+    "sonic-pi": [
+      {
+        "cask": "sonic-pi",
+        "count": "239"
+      }
+    ],
+    "sonic-visualiser": [
+      {
+        "cask": "sonic-visualiser",
+        "count": "69"
+      }
+    ],
+    "sonoair": [
+      {
+        "cask": "sonoair",
+        "count": "14"
+      }
+    ],
+    "sonos": [
+      {
+        "cask": "sonos",
+        "count": "398"
+      }
+    ],
+    "sony-ps4-remote-play": [
+      {
+        "cask": "sony-ps4-remote-play",
+        "count": "202"
+      }
+    ],
+    "sony-xperia-companion": [
+      {
+        "cask": "sony-xperia-companion",
+        "count": "5"
+      }
+    ],
+    "sopcast": [
+      {
+        "cask": "sopcast",
+        "count": "41"
+      }
+    ],
+    "soqlxplorer": [
+      {
+        "cask": "soqlxplorer",
+        "count": "47"
+      }
+    ],
+    "soulseek": [
+      {
+        "cask": "soulseek",
+        "count": "137"
+      }
+    ],
+    "soulver": [
+      {
+        "cask": "soulver",
+        "count": "201"
+      }
+    ],
+    "soulver2": [
+      {
+        "cask": "soulver2",
+        "count": "7"
+      }
+    ],
+    "sound-blaster-play3": [
+      {
+        "cask": "sound-blaster-play3",
+        "count": "2"
+      }
+    ],
+    "sound-control": [
+      {
+        "cask": "sound-control",
+        "count": "139"
+      }
+    ],
+    "sound-siphon": [
+      {
+        "cask": "sound-siphon",
+        "count": "16"
+      }
+    ],
+    "soundboosterlite": [
+      {
+        "cask": "soundboosterlite",
+        "count": "7"
+      }
+    ],
+    "soundcleod": [
+      {
+        "cask": "soundcleod",
+        "count": "105"
+      }
+    ],
+    "soundcloud-downloader": [
+      {
+        "cask": "soundcloud-downloader",
+        "count": "96"
+      }
+    ],
+    "soundflower": [
+      {
+        "cask": "soundflower",
+        "count": "1,902"
+      }
+    ],
+    "soundflowerbed": [
+      {
+        "cask": "soundflowerbed",
+        "count": "460"
+      }
+    ],
+    "soundnode": [
+      {
+        "cask": "soundnode",
+        "count": "13"
+      }
+    ],
+    "soundsource": [
+      {
+        "cask": "soundsource",
+        "count": "255"
+      }
+    ],
+    "sourcenote": [
+      {
+        "cask": "sourcenote",
+        "count": "7"
+      }
+    ],
+    "sourcetrail": [
+      {
+        "cask": "sourcetrail",
+        "count": "170"
+      }
+    ],
+    "sourcetree": [
+      {
+        "cask": "sourcetree",
+        "count": "7,226"
+      }
+    ],
+    "sourcetree-alpha": [
+      {
+        "cask": "sourcetree-alpha",
+        "count": "2"
+      }
+    ],
+    "sourcetree-beta": [
+      {
+        "cask": "sourcetree-beta",
+        "count": "17"
+      }
+    ],
+    "spaceid": [
+      {
+        "cask": "spaceid",
+        "count": "3"
+      }
+    ],
+    "spacelauncher": [
+      {
+        "cask": "spacelauncher",
+        "count": "24"
+      }
+    ],
+    "spaceradar": [
+      {
+        "cask": "spaceradar",
+        "count": "17"
+      }
+    ],
+    "spamsieve": [
+      {
+        "cask": "spamsieve",
+        "count": "55"
+      }
+    ],
+    "spark": [
+      {
+        "cask": "spark",
+        "count": "604"
+      }
+    ],
+    "sparkle": [
+      {
+        "cask": "sparkle",
+        "count": "84"
+      }
+    ],
+    "sparkleshare": [
+      {
+        "cask": "sparkleshare",
+        "count": "17"
+      }
+    ],
+    "spatial": [
+      {
+        "cask": "spatial",
+        "count": "11"
+      }
+    ],
+    "spatterlight": [
+      {
+        "cask": "spatterlight",
+        "count": "3"
+      }
+    ],
+    "spechtlite": [
+      {
+        "cask": "spechtlite",
+        "count": "5"
+      }
+    ],
+    "spectacle": [
+      {
+        "cask": "spectacle",
+        "count": "6,573"
+      }
+    ],
+    "spectacle-editor": [
+      {
+        "cask": "spectacle-editor",
+        "count": "12"
+      }
+    ],
+    "spectacularity": [
+      {
+        "cask": "spectacularity",
+        "count": "1"
+      }
+    ],
+    "spectrum": [
+      {
+        "cask": "spectrum",
+        "count": "44"
+      }
+    ],
+    "spectx": [
+      {
+        "cask": "spectx",
+        "count": "5"
+      }
+    ],
+    "speculid": [
+      {
+        "cask": "speculid",
+        "count": "17"
+      }
+    ],
+    "speedcrunch": [
+      {
+        "cask": "speedcrunch",
+        "count": "112"
+      }
+    ],
+    "speedify": [
+      {
+        "cask": "speedify",
+        "count": "48"
+      }
+    ],
+    "spek": [
+      {
+        "cask": "spek",
+        "count": "2"
+      }
+    ],
+    "spek-alternative": [
+      {
+        "cask": "spek-alternative",
+        "count": "1"
+      }
+    ],
+    "spideroak-share": [
+      {
+        "cask": "spideroak-share",
+        "count": "3"
+      }
+    ],
+    "spideroakone": [
+      {
+        "cask": "spideroakone",
+        "count": "27"
+      }
+    ],
+    "spike": [
+      {
+        "cask": "spike",
+        "count": "51"
+      }
+    ],
+    "spillo": [
+      {
+        "cask": "spillo",
+        "count": "13"
+      }
+    ],
+    "spires": [
+      {
+        "cask": "spires",
+        "count": "3"
+      }
+    ],
+    "splashtop-business": [
+      {
+        "cask": "splashtop-business",
+        "count": "21"
+      }
+    ],
+    "splashtop-personal": [
+      {
+        "cask": "splashtop-personal",
+        "count": "37"
+      }
+    ],
+    "splashtop-streamer": [
+      {
+        "cask": "splashtop-streamer",
+        "count": "36"
+      }
+    ],
+    "splayer": [
+      {
+        "cask": "splayer",
+        "count": "4"
+      }
+    ],
+    "splice": [
+      {
+        "cask": "splice",
+        "count": "53"
+      }
+    ],
+    "splitshow": [
+      {
+        "cask": "splitshow",
+        "count": "13"
+      }
+    ],
+    "spotifree": [
+      {
+        "cask": "spotifree",
+        "count": "75"
+      }
+    ],
+    "spotify": [
+      {
+        "cask": "spotify",
+        "count": "14,202"
+      }
+    ],
+    "spotify-notifications": [
+      {
+        "cask": "spotify-notifications",
+        "count": "192"
+      }
+    ],
+    "spotify-now-playing": [
+      {
+        "cask": "spotify-now-playing",
+        "count": "171"
+      }
+    ],
+    "spotmenu": [
+      {
+        "cask": "spotmenu",
+        "count": "1,034"
+      }
+    ],
+    "spotspot": [
+      {
+        "cask": "spotspot",
+        "count": "8"
+      }
+    ],
+    "springtoolsuite": [
+      {
+        "cask": "springtoolsuite",
+        "count": "504"
+      }
+    ],
+    "spyder-py2": [
+      {
+        "cask": "spyder-py2",
+        "count": "22"
+      }
+    ],
+    "sql-power-architect-jdbc": [
+      {
+        "cask": "sql-power-architect-jdbc",
+        "count": "15"
+      }
+    ],
+    "sql-tabs": [
+      {
+        "cask": "sql-tabs",
+        "count": "6"
+      }
+    ],
+    "sqlcheck": [
+      {
+        "cask": "sqlcheck",
+        "count": "25"
+      }
+    ],
+    "sqlectron": [
+      {
+        "cask": "sqlectron",
+        "count": "101"
+      }
+    ],
+    "sqleditor": [
+      {
+        "cask": "sqleditor",
+        "count": "20"
+      }
+    ],
+    "sqlexplorer": [
+      {
+        "cask": "sqlexplorer",
+        "count": "30"
+      }
+    ],
+    "sqlitemanager": [
+      {
+        "cask": "sqlitemanager",
+        "count": "56"
+      }
+    ],
+    "sqlitestudio": [
+      {
+        "cask": "sqlitestudio",
+        "count": "292"
+      }
+    ],
+    "sqlpro-for-mssql": [
+      {
+        "cask": "sqlpro-for-mssql",
+        "count": "61"
+      }
+    ],
+    "sqlpro-for-mysql": [
+      {
+        "cask": "sqlpro-for-mysql",
+        "count": "92"
+      }
+    ],
+    "sqlpro-for-postgres": [
+      {
+        "cask": "sqlpro-for-postgres",
+        "count": "84"
+      }
+    ],
+    "sqlpro-for-sqlite": [
+      {
+        "cask": "sqlpro-for-sqlite",
+        "count": "61"
+      }
+    ],
+    "sqlpro-studio": [
+      {
+        "cask": "sqlpro-studio",
+        "count": "82"
+      }
+    ],
+    "sqlworkbenchj": [
+      {
+        "cask": "sqlworkbenchj",
+        "count": "732"
+      }
+    ],
+    "squeak": [
+      {
+        "cask": "squeak",
+        "count": "20"
+      }
+    ],
+    "squidman": [
+      {
+        "cask": "squidman",
+        "count": "204"
+      }
+    ],
+    "squirrel": [
+      {
+        "cask": "squirrel",
+        "count": "1,062"
+      }
+    ],
+    "squirrelsql": [
+      {
+        "cask": "squirrelsql",
+        "count": "215"
+      }
+    ],
+    "srware-iron": [
+      {
+        "cask": "srware-iron",
+        "count": "30"
+      }
+    ],
+    "ssd-fan-control": [
+      {
+        "cask": "ssd-fan-control",
+        "count": "1"
+      }
+    ],
+    "ssh-tunnel-manager": [
+      {
+        "cask": "ssh-tunnel-manager",
+        "count": "197"
+      }
+    ],
+    "ssokit": [
+      {
+        "cask": "ssokit",
+        "count": "20"
+      }
+    ],
+    "stack": [
+      {
+        "cask": "stack",
+        "count": "97"
+      }
+    ],
+    "stack-exchange-notifier": [
+      {
+        "cask": "stack-exchange-notifier",
+        "count": "11"
+      }
+    ],
+    "stack-stack": [
+      {
+        "cask": "stack-stack",
+        "count": "16"
+      }
+    ],
+    "stamp": [
+      {
+        "cask": "stamp",
+        "count": "15"
+      }
+    ],
+    "stand": [
+      {
+        "cask": "stand",
+        "count": "19"
+      }
+    ],
+    "standard-notes": [
+      {
+        "cask": "standard-notes",
+        "count": "309"
+      }
+    ],
+    "standing-desk": [
+      {
+        "cask": "standing-desk",
+        "count": "2"
+      }
+    ],
+    "starcraft": [
+      {
+        "cask": "starcraft",
+        "count": "49"
+      }
+    ],
+    "stark": [
+      {
+        "cask": "stark",
+        "count": "1"
+      }
+    ],
+    "starleaf": [
+      {
+        "cask": "starleaf",
+        "count": "43"
+      }
+    ],
+    "starsector": [
+      {
+        "cask": "starsector",
+        "count": "1"
+      }
+    ],
+    "startninja": [
+      {
+        "cask": "startninja",
+        "count": "13"
+      }
+    ],
+    "startupizer": [
+      {
+        "cask": "startupizer",
+        "count": "8"
+      }
+    ],
+    "staruml": [
+      {
+        "cask": "staruml",
+        "count": "337"
+      }
+    ],
+    "station": [
+      {
+        "cask": "station",
+        "count": "643"
+      }
+    ],
+    "stationtv-link": [
+      {
+        "cask": "stationtv-link",
+        "count": "3"
+      }
+    ],
+    "statusfy": [
+      {
+        "cask": "statusfy",
+        "count": "24"
+      }
+    ],
+    "stay": [
+      {
+        "cask": "stay",
+        "count": "79"
+      }
+    ],
+    "steam": [
+      {
+        "cask": "steam",
+        "count": "8,385"
+      }
+    ],
+    "steamcmd": [
+      {
+        "cask": "steamcmd",
+        "count": "80"
+      }
+    ],
+    "steelseries-engine": [
+      {
+        "cask": "steelseries-engine",
+        "count": "90"
+      }
+    ],
+    "steelseries-exactmouse-tool": [
+      {
+        "cask": "steelseries-exactmouse-tool",
+        "count": "63"
+      }
+    ],
+    "steermouse": [
+      {
+        "cask": "steermouse",
+        "count": "508"
+      }
+    ],
+    "stella": [
+      {
+        "cask": "stella",
+        "count": "14"
+      }
+    ],
+    "stellarium": [
+      {
+        "cask": "stellarium",
+        "count": "282"
+      }
+    ],
+    "stepmania": [
+      {
+        "cask": "stepmania",
+        "count": "19"
+      }
+    ],
+    "steveschow-gfxcardstatus": [
+      {
+        "cask": "steveschow-gfxcardstatus",
+        "count": "77"
+      }
+    ],
+    "stigma": [
+      {
+        "cask": "stigma",
+        "count": "2"
+      }
+    ],
+    "stm32cubeide": [
+      {
+        "cask": "stm32cubeide",
+        "count": "2"
+      }
+    ],
+    "stm32cubemx": [
+      {
+        "cask": "stm32cubemx",
+        "count": "7"
+      }
+    ],
+    "stoplight-studio": [
+      {
+        "cask": "stoplight-studio",
+        "count": "247"
+      }
+    ],
+    "storyboarder": [
+      {
+        "cask": "storyboarder",
+        "count": "24"
+      }
+    ],
+    "strange-flesh": [
+      {
+        "cask": "strange-flesh",
+        "count": "2"
+      }
+    ],
+    "strawberry": [
+      {
+        "cask": "strawberry",
+        "count": "13"
+      }
+    ],
+    "streamlabs-obs": [
+      {
+        "cask": "streamlabs-obs",
+        "count": "164"
+      }
+    ],
+    "streamlink-twitch-gui": [
+      {
+        "cask": "streamlink-twitch-gui",
+        "count": "163"
+      }
+    ],
+    "stremio": [
+      {
+        "cask": "stremio",
+        "count": "223"
+      }
+    ],
+    "stretchly": [
+      {
+        "cask": "stretchly",
+        "count": "720"
+      }
+    ],
+    "stringsfile": [
+      {
+        "cask": "stringsfile",
+        "count": "16"
+      }
+    ],
+    "strongdm": [
+      {
+        "cask": "strongdm",
+        "count": "5"
+      }
+    ],
+    "strongvpn": [
+      {
+        "cask": "strongvpn",
+        "count": "2"
+      }
+    ],
+    "strongvpn-client": [
+      {
+        "cask": "strongvpn-client",
+        "count": "7"
+      }
+    ],
+    "stubbymanager": [
+      {
+        "cask": "stubbymanager",
+        "count": "13"
+      }
+    ],
+    "studio-3t": [
+      {
+        "cask": "studio-3t",
+        "count": "396"
+      }
+    ],
+    "studio-link": [
+      {
+        "cask": "studio-link",
+        "count": "1"
+      }
+    ],
+    "studiolinkstandalone": [
+      {
+        "cask": "studiolinkstandalone",
+        "count": "6"
+      }
+    ],
+    "suas-monitor": [
+      {
+        "cask": "suas-monitor",
+        "count": "1"
+      }
+    ],
+    "subethaedit": [
+      {
+        "cask": "subethaedit",
+        "count": "30"
+      }
+    ],
+    "subgit": [
+      {
+        "cask": "subgit",
+        "count": "9"
+      }
+    ],
+    "subler": [
+      {
+        "cask": "subler",
+        "count": "384"
+      }
+    ],
+    "sublercli": [
+      {
+        "cask": "sublercli",
+        "count": "41"
+      }
+    ],
+    "sublime": [
+      {
+        "cask": "sublime",
+        "count": "5"
+      }
+    ],
+    "sublime-merge": [
+      {
+        "cask": "sublime-merge",
+        "count": "1,023"
+      }
+    ],
+    "sublime-merge-dev": [
+      {
+        "cask": "sublime-merge-dev",
+        "count": "44"
+      }
+    ],
+    "sublime-text": [
+      {
+        "cask": "sublime-text",
+        "count": "13,906"
+      }
+    ],
+    "sublime-text-dev": [
+      {
+        "cask": "sublime-text-dev",
+        "count": "106"
+      }
+    ],
+    "sublime-text2": [
+      {
+        "cask": "sublime-text2",
+        "count": "178"
+      }
+    ],
+    "subnetcalc": [
+      {
+        "cask": "subnetcalc",
+        "count": "35"
+      }
+    ],
+    "subsmarine": [
+      {
+        "cask": "subsmarine",
+        "count": "1"
+      }
+    ],
+    "subsurface": [
+      {
+        "cask": "subsurface",
+        "count": "12"
+      }
+    ],
+    "subtitle-master": [
+      {
+        "cask": "subtitle-master",
+        "count": "18"
+      }
+    ],
+    "subtitles": [
+      {
+        "cask": "subtitles",
+        "count": "60"
+      }
+    ],
+    "subtools": [
+      {
+        "cask": "subtools",
+        "count": "18"
+      }
+    ],
+    "suitcase-fusion": [
+      {
+        "cask": "suitcase-fusion",
+        "count": "4"
+      }
+    ],
+    "sunlogincontrol": [
+      {
+        "cask": "sunlogincontrol",
+        "count": "74"
+      }
+    ],
+    "sunsama": [
+      {
+        "cask": "sunsama",
+        "count": "6"
+      }
+    ],
+    "sunvox": [
+      {
+        "cask": "sunvox",
+        "count": "27"
+      }
+    ],
+    "superbeam": [
+      {
+        "cask": "superbeam",
+        "count": "4"
+      }
+    ],
+    "supercollider": [
+      {
+        "cask": "supercollider",
+        "count": "192"
+      }
+    ],
+    "superduper": [
+      {
+        "cask": "superduper",
+        "count": "493"
+      }
+    ],
+    "superhuman": [
+      {
+        "cask": "superhuman",
+        "count": "51"
+      }
+    ],
+    "superproductivity": [
+      {
+        "cask": "superproductivity",
+        "count": "167"
+      }
+    ],
+    "supersync": [
+      {
+        "cask": "supersync",
+        "count": "1"
+      }
+    ],
+    "supertuxkart": [
+      {
+        "cask": "supertuxkart",
+        "count": "113"
+      }
+    ],
+    "surfeasy-vpn": [
+      {
+        "cask": "surfeasy-vpn",
+        "count": "4"
+      }
+    ],
+    "surge": [
+      {
+        "cask": "surge",
+        "count": "278"
+      }
+    ],
+    "surge-synthesizer": [
+      {
+        "cask": "surge-synthesizer",
+        "count": "202"
+      }
+    ],
+    "surge2": [
+      {
+        "cask": "surge2",
+        "count": "1"
+      }
+    ],
+    "sus-inspector": [
+      {
+        "cask": "sus-inspector",
+        "count": "2"
+      }
+    ],
+    "suspicious-package": [
+      {
+        "cask": "suspicious-package",
+        "count": "3,615"
+      }
+    ],
+    "suunto-moveslink2": [
+      {
+        "cask": "suunto-moveslink2",
+        "count": "9"
+      }
+    ],
+    "svgcleaner": [
+      {
+        "cask": "svgcleaner",
+        "count": "124"
+      }
+    ],
+    "svnx": [
+      {
+        "cask": "svnx",
+        "count": "377"
+      }
+    ],
+    "sweet-home3d": [
+      {
+        "cask": "sweet-home3d",
+        "count": "198"
+      }
+    ],
+    "swift": [
+      {
+        "cask": "swift",
+        "count": "30"
+      }
+    ],
+    "swift-explorer": [
+      {
+        "cask": "swift-explorer",
+        "count": "5"
+      }
+    ],
+    "swift-publisher": [
+      {
+        "cask": "swift-publisher",
+        "count": "16"
+      }
+    ],
+    "swiftdefaultappsprefpane": [
+      {
+        "cask": "swiftdefaultappsprefpane",
+        "count": "123"
+      }
+    ],
+    "swiftformat-for-xcode": [
+      {
+        "cask": "swiftformat-for-xcode",
+        "count": "1,222"
+      }
+    ],
+    "swiftpm-catalog": [
+      {
+        "cask": "swiftpm-catalog",
+        "count": "3"
+      }
+    ],
+    "swiftstack-client": [
+      {
+        "cask": "swiftstack-client",
+        "count": "15"
+      }
+    ],
+    "swifty": [
+      {
+        "cask": "swifty",
+        "count": "4"
+      }
+    ],
+    "swiftybeaver": [
+      {
+        "cask": "swiftybeaver",
+        "count": "13"
+      }
+    ],
+    "swimat": [
+      {
+        "cask": "swimat",
+        "count": "446"
+      }
+    ],
+    "swinsian": [
+      {
+        "cask": "swinsian",
+        "count": "42"
+      }
+    ],
+    "swish": [
+      {
+        "cask": "swish",
+        "count": "83"
+      }
+    ],
+    "switch": [
+      {
+        "cask": "switch",
+        "count": "27"
+      }
+    ],
+    "switchhosts": [
+      {
+        "cask": "switchhosts",
+        "count": "663"
+      }
+    ],
+    "switchkey": [
+      {
+        "cask": "switchkey",
+        "count": "88"
+      }
+    ],
+    "switchresx": [
+      {
+        "cask": "switchresx",
+        "count": "592"
+      }
+    ],
+    "symboliclinker": [
+      {
+        "cask": "symboliclinker",
+        "count": "50"
+      }
+    ],
+    "synalyze-it-pro": [
+      {
+        "cask": "synalyze-it-pro",
+        "count": "19"
+      }
+    ],
+    "sync": [
+      {
+        "cask": "sync",
+        "count": "89"
+      }
+    ],
+    "sync-my-l2p": [
+      {
+        "cask": "sync-my-l2p",
+        "count": "2"
+      }
+    ],
+    "syncmate": [
+      {
+        "cask": "syncmate",
+        "count": "28"
+      }
+    ],
+    "syncovery": [
+      {
+        "cask": "syncovery",
+        "count": "3"
+      }
+    ],
+    "syncplay": [
+      {
+        "cask": "syncplay",
+        "count": "94"
+      }
+    ],
+    "syncterm": [
+      {
+        "cask": "syncterm",
+        "count": "16"
+      }
+    ],
+    "syncthing": [
+      {
+        "cask": "syncthing",
+        "count": "729"
+      }
+    ],
+    "syncthing-brewbar": [
+      {
+        "cask": "syncthing-brewbar",
+        "count": "4"
+      }
+    ],
+    "syncwalkman": [
+      {
+        "cask": "syncwalkman",
+        "count": "5"
+      }
+    ],
+    "synergy": [
+      {
+        "cask": "synergy",
+        "count": "1,107"
+      }
+    ],
+    "synergy-beta": [
+      {
+        "cask": "synergy-beta",
+        "count": "48"
+      }
+    ],
+    "synfigstudio": [
+      {
+        "cask": "synfigstudio",
+        "count": "40"
+      }
+    ],
+    "synology-assistant": [
+      {
+        "cask": "synology-assistant",
+        "count": "7"
+      }
+    ],
+    "synology-chat": [
+      {
+        "cask": "synology-chat",
+        "count": "21"
+      }
+    ],
+    "synology-cloud-station-backup": [
+      {
+        "cask": "synology-cloud-station-backup",
+        "count": "22"
+      }
+    ],
+    "synology-drive": [
+      {
+        "cask": "synology-drive",
+        "count": "252"
+      }
+    ],
+    "synology-drive-client": [
+      {
+        "cask": "synology-drive-client",
+        "count": "6"
+      }
+    ],
+    "synology-note-station-client": [
+      {
+        "cask": "synology-note-station-client",
+        "count": "48"
+      }
+    ],
+    "synology-photo-station-uploader": [
+      {
+        "cask": "synology-photo-station-uploader",
+        "count": "9"
+      }
+    ],
+    "synology-surveillance-station-client": [
+      {
+        "cask": "synology-surveillance-station-client",
+        "count": "27"
+      }
+    ],
+    "synologyassistant": [
+      {
+        "cask": "synologyassistant",
+        "count": "61"
+      }
+    ],
+    "synoptico": [
+      {
+        "cask": "synoptico",
+        "count": "4"
+      }
+    ],
+    "syntax-highlight": [
+      {
+        "cask": "syntax-highlight",
+        "count": "19"
+      }
+    ],
+    "syntaxhighlight": [
+      {
+        "cask": "syntaxhighlight",
+        "count": "1"
+      }
+    ],
+    "synthesia": [
+      {
+        "cask": "synthesia",
+        "count": "48"
+      }
+    ],
+    "sysdig-inspect": [
+      {
+        "cask": "sysdig-inspect",
+        "count": "19"
+      }
+    ],
+    "sysex-librarian": [
+      {
+        "cask": "sysex-librarian",
+        "count": "29"
+      }
+    ],
+    "systemupdate": [
+      {
+        "cask": "systemupdate",
+        "count": "2"
+      }
+    ],
+    "systhist": [
+      {
+        "cask": "systhist",
+        "count": "6"
+      }
+    ],
+    "t2m2": [
+      {
+        "cask": "t2m2",
+        "count": "11"
+      }
+    ],
+    "table-tool": [
+      {
+        "cask": "table-tool",
+        "count": "200"
+      }
+    ],
+    "tableau": [
+      {
+        "cask": "tableau",
+        "count": "337"
+      }
+    ],
+    "tableau-prep": [
+      {
+        "cask": "tableau-prep",
+        "count": "62"
+      }
+    ],
+    "tableau-public": [
+      {
+        "cask": "tableau-public",
+        "count": "102"
+      }
+    ],
+    "tableau-reader": [
+      {
+        "cask": "tableau-reader",
+        "count": "32"
+      }
+    ],
+    "tableflip": [
+      {
+        "cask": "tableflip",
+        "count": "18"
+      }
+    ],
+    "tableplus": [
+      {
+        "cask": "tableplus",
+        "count": "2,327"
+      }
+    ],
+    "tableplus2": [
+      {
+        "cask": "tableplus2",
+        "count": "2"
+      }
+    ],
+    "tabula": [
+      {
+        "cask": "tabula",
+        "count": "99"
+      }
+    ],
+    "taccy": [
+      {
+        "cask": "taccy",
+        "count": "8"
+      }
+    ],
+    "tad": [
+      {
+        "cask": "tad",
+        "count": "58"
+      }
+    ],
+    "tag": [
+      {
+        "cask": "tag",
+        "count": "6"
+      }
+    ],
+    "tagalicious": [
+      {
+        "cask": "tagalicious",
+        "count": "1"
+      }
+    ],
+    "tagger": [
+      {
+        "cask": "tagger",
+        "count": "26"
+      }
+    ],
+    "tagspaces": [
+      {
+        "cask": "tagspaces",
+        "count": "46"
+      }
+    ],
+    "tal-chorus-lx": [
+      {
+        "cask": "tal-chorus-lx",
+        "count": "3"
+      }
+    ],
+    "tal-filter": [
+      {
+        "cask": "tal-filter",
+        "count": "3"
+      }
+    ],
+    "tal-filter2": [
+      {
+        "cask": "tal-filter2",
+        "count": "3"
+      }
+    ],
+    "tal-noisemaker": [
+      {
+        "cask": "tal-noisemaker",
+        "count": "7"
+      }
+    ],
+    "tal-reverb-2": [
+      {
+        "cask": "tal-reverb-2",
+        "count": "2"
+      }
+    ],
+    "tal-reverb-3": [
+      {
+        "cask": "tal-reverb-3",
+        "count": "2"
+      }
+    ],
+    "tal-reverb-4": [
+      {
+        "cask": "tal-reverb-4",
+        "count": "2"
+      }
+    ],
+    "tal-reverb2": [
+      {
+        "cask": "tal-reverb2",
+        "count": "3"
+      }
+    ],
+    "tal-reverb3": [
+      {
+        "cask": "tal-reverb3",
+        "count": "3"
+      }
+    ],
+    "tal-reverb4": [
+      {
+        "cask": "tal-reverb4",
+        "count": "3"
+      }
+    ],
+    "tal-vocoder": [
+      {
+        "cask": "tal-vocoder",
+        "count": "5"
+      }
+    ],
+    "tales-of-majeyal": [
+      {
+        "cask": "tales-of-majeyal",
+        "count": "12"
+      }
+    ],
+    "talon": [
+      {
+        "cask": "talon",
+        "count": "12"
+      }
+    ],
+    "tandem": [
+      {
+        "cask": "tandem",
+        "count": "101"
+      }
+    ],
+    "tap": [
+      {
+        "cask": "tap",
+        "count": "48"
+      }
+    ],
+    "tapaal": [
+      {
+        "cask": "tapaal",
+        "count": "1"
+      }
+    ],
+    "task-till-dawn": [
+      {
+        "cask": "task-till-dawn",
+        "count": "2"
+      }
+    ],
+    "taskade": [
+      {
+        "cask": "taskade",
+        "count": "23"
+      }
+    ],
+    "taskexplorer": [
+      {
+        "cask": "taskexplorer",
+        "count": "115"
+      }
+    ],
+    "taskpaper": [
+      {
+        "cask": "taskpaper",
+        "count": "68"
+      }
+    ],
+    "taskquor": [
+      {
+        "cask": "taskquor",
+        "count": "20"
+      }
+    ],
+    "taskwarrior-pomodoro": [
+      {
+        "cask": "taskwarrior-pomodoro",
+        "count": "122"
+      }
+    ],
+    "tastyworks": [
+      {
+        "cask": "tastyworks",
+        "count": "31"
+      }
+    ],
+    "tau": [
+      {
+        "cask": "tau",
+        "count": "9"
+      }
+    ],
+    "tbe": [
+      {
+        "cask": "tbe",
+        "count": "5"
+      }
+    ],
+    "tbs-studio": [
+      {
+        "cask": "tbs-studio",
+        "count": "3"
+      }
+    ],
+    "tcl": [
+      {
+        "cask": "tcl",
+        "count": "552"
+      }
+    ],
+    "td-agent": [
+      {
+        "cask": "td-agent",
+        "count": "69"
+      }
+    ],
+    "tdr-kotelnikov": [
+      {
+        "cask": "tdr-kotelnikov",
+        "count": "4"
+      }
+    ],
+    "tdr-nova": [
+      {
+        "cask": "tdr-nova",
+        "count": "4"
+      }
+    ],
+    "tdr-proximity": [
+      {
+        "cask": "tdr-proximity",
+        "count": "2"
+      }
+    ],
+    "tdr-vos-slickeq": [
+      {
+        "cask": "tdr-vos-slickeq",
+        "count": "4"
+      }
+    ],
+    "teacode": [
+      {
+        "cask": "teacode",
+        "count": "17"
+      }
+    ],
+    "teambition": [
+      {
+        "cask": "teambition",
+        "count": "31"
+      }
+    ],
+    "teamdrive": [
+      {
+        "cask": "teamdrive",
+        "count": "6"
+      }
+    ],
+    "teamspeak-client": [
+      {
+        "cask": "teamspeak-client",
+        "count": "521"
+      }
+    ],
+    "teamviewer": [
+      {
+        "cask": "teamviewer",
+        "count": "7,235"
+      }
+    ],
+    "teamviewer-custom": [
+      {
+        "cask": "teamviewer-custom",
+        "count": "31"
+      }
+    ],
+    "teamviewer-host": [
+      {
+        "cask": "teamviewer-host",
+        "count": "93"
+      }
+    ],
+    "teamviewer-quickjoin": [
+      {
+        "cask": "teamviewer-quickjoin",
+        "count": "67"
+      }
+    ],
+    "teamviewer-quicksupport": [
+      {
+        "cask": "teamviewer-quicksupport",
+        "count": "89"
+      }
+    ],
+    "teamviewer8": [
+      {
+        "cask": "teamviewer8",
+        "count": "2"
+      }
+    ],
+    "teamwire": [
+      {
+        "cask": "teamwire",
+        "count": "3"
+      }
+    ],
+    "teensy": [
+      {
+        "cask": "teensy",
+        "count": "71"
+      }
+    ],
+    "teeworlds": [
+      {
+        "cask": "teeworlds",
+        "count": "43"
+      }
+    ],
+    "telavox-flow": [
+      {
+        "cask": "telavox-flow",
+        "count": "15"
+      }
+    ],
+    "telegram": [
+      {
+        "cask": "telegram",
+        "count": "6,111"
+      }
+    ],
+    "telegram-alpha": [
+      {
+        "cask": "telegram-alpha",
+        "count": "11"
+      }
+    ],
+    "telegram-desktop": [
+      {
+        "cask": "telegram-desktop",
+        "count": "1,785"
+      }
+    ],
+    "telegram-desktop-dev": [
+      {
+        "cask": "telegram-desktop-dev",
+        "count": "127"
+      }
+    ],
+    "tempo": [
+      {
+        "cask": "tempo",
+        "count": "20"
+      }
+    ],
+    "tencent-lemon": [
+      {
+        "cask": "tencent-lemon",
+        "count": "647"
+      }
+    ],
+    "tencent-meeting": [
+      {
+        "cask": "tencent-meeting",
+        "count": "18"
+      }
+    ],
+    "tencentmeeting": [
+      {
+        "cask": "tencentmeeting",
+        "count": "1"
+      }
+    ],
+    "tenor": [
+      {
+        "cask": "tenor",
+        "count": "11"
+      }
+    ],
+    "termhere": [
+      {
+        "cask": "termhere",
+        "count": "28"
+      }
+    ],
+    "terminology": [
+      {
+        "cask": "terminology",
+        "count": "77"
+      }
+    ],
+    "terminus": [
+      {
+        "cask": "terminus",
+        "count": "522"
+      }
+    ],
+    "termius": [
+      {
+        "cask": "termius",
+        "count": "535"
+      }
+    ],
+    "termius-beta": [
+      {
+        "cask": "termius-beta",
+        "count": "10"
+      }
+    ],
+    "terraform-0.10.0": [
+      {
+        "cask": "terraform-0.10.0",
+        "count": "1"
+      }
+    ],
+    "terraform-0.10.6": [
+      {
+        "cask": "terraform-0.10.6",
+        "count": "1"
+      }
+    ],
+    "terraform-0.10.7": [
+      {
+        "cask": "terraform-0.10.7",
+        "count": "2"
+      }
+    ],
+    "terraform-0.10.8": [
+      {
+        "cask": "terraform-0.10.8",
+        "count": "10"
+      }
+    ],
+    "terraform-0.11.0": [
+      {
+        "cask": "terraform-0.11.0",
+        "count": "2"
+      }
+    ],
+    "terraform-0.11.1": [
+      {
+        "cask": "terraform-0.11.1",
+        "count": "1"
+      }
+    ],
+    "terraform-0.11.10": [
+      {
+        "cask": "terraform-0.11.10",
+        "count": "8"
+      }
+    ],
+    "terraform-0.11.11": [
+      {
+        "cask": "terraform-0.11.11",
+        "count": "11"
+      }
+    ],
+    "terraform-0.11.13": [
+      {
+        "cask": "terraform-0.11.13",
+        "count": "15"
+      }
+    ],
+    "terraform-0.11.14": [
+      {
+        "cask": "terraform-0.11.14",
+        "count": "64"
+      }
+    ],
+    "terraform-0.11.2": [
+      {
+        "cask": "terraform-0.11.2",
+        "count": "2"
+      }
+    ],
+    "terraform-0.11.3": [
+      {
+        "cask": "terraform-0.11.3",
+        "count": "12"
+      }
+    ],
+    "terraform-0.11.4": [
+      {
+        "cask": "terraform-0.11.4",
+        "count": "1"
+      }
+    ],
+    "terraform-0.11.5": [
+      {
+        "cask": "terraform-0.11.5",
+        "count": "2"
+      }
+    ],
+    "terraform-0.11.6": [
+      {
+        "cask": "terraform-0.11.6",
+        "count": "2"
+      }
+    ],
+    "terraform-0.11.7": [
+      {
+        "cask": "terraform-0.11.7",
+        "count": "11"
+      }
+    ],
+    "terraform-0.11.8": [
+      {
+        "cask": "terraform-0.11.8",
+        "count": "16"
+      }
+    ],
+    "terraform-0.11.9": [
+      {
+        "cask": "terraform-0.11.9",
+        "count": "5"
+      }
+    ],
+    "terraform-0.12.0": [
+      {
+        "cask": "terraform-0.12.0",
+        "count": "15"
+      }
+    ],
+    "terraform-0.12.1": [
+      {
+        "cask": "terraform-0.12.1",
+        "count": "4"
+      }
+    ],
+    "terraform-0.12.10": [
+      {
+        "cask": "terraform-0.12.10",
+        "count": "9"
+      }
+    ],
+    "terraform-0.12.11": [
+      {
+        "cask": "terraform-0.12.11",
+        "count": "3"
+      }
+    ],
+    "terraform-0.12.12": [
+      {
+        "cask": "terraform-0.12.12",
+        "count": "2"
+      }
+    ],
+    "terraform-0.12.13": [
+      {
+        "cask": "terraform-0.12.13",
+        "count": "13"
+      }
+    ],
+    "terraform-0.12.14": [
+      {
+        "cask": "terraform-0.12.14",
+        "count": "7"
+      }
+    ],
+    "terraform-0.12.15": [
+      {
+        "cask": "terraform-0.12.15",
+        "count": "3"
+      }
+    ],
+    "terraform-0.12.16": [
+      {
+        "cask": "terraform-0.12.16",
+        "count": "4"
+      }
+    ],
+    "terraform-0.12.17": [
+      {
+        "cask": "terraform-0.12.17",
+        "count": "6"
+      }
+    ],
+    "terraform-0.12.18": [
+      {
+        "cask": "terraform-0.12.18",
+        "count": "22"
+      }
+    ],
+    "terraform-0.12.19": [
+      {
+        "cask": "terraform-0.12.19",
+        "count": "23"
+      }
+    ],
+    "terraform-0.12.20": [
+      {
+        "cask": "terraform-0.12.20",
+        "count": "113"
+      }
+    ],
+    "terraform-0.12.21": [
+      {
+        "cask": "terraform-0.12.21",
+        "count": "88"
+      }
+    ],
+    "terraform-0.12.23": [
+      {
+        "cask": "terraform-0.12.23",
+        "count": "100"
+      }
+    ],
+    "terraform-0.12.24": [
+      {
+        "cask": "terraform-0.12.24",
+        "count": "133"
+      }
+    ],
+    "terraform-0.12.3": [
+      {
+        "cask": "terraform-0.12.3",
+        "count": "3"
+      }
+    ],
+    "terraform-0.12.4": [
+      {
+        "cask": "terraform-0.12.4",
+        "count": "6"
+      }
+    ],
+    "terraform-0.12.5": [
+      {
+        "cask": "terraform-0.12.5",
+        "count": "2"
+      }
+    ],
+    "terraform-0.12.6": [
+      {
+        "cask": "terraform-0.12.6",
+        "count": "13"
+      }
+    ],
+    "terraform-0.12.7": [
+      {
+        "cask": "terraform-0.12.7",
+        "count": "1"
+      }
+    ],
+    "terraform-0.12.8": [
+      {
+        "cask": "terraform-0.12.8",
+        "count": "20"
+      }
+    ],
+    "terraform-0.12.9": [
+      {
+        "cask": "terraform-0.12.9",
+        "count": "8"
+      }
+    ],
+    "terraform-0.8.8": [
+      {
+        "cask": "terraform-0.8.8",
+        "count": "1"
+      }
+    ],
+    "terraform-0.9.5": [
+      {
+        "cask": "terraform-0.9.5",
+        "count": "1"
+      }
+    ],
+    "terraform-0.9.6": [
+      {
+        "cask": "terraform-0.9.6",
+        "count": "1"
+      }
+    ],
+    "test": [
+      {
+        "cask": "test",
+        "count": "1"
+      }
+    ],
+    "test-formula": [
+      {
+        "cask": "test-formula",
+        "count": "5"
+      }
+    ],
+    "testvpn": [
+      {
+        "cask": "testvpn",
+        "count": "2"
+      }
+    ],
+    "tex-live-utility": [
+      {
+        "cask": "tex-live-utility",
+        "count": "752"
+      }
+    ],
+    "texmacs": [
+      {
+        "cask": "texmacs",
+        "count": "104"
+      }
+    ],
+    "texmaker": [
+      {
+        "cask": "texmaker",
+        "count": "912"
+      }
+    ],
+    "texpad": [
+      {
+        "cask": "texpad",
+        "count": "159"
+      }
+    ],
+    "texshop": [
+      {
+        "cask": "texshop",
+        "count": "291"
+      }
+    ],
+    "texstudio": [
+      {
+        "cask": "texstudio",
+        "count": "1,078"
+      }
+    ],
+    "texstudio-beta": [
+      {
+        "cask": "texstudio-beta",
+        "count": "2"
+      }
+    ],
+    "textadept": [
+      {
+        "cask": "textadept",
+        "count": "23"
+      }
+    ],
+    "textbar": [
+      {
+        "cask": "textbar",
+        "count": "10"
+      }
+    ],
+    "textexpander": [
+      {
+        "cask": "textexpander",
+        "count": "207"
+      }
+    ],
+    "textmate": [
+      {
+        "cask": "textmate",
+        "count": "1,912"
+      }
+    ],
+    "textmate-crystal": [
+      {
+        "cask": "textmate-crystal",
+        "count": "108"
+      }
+    ],
+    "textmate-cucumber": [
+      {
+        "cask": "textmate-cucumber",
+        "count": "108"
+      }
+    ],
+    "textmate-editorconfig": [
+      {
+        "cask": "textmate-editorconfig",
+        "count": "108"
+      }
+    ],
+    "textmate-elixir": [
+      {
+        "cask": "textmate-elixir",
+        "count": "108"
+      }
+    ],
+    "textmate-fish": [
+      {
+        "cask": "textmate-fish",
+        "count": "108"
+      }
+    ],
+    "textmate-glsl": [
+      {
+        "cask": "textmate-glsl",
+        "count": "108"
+      }
+    ],
+    "textmate-javascript-babel": [
+      {
+        "cask": "textmate-javascript-babel",
+        "count": "108"
+      }
+    ],
+    "textmate-javascript-eslint": [
+      {
+        "cask": "textmate-javascript-eslint",
+        "count": "108"
+      }
+    ],
+    "textmate-onsave": [
+      {
+        "cask": "textmate-onsave",
+        "count": "108"
+      }
+    ],
+    "textmate-opencl": [
+      {
+        "cask": "textmate-opencl",
+        "count": "108"
+      }
+    ],
+    "textmate-openhab": [
+      {
+        "cask": "textmate-openhab",
+        "count": "108"
+      }
+    ],
+    "textmate-preview": [
+      {
+        "cask": "textmate-preview",
+        "count": "117"
+      }
+    ],
+    "textmate-rubocop": [
+      {
+        "cask": "textmate-rubocop",
+        "count": "108"
+      }
+    ],
+    "textmate-rust": [
+      {
+        "cask": "textmate-rust",
+        "count": "109"
+      }
+    ],
+    "textmate-solarized": [
+      {
+        "cask": "textmate-solarized",
+        "count": "108"
+      }
+    ],
+    "texts": [
+      {
+        "cask": "texts",
+        "count": "12"
+      }
+    ],
+    "textual": [
+      {
+        "cask": "textual",
+        "count": "222"
+      }
+    ],
+    "texturepacker": [
+      {
+        "cask": "texturepacker",
+        "count": "48"
+      }
+    ],
+    "texworks": [
+      {
+        "cask": "texworks",
+        "count": "125"
+      }
+    ],
+    "tftpserver": [
+      {
+        "cask": "tftpserver",
+        "count": "255"
+      }
+    ],
+    "tg-pro": [
+      {
+        "cask": "tg-pro",
+        "count": "98"
+      }
+    ],
+    "th-makerx": [
+      {
+        "cask": "th-makerx",
+        "count": "9"
+      }
+    ],
+    "the-anvil": [
+      {
+        "cask": "the-anvil",
+        "count": "2"
+      }
+    ],
+    "the-archive-browser": [
+      {
+        "cask": "the-archive-browser",
+        "count": "36"
+      }
+    ],
+    "the-battle-for-wesnoth": [
+      {
+        "cask": "the-battle-for-wesnoth",
+        "count": "53"
+      }
+    ],
+    "the-cheat": [
+      {
+        "cask": "the-cheat",
+        "count": "17"
+      }
+    ],
+    "the-clock": [
+      {
+        "cask": "the-clock",
+        "count": "13"
+      }
+    ],
+    "the-hit-list": [
+      {
+        "cask": "the-hit-list",
+        "count": "2"
+      }
+    ],
+    "the-tagger": [
+      {
+        "cask": "the-tagger",
+        "count": "20"
+      }
+    ],
+    "the-unarchiver": [
+      {
+        "cask": "the-unarchiver",
+        "count": "6,191"
+      }
+    ],
+    "thebrain": [
+      {
+        "cask": "thebrain",
+        "count": "28"
+      }
+    ],
+    "thedesk": [
+      {
+        "cask": "thedesk",
+        "count": "34"
+      }
+    ],
+    "themeengine": [
+      {
+        "cask": "themeengine",
+        "count": "7"
+      }
+    ],
+    "thenewplayerfree": [
+      {
+        "cask": "thenewplayerfree",
+        "count": "3"
+      }
+    ],
+    "there": [
+      {
+        "cask": "there",
+        "count": "74"
+      }
+    ],
+    "therm": [
+      {
+        "cask": "therm",
+        "count": "76"
+      }
+    ],
+    "thetube": [
+      {
+        "cask": "thetube",
+        "count": "2"
+      }
+    ],
+    "thingsmacsandboxhelper": [
+      {
+        "cask": "thingsmacsandboxhelper",
+        "count": "77"
+      }
+    ],
+    "thinkorswim": [
+      {
+        "cask": "thinkorswim",
+        "count": "134"
+      }
+    ],
+    "thonny": [
+      {
+        "cask": "thonny",
+        "count": "74"
+      }
+    ],
+    "thonny-xxl": [
+      {
+        "cask": "thonny-xxl",
+        "count": "4"
+      }
+    ],
+    "thor": [
+      {
+        "cask": "thor",
+        "count": "29"
+      }
+    ],
+    "thorn-writing": [
+      {
+        "cask": "thorn-writing",
+        "count": "1"
+      }
+    ],
+    "thought-train": [
+      {
+        "cask": "thought-train",
+        "count": "14"
+      }
+    ],
+    "threads": [
+      {
+        "cask": "threads",
+        "count": "14"
+      }
+    ],
+    "thumbsup": [
+      {
+        "cask": "thumbsup",
+        "count": "5"
+      }
+    ],
+    "thunder": [
+      {
+        "cask": "thunder",
+        "count": "1,223"
+      }
+    ],
+    "thunder301": [
+      {
+        "cask": "thunder301",
+        "count": "4"
+      }
+    ],
+    "thunderbird": [
+      {
+        "cask": "thunderbird",
+        "count": "2,369"
+      }
+    ],
+    "thunderbird-beta": [
+      {
+        "cask": "thunderbird-beta",
+        "count": "47"
+      }
+    ],
+    "thunderbird-daily": [
+      {
+        "cask": "thunderbird-daily",
+        "count": "10"
+      }
+    ],
+    "thyme": [
+      {
+        "cask": "thyme",
+        "count": "39"
+      }
+    ],
+    "ti-connect-ce": [
+      {
+        "cask": "ti-connect-ce",
+        "count": "14"
+      }
+    ],
+    "tiat": [
+      {
+        "cask": "tiat",
+        "count": "1"
+      }
+    ],
+    "tibco-jaspersoft-studio": [
+      {
+        "cask": "tibco-jaspersoft-studio",
+        "count": "112"
+      }
+    ],
+    "tickeys": [
+      {
+        "cask": "tickeys",
+        "count": "157"
+      }
+    ],
+    "ticktick": [
+      {
+        "cask": "ticktick",
+        "count": "392"
+      }
+    ],
+    "tidal": [
+      {
+        "cask": "tidal",
+        "count": "387"
+      }
+    ],
+    "tiddly": [
+      {
+        "cask": "tiddly",
+        "count": "47"
+      }
+    ],
+    "tidepool-uploader": [
+      {
+        "cask": "tidepool-uploader",
+        "count": "3"
+      }
+    ],
+    "tifig": [
+      {
+        "cask": "tifig",
+        "count": "15"
+      }
+    ],
+    "tiger-trade": [
+      {
+        "cask": "tiger-trade",
+        "count": "15"
+      }
+    ],
+    "tigervnc-viewer": [
+      {
+        "cask": "tigervnc-viewer",
+        "count": "1,863"
+      }
+    ],
+    "tigervpn": [
+      {
+        "cask": "tigervpn",
+        "count": "17"
+      }
+    ],
+    "tikz-editor": [
+      {
+        "cask": "tikz-editor",
+        "count": "84"
+      }
+    ],
+    "tikzit": [
+      {
+        "cask": "tikzit",
+        "count": "71"
+      }
+    ],
+    "tiled": [
+      {
+        "cask": "tiled",
+        "count": "114"
+      }
+    ],
+    "tiles": [
+      {
+        "cask": "tiles",
+        "count": "226"
+      }
+    ],
+    "time-lapse-assembler": [
+      {
+        "cask": "time-lapse-assembler",
+        "count": "16"
+      }
+    ],
+    "time-out": [
+      {
+        "cask": "time-out",
+        "count": "153"
+      }
+    ],
+    "time-sink": [
+      {
+        "cask": "time-sink",
+        "count": "7"
+      }
+    ],
+    "time-tracker": [
+      {
+        "cask": "time-tracker",
+        "count": "4"
+      }
+    ],
+    "timecamp": [
+      {
+        "cask": "timecamp",
+        "count": "5"
+      }
+    ],
+    "timelane": [
+      {
+        "cask": "timelane",
+        "count": "4"
+      }
+    ],
+    "timely": [
+      {
+        "cask": "timely",
+        "count": "14"
+      }
+    ],
+    "timemachineeditor": [
+      {
+        "cask": "timemachineeditor",
+        "count": "310"
+      }
+    ],
+    "timemator": [
+      {
+        "cask": "timemator",
+        "count": "11"
+      }
+    ],
+    "timeme": [
+      {
+        "cask": "timeme",
+        "count": "1"
+      }
+    ],
+    "timer": [
+      {
+        "cask": "timer",
+        "count": "155"
+      }
+    ],
+    "timestamp": [
+      {
+        "cask": "timestamp",
+        "count": "43"
+      }
+    ],
+    "timeular": [
+      {
+        "cask": "timeular",
+        "count": "27"
+      }
+    ],
+    "timing": [
+      {
+        "cask": "timing",
+        "count": "145"
+      }
+    ],
+    "timings": [
+      {
+        "cask": "timings",
+        "count": "3"
+      }
+    ],
+    "tinderbox": [
+      {
+        "cask": "tinderbox",
+        "count": "26"
+      }
+    ],
+    "ting-en": [
+      {
+        "cask": "ting-en",
+        "count": "1"
+      }
+    ],
+    "ting-es": [
+      {
+        "cask": "ting-es",
+        "count": "1"
+      }
+    ],
+    "ting-fr": [
+      {
+        "cask": "ting-fr",
+        "count": "1"
+      }
+    ],
+    "tinkerwell": [
+      {
+        "cask": "tinkerwell",
+        "count": "23"
+      }
+    ],
+    "tiny-player": [
+      {
+        "cask": "tiny-player",
+        "count": "18"
+      }
+    ],
+    "tinymediamanager": [
+      {
+        "cask": "tinymediamanager",
+        "count": "139"
+      }
+    ],
+    "tinypng4mac": [
+      {
+        "cask": "tinypng4mac",
+        "count": "279"
+      }
+    ],
+    "tipp10": [
+      {
+        "cask": "tipp10",
+        "count": "30"
+      }
+    ],
+    "tiptoi-manager": [
+      {
+        "cask": "tiptoi-manager",
+        "count": "8"
+      }
+    ],
+    "tla-plus-toolbox": [
+      {
+        "cask": "tla-plus-toolbox",
+        "count": "153"
+      }
+    ],
+    "tla-plus-toolbox-nightly": [
+      {
+        "cask": "tla-plus-toolbox-nightly",
+        "count": "4"
+      }
+    ],
+    "tn3270-x": [
+      {
+        "cask": "tn3270-x",
+        "count": "35"
+      }
+    ],
+    "tnefs-enough": [
+      {
+        "cask": "tnefs-enough",
+        "count": "42"
+      }
+    ],
+    "today-scripts": [
+      {
+        "cask": "today-scripts",
+        "count": "8"
+      }
+    ],
+    "todometer": [
+      {
+        "cask": "todometer",
+        "count": "29"
+      }
+    ],
+    "todos": [
+      {
+        "cask": "todos",
+        "count": "5"
+      }
+    ],
+    "todotxt": [
+      {
+        "cask": "todotxt",
+        "count": "49"
+      }
+    ],
+    "todour": [
+      {
+        "cask": "todour",
+        "count": "8"
+      }
+    ],
+    "tofu": [
+      {
+        "cask": "tofu",
+        "count": "9"
+      }
+    ],
+    "toggl": [
+      {
+        "cask": "toggl",
+        "count": "752"
+      }
+    ],
+    "toggl-beta": [
+      {
+        "cask": "toggl-beta",
+        "count": "1"
+      }
+    ],
+    "tomighty": [
+      {
+        "cask": "tomighty",
+        "count": "129"
+      }
+    ],
+    "tomtom-mydrive-connect": [
+      {
+        "cask": "tomtom-mydrive-connect",
+        "count": "8"
+      }
+    ],
+    "tomtom-sports-connect": [
+      {
+        "cask": "tomtom-sports-connect",
+        "count": "10"
+      }
+    ],
+    "tongbu": [
+      {
+        "cask": "tongbu",
+        "count": "28"
+      }
+    ],
+    "toontown-rewritten": [
+      {
+        "cask": "toontown-rewritten",
+        "count": "10"
+      }
+    ],
+    "topcat": [
+      {
+        "cask": "topcat",
+        "count": "11"
+      }
+    ],
+    "toptracker": [
+      {
+        "cask": "toptracker",
+        "count": "16"
+      }
+    ],
+    "tor-browser": [
+      {
+        "cask": "tor-browser",
+        "count": "4,314"
+      }
+    ],
+    "tor-browser-alpha": [
+      {
+        "cask": "tor-browser-alpha",
+        "count": "38"
+      }
+    ],
+    "torguard": [
+      {
+        "cask": "torguard",
+        "count": "101"
+      }
+    ],
+    "torrent-file-editor": [
+      {
+        "cask": "torrent-file-editor",
+        "count": "16"
+      }
+    ],
+    "tortoisehg": [
+      {
+        "cask": "tortoisehg",
+        "count": "104"
+      }
+    ],
+    "totalfinder": [
+      {
+        "cask": "totalfinder",
+        "count": "2"
+      }
+    ],
+    "totalspaces": [
+      {
+        "cask": "totalspaces",
+        "count": "4"
+      }
+    ],
+    "touch-bar-pong": [
+      {
+        "cask": "touch-bar-pong",
+        "count": "29"
+      }
+    ],
+    "touch-bar-simulator": [
+      {
+        "cask": "touch-bar-simulator",
+        "count": "215"
+      }
+    ],
+    "touchbarserver": [
+      {
+        "cask": "touchbarserver",
+        "count": "3"
+      }
+    ],
+    "touchdesigner": [
+      {
+        "cask": "touchdesigner",
+        "count": "37"
+      }
+    ],
+    "touchosc-bridge": [
+      {
+        "cask": "touchosc-bridge",
+        "count": "15"
+      }
+    ],
+    "touchosc-editor": [
+      {
+        "cask": "touchosc-editor",
+        "count": "24"
+      }
+    ],
+    "touchswitcher": [
+      {
+        "cask": "touchswitcher",
+        "count": "44"
+      }
+    ],
+    "tower": [
+      {
+        "cask": "tower",
+        "count": "791"
+      }
+    ],
+    "tower2": [
+      {
+        "cask": "tower2",
+        "count": "36"
+      }
+    ],
+    "townwifi": [
+      {
+        "cask": "townwifi",
+        "count": "17"
+      }
+    ],
+    "tpa1": [
+      {
+        "cask": "tpa1",
+        "count": "2"
+      }
+    ],
+    "tracks-live": [
+      {
+        "cask": "tracks-live",
+        "count": "1"
+      }
+    ],
+    "trader-workstation": [
+      {
+        "cask": "trader-workstation",
+        "count": "37"
+      }
+    ],
+    "trailer": [
+      {
+        "cask": "trailer",
+        "count": "81"
+      }
+    ],
+    "trailrunner": [
+      {
+        "cask": "trailrunner",
+        "count": "1"
+      }
+    ],
+    "trainerroad": [
+      {
+        "cask": "trainerroad",
+        "count": "12"
+      }
+    ],
+    "tranquility": [
+      {
+        "cask": "tranquility",
+        "count": "8"
+      }
+    ],
+    "transfer": [
+      {
+        "cask": "transfer",
+        "count": "1"
+      }
+    ],
+    "transformant": [
+      {
+        "cask": "transformant",
+        "count": "2"
+      }
+    ],
+    "transmission": [
+      {
+        "cask": "transmission",
+        "count": "6,356"
+      }
+    ],
+    "transmission-nightly": [
+      {
+        "cask": "transmission-nightly",
+        "count": "41"
+      }
+    ],
+    "transmission-remote-gui": [
+      {
+        "cask": "transmission-remote-gui",
+        "count": "667"
+      }
+    ],
+    "transmit": [
+      {
+        "cask": "transmit",
+        "count": "1,598"
+      }
+    ],
+    "transmit-disk": [
+      {
+        "cask": "transmit-disk",
+        "count": "21"
+      }
+    ],
+    "transmit4": [
+      {
+        "cask": "transmit4",
+        "count": "17"
+      }
+    ],
+    "transocks": [
+      {
+        "cask": "transocks",
+        "count": "10"
+      }
+    ],
+    "transtype": [
+      {
+        "cask": "transtype",
+        "count": "6"
+      }
+    ],
+    "trash-it": [
+      {
+        "cask": "trash-it",
+        "count": "7"
+      }
+    ],
+    "trayplay": [
+      {
+        "cask": "trayplay",
+        "count": "9"
+      }
+    ],
+    "treesheets": [
+      {
+        "cask": "treesheets",
+        "count": "17"
+      }
+    ],
+    "tresorit": [
+      {
+        "cask": "tresorit",
+        "count": "437"
+      }
+    ],
+    "trezor-bridge": [
+      {
+        "cask": "trezor-bridge",
+        "count": "20"
+      }
+    ],
+    "tribler": [
+      {
+        "cask": "tribler",
+        "count": "19"
+      }
+    ],
+    "tricent": [
+      {
+        "cask": "tricent",
+        "count": "5"
+      }
+    ],
+    "trilium-notes": [
+      {
+        "cask": "trilium-notes",
+        "count": "111"
+      }
+    ],
+    "trim-enabler": [
+      {
+        "cask": "trim-enabler",
+        "count": "25"
+      }
+    ],
+    "trinity": [
+      {
+        "cask": "trinity",
+        "count": "31"
+      }
+    ],
+    "triplecheese": [
+      {
+        "cask": "triplecheese",
+        "count": "5"
+      }
+    ],
+    "tripmode": [
+      {
+        "cask": "tripmode",
+        "count": "163"
+      }
+    ],
+    "trojan-qt5": [
+      {
+        "cask": "trojan-qt5",
+        "count": "30"
+      }
+    ],
+    "trolcommander": [
+      {
+        "cask": "trolcommander",
+        "count": "31"
+      }
+    ],
+    "tropy": [
+      {
+        "cask": "tropy",
+        "count": "10"
+      }
+    ],
+    "truecrypt": [
+      {
+        "cask": "truecrypt",
+        "count": "6"
+      }
+    ],
+    "trufont": [
+      {
+        "cask": "trufont",
+        "count": "12"
+      }
+    ],
+    "ts999": [
+      {
+        "cask": "ts999",
+        "count": "2"
+      }
+    ],
+    "tsb1": [
+      {
+        "cask": "tsb1",
+        "count": "2"
+      }
+    ],
+    "ttscoff-mmd-quicklook": [
+      {
+        "cask": "ttscoff-mmd-quicklook",
+        "count": "47"
+      }
+    ],
+    "tuck": [
+      {
+        "cask": "tuck",
+        "count": "5"
+      }
+    ],
+    "tuneinstructor": [
+      {
+        "cask": "tuneinstructor",
+        "count": "3"
+      }
+    ],
+    "tuneskit-m4v-converter": [
+      {
+        "cask": "tuneskit-m4v-converter",
+        "count": "11"
+      }
+    ],
+    "tunnelbear": [
+      {
+        "cask": "tunnelbear",
+        "count": "349"
+      }
+    ],
+    "tunnelblick": [
+      {
+        "cask": "tunnelblick",
+        "count": "8,339"
+      }
+    ],
+    "tunnelblick-beta": [
+      {
+        "cask": "tunnelblick-beta",
+        "count": "79"
+      }
+    ],
+    "tuntap": [
+      {
+        "cask": "tuntap",
+        "count": "1,604"
+      }
+    ],
+    "tuple": [
+      {
+        "cask": "tuple",
+        "count": "292"
+      }
+    ],
+    "turbo-boost-switcher": [
+      {
+        "cask": "turbo-boost-switcher",
+        "count": "440"
+      }
+    ],
+    "turbovnc-viewer": [
+      {
+        "cask": "turbovnc-viewer",
+        "count": "230"
+      }
+    ],
+    "turtl": [
+      {
+        "cask": "turtl",
+        "count": "41"
+      }
+    ],
+    "tusk": [
+      {
+        "cask": "tusk",
+        "count": "62"
+      }
+    ],
+    "tutanota": [
+      {
+        "cask": "tutanota",
+        "count": "63"
+      }
+    ],
+    "tuxera-ntfs": [
+      {
+        "cask": "tuxera-ntfs",
+        "count": "222"
+      }
+    ],
+    "tuxguitar": [
+      {
+        "cask": "tuxguitar",
+        "count": "242"
+      }
+    ],
+    "tv-browser": [
+      {
+        "cask": "tv-browser",
+        "count": "22"
+      }
+    ],
+    "tvrenamer": [
+      {
+        "cask": "tvrenamer",
+        "count": "19"
+      }
+    ],
+    "tweet-tray": [
+      {
+        "cask": "tweet-tray",
+        "count": "9"
+      }
+    ],
+    "tweetbot": [
+      {
+        "cask": "tweetbot",
+        "count": "122"
+      }
+    ],
+    "tweeten": [
+      {
+        "cask": "tweeten",
+        "count": "62"
+      }
+    ],
+    "twelf": [
+      {
+        "cask": "twelf",
+        "count": "1"
+      }
+    ],
+    "twine": [
+      {
+        "cask": "twine",
+        "count": "257"
+      }
+    ],
+    "twist": [
+      {
+        "cask": "twist",
+        "count": "48"
+      }
+    ],
+    "twitch": [
+      {
+        "cask": "twitch",
+        "count": "570"
+      }
+    ],
+    "twitter-mini": [
+      {
+        "cask": "twitter-mini",
+        "count": "1"
+      }
+    ],
+    "twonkyserver": [
+      {
+        "cask": "twonkyserver",
+        "count": "3"
+      }
+    ],
+    "tyke": [
+      {
+        "cask": "tyke",
+        "count": "54"
+      }
+    ],
+    "typeface": [
+      {
+        "cask": "typeface",
+        "count": "17"
+      }
+    ],
+    "typeit4me": [
+      {
+        "cask": "typeit4me",
+        "count": "8"
+      }
+    ],
+    "typinator": [
+      {
+        "cask": "typinator",
+        "count": "65"
+      }
+    ],
+    "typora": [
+      {
+        "cask": "typora",
+        "count": "4,018"
+      }
+    ],
+    "tysimulator": [
+      {
+        "cask": "tysimulator",
+        "count": "1"
+      }
+    ],
+    "ubar": [
+      {
+        "cask": "ubar",
+        "count": "70"
+      }
+    ],
+    "uberconference": [
+      {
+        "cask": "uberconference",
+        "count": "3"
+      }
+    ],
+    "ubersicht": [
+      {
+        "cask": "ubersicht",
+        "count": "446"
+      }
+    ],
+    "ubiquiti-unifi-controller": [
+      {
+        "cask": "ubiquiti-unifi-controller",
+        "count": "177"
+      }
+    ],
+    "ubiquiti-unifi-controller-lts": [
+      {
+        "cask": "ubiquiti-unifi-controller-lts",
+        "count": "13"
+      }
+    ],
+    "uc-one": [
+      {
+        "cask": "uc-one",
+        "count": "1"
+      }
+    ],
+    "udeler": [
+      {
+        "cask": "udeler",
+        "count": "76"
+      }
+    ],
+    "udig": [
+      {
+        "cask": "udig",
+        "count": "12"
+      }
+    ],
+    "ueli": [
+      {
+        "cask": "ueli",
+        "count": "31"
+      }
+    ],
+    "ugene": [
+      {
+        "cask": "ugene",
+        "count": "1"
+      }
+    ],
+    "uhe-diva": [
+      {
+        "cask": "uhe-diva",
+        "count": "4"
+      }
+    ],
+    "uhe-zebra": [
+      {
+        "cask": "uhe-zebra",
+        "count": "5"
+      }
+    ],
+    "uhk-agent": [
+      {
+        "cask": "uhk-agent",
+        "count": "30"
+      }
+    ],
+    "ui-browser": [
+      {
+        "cask": "ui-browser",
+        "count": "23"
+      }
+    ],
+    "ui-desktop": [
+      {
+        "cask": "ui-desktop",
+        "count": "2"
+      }
+    ],
+    "uielementinspector": [
+      {
+        "cask": "uielementinspector",
+        "count": "3"
+      }
+    ],
+    "ukelele": [
+      {
+        "cask": "ukelele",
+        "count": "265"
+      }
+    ],
+    "ukrainian-unicode-layout": [
+      {
+        "cask": "ukrainian-unicode-layout",
+        "count": "37"
+      }
+    ],
+    "ulbow": [
+      {
+        "cask": "ulbow",
+        "count": "9"
+      }
+    ],
+    "ultimaker-cura": [
+      {
+        "cask": "ultimaker-cura",
+        "count": "682"
+      }
+    ],
+    "ultimate": [
+      {
+        "cask": "ultimate",
+        "count": "8"
+      }
+    ],
+    "ultimate-control": [
+      {
+        "cask": "ultimate-control",
+        "count": "4"
+      }
+    ],
+    "ultrastardeluxe": [
+      {
+        "cask": "ultrastardeluxe",
+        "count": "17"
+      }
+    ],
+    "uncolored": [
+      {
+        "cask": "uncolored",
+        "count": "5"
+      }
+    ],
+    "uncrustifyx": [
+      {
+        "cask": "uncrustifyx",
+        "count": "5"
+      }
+    ],
+    "understand": [
+      {
+        "cask": "understand",
+        "count": "56"
+      }
+    ],
+    "unetbootin": [
+      {
+        "cask": "unetbootin",
+        "count": "1,860"
+      }
+    ],
+    "uni": [
+      {
+        "cask": "uni",
+        "count": "1"
+      }
+    ],
+    "unicodechecker": [
+      {
+        "cask": "unicodechecker",
+        "count": "126"
+      }
+    ],
+    "uniconverter": [
+      {
+        "cask": "uniconverter",
+        "count": "62"
+      }
+    ],
+    "unified-remote": [
+      {
+        "cask": "unified-remote",
+        "count": "42"
+      }
+    ],
+    "unil-inv": [
+      {
+        "cask": "unil-inv",
+        "count": "1"
+      }
+    ],
+    "uninstallpkg": [
+      {
+        "cask": "uninstallpkg",
+        "count": "142"
+      }
+    ],
+    "unison": [
+      {
+        "cask": "unison",
+        "count": "287"
+      }
+    ],
+    "unison248": [
+      {
+        "cask": "unison248",
+        "count": "1"
+      }
+    ],
+    "unite": [
+      {
+        "cask": "unite",
+        "count": "42"
+      }
+    ],
+    "unity": [
+      {
+        "cask": "unity",
+        "count": "2,398"
+      }
+    ],
+    "unity-2017-4-1f1": [
+      {
+        "cask": "unity-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-2018-2-5f1": [
+      {
+        "cask": "unity-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-2019.3.4f1": [
+      {
+        "cask": "unity-2019.3.4f1",
+        "count": "5"
+      }
+    ],
+    "unity-5-6-6f2": [
+      {
+        "cask": "unity-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor": [
+      {
+        "cask": "unity-android-support-for-editor",
+        "count": "57"
+      }
+    ],
+    "unity-android-support-for-editor-2017-4-1f1": [
+      {
+        "cask": "unity-android-support-for-editor-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor-2018-2-5f1": [
+      {
+        "cask": "unity-android-support-for-editor-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor-5-6-6f2": [
+      {
+        "cask": "unity-android-support-for-editor-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.16f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.16f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2017.4.34f1": [
+      {
+        "cask": "unity-android-support-for-editor@2017.4.34f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.2.18f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.2.18f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.17f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.17f1",
+        "count": "12"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.20f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.20f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2018.4.3f1": [
+      {
+        "cask": "unity-android-support-for-editor@2018.4.3f1",
+        "count": "11"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.11f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.11f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.15f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.21f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.2.6f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.2.6f1",
+        "count": "2"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.0f6": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.0f6",
+        "count": "8"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.1f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.1f1",
+        "count": "8"
+      }
+    ],
+    "unity-android-support-for-editor@2019.3.9f1": [
+      {
+        "cask": "unity-android-support-for-editor@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity-download-assistant": [
+      {
+        "cask": "unity-download-assistant",
+        "count": "65"
+      }
+    ],
+    "unity-hub": [
+      {
+        "cask": "unity-hub",
+        "count": "842"
+      }
+    ],
+    "unity-ios-support-for-editor": [
+      {
+        "cask": "unity-ios-support-for-editor",
+        "count": "70"
+      }
+    ],
+    "unity-ios-support-for-editor-2017-4-1f1": [
+      {
+        "cask": "unity-ios-support-for-editor-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor-2018-2-5f1": [
+      {
+        "cask": "unity-ios-support-for-editor-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor-5-6-6f2": [
+      {
+        "cask": "unity-ios-support-for-editor-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.16f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.16f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.20f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.34f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.34f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2017.4.36f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2017.4.36f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.2.18f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.2.18f1",
+        "count": "3"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.17f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.17f1",
+        "count": "13"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.20f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2018.4.3f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2018.4.3f1",
+        "count": "11"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.11f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.11f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.15f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.15f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.21f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.2.6f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.2.6f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.0f6": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.0f6",
+        "count": "2"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.7f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.8f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.8f1",
+        "count": "1"
+      }
+    ],
+    "unity-ios-support-for-editor@2019.3.9f1": [
+      {
+        "cask": "unity-ios-support-for-editor@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity-linux-support-for-editor@2017.4.6f1": [
+      {
+        "cask": "unity-linux-support-for-editor@2017.4.6f1",
+        "count": "1"
+      }
+    ],
+    "unity-linux-support-for-editor@2018.4.16f1": [
+      {
+        "cask": "unity-linux-support-for-editor@2018.4.16f1",
+        "count": "1"
+      }
+    ],
+    "unity-linux-support-for-editor@2019.1.5f1": [
+      {
+        "cask": "unity-linux-support-for-editor@2019.1.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-lumin-support-for-editor": [
+      {
+        "cask": "unity-lumin-support-for-editor",
+        "count": "18"
+      }
+    ],
+    "unity-mac-il2cpp-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-mac-il2cpp-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-standard-assets": [
+      {
+        "cask": "unity-standard-assets",
+        "count": "13"
+      }
+    ],
+    "unity-tvos-support-for-editor-2017-4-1f1": [
+      {
+        "cask": "unity-tvos-support-for-editor-2017-4-1f1",
+        "count": "1"
+      }
+    ],
+    "unity-tvos-support-for-editor-2018-2-5f1": [
+      {
+        "cask": "unity-tvos-support-for-editor-2018-2-5f1",
+        "count": "1"
+      }
+    ],
+    "unity-tvos-support-for-editor-5-6-6f2": [
+      {
+        "cask": "unity-tvos-support-for-editor-5-6-6f2",
+        "count": "1"
+      }
+    ],
+    "unity-web-player": [
+      {
+        "cask": "unity-web-player",
+        "count": "20"
+      }
+    ],
+    "unity-webgl-support-for-editor": [
+      {
+        "cask": "unity-webgl-support-for-editor",
+        "count": "38"
+      }
+    ],
+    "unity-webgl-support-for-editor@2017.4.28f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity-webgl-support-for-editor@2018.4.13f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2018.4.13f1",
+        "count": "1"
+      }
+    ],
+    "unity-webgl-support-for-editor@2019.2.11f1": [
+      {
+        "cask": "unity-webgl-support-for-editor@2019.2.11f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2018.4.16f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2018.4.16f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.1.5f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.1.5f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-mono-support-for-editor@2019.3.10f1": [
+      {
+        "cask": "unity-windows-mono-support-for-editor@2019.3.10f1",
+        "count": "1"
+      }
+    ],
+    "unity-windows-support-for-editor": [
+      {
+        "cask": "unity-windows-support-for-editor",
+        "count": "34"
+      }
+    ],
+    "unity-windows-support-for-editor@2017.4.20f2": [
+      {
+        "cask": "unity-windows-support-for-editor@2017.4.20f2",
+        "count": "1"
+      }
+    ],
+    "unity-windows-support-for-editor@2017.4.6f1": [
+      {
+        "cask": "unity-windows-support-for-editor@2017.4.6f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.16f1": [
+      {
+        "cask": "unity@2017.4.16f1",
+        "count": "8"
+      }
+    ],
+    "unity@2017.4.20f1": [
+      {
+        "cask": "unity@2017.4.20f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.20f2": [
+      {
+        "cask": "unity@2017.4.20f2",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.28f1": [
+      {
+        "cask": "unity@2017.4.28f1",
+        "count": "2"
+      }
+    ],
+    "unity@2017.4.34f1": [
+      {
+        "cask": "unity@2017.4.34f1",
+        "count": "5"
+      }
+    ],
+    "unity@2017.4.36f1": [
+      {
+        "cask": "unity@2017.4.36f1",
+        "count": "1"
+      }
+    ],
+    "unity@2017.4.6f1": [
+      {
+        "cask": "unity@2017.4.6f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.2.18f1": [
+      {
+        "cask": "unity@2018.2.18f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.4.12f1": [
+      {
+        "cask": "unity@2018.4.12f1",
+        "count": "4"
+      }
+    ],
+    "unity@2018.4.13f1": [
+      {
+        "cask": "unity@2018.4.13f1",
+        "count": "2"
+      }
+    ],
+    "unity@2018.4.14f1": [
+      {
+        "cask": "unity@2018.4.14f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.15f1": [
+      {
+        "cask": "unity@2018.4.15f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.16f1": [
+      {
+        "cask": "unity@2018.4.16f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.17f1": [
+      {
+        "cask": "unity@2018.4.17f1",
+        "count": "16"
+      }
+    ],
+    "unity@2018.4.18f1": [
+      {
+        "cask": "unity@2018.4.18f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.19f1": [
+      {
+        "cask": "unity@2018.4.19f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.20f1": [
+      {
+        "cask": "unity@2018.4.20f1",
+        "count": "3"
+      }
+    ],
+    "unity@2018.4.21f1": [
+      {
+        "cask": "unity@2018.4.21f1",
+        "count": "19"
+      }
+    ],
+    "unity@2018.4.2f1": [
+      {
+        "cask": "unity@2018.4.2f1",
+        "count": "1"
+      }
+    ],
+    "unity@2018.4.3f1": [
+      {
+        "cask": "unity@2018.4.3f1",
+        "count": "11"
+      }
+    ],
+    "unity@2019.1.5f1": [
+      {
+        "cask": "unity@2019.1.5f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.2.11f1": [
+      {
+        "cask": "unity@2019.2.11f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.2.15f1": [
+      {
+        "cask": "unity@2019.2.15f1",
+        "count": "2"
+      }
+    ],
+    "unity@2019.2.21f1": [
+      {
+        "cask": "unity@2019.2.21f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.2.6f1": [
+      {
+        "cask": "unity@2019.2.6f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.0f6": [
+      {
+        "cask": "unity@2019.3.0f6",
+        "count": "8"
+      }
+    ],
+    "unity@2019.3.10f1": [
+      {
+        "cask": "unity@2019.3.10f1",
+        "count": "3"
+      }
+    ],
+    "unity@2019.3.1f1": [
+      {
+        "cask": "unity@2019.3.1f1",
+        "count": "8"
+      }
+    ],
+    "unity@2019.3.2f1": [
+      {
+        "cask": "unity@2019.3.2f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.4f1": [
+      {
+        "cask": "unity@2019.3.4f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.7f1": [
+      {
+        "cask": "unity@2019.3.7f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.8f1": [
+      {
+        "cask": "unity@2019.3.8f1",
+        "count": "1"
+      }
+    ],
+    "unity@2019.3.9f1": [
+      {
+        "cask": "unity@2019.3.9f1",
+        "count": "1"
+      }
+    ],
+    "unity@2020.1.0b6": [
+      {
+        "cask": "unity@2020.1.0b6",
+        "count": "1"
+      }
+    ],
+    "unity@5.6.4f1": [
+      {
+        "cask": "unity@5.6.4f1",
+        "count": "1"
+      }
+    ],
+    "universal-media-server": [
+      {
+        "cask": "universal-media-server",
+        "count": "125"
+      }
+    ],
+    "universalmailer": [
+      {
+        "cask": "universalmailer",
+        "count": "2"
+      }
+    ],
+    "unlox": [
+      {
+        "cask": "unlox",
+        "count": "46"
+      }
+    ],
+    "unofficial-wineskin": [
+      {
+        "cask": "unofficial-wineskin",
+        "count": "4"
+      }
+    ],
+    "unorml": [
+      {
+        "cask": "unorml",
+        "count": "1"
+      }
+    ],
+    "unpkg": [
+      {
+        "cask": "unpkg",
+        "count": "91"
+      }
+    ],
+    "unshaky": [
+      {
+        "cask": "unshaky",
+        "count": "128"
+      }
+    ],
+    "upic": [
+      {
+        "cask": "upic",
+        "count": "812"
+      }
+    ],
+    "upm": [
+      {
+        "cask": "upm",
+        "count": "7"
+      }
+    ],
+    "upterm": [
+      {
+        "cask": "upterm",
+        "count": "137"
+      }
+    ],
+    "upwork": [
+      {
+        "cask": "upwork",
+        "count": "108"
+      }
+    ],
+    "urbanterror": [
+      {
+        "cask": "urbanterror",
+        "count": "1"
+      }
+    ],
+    "usage": [
+      {
+        "cask": "usage",
+        "count": "26"
+      }
+    ],
+    "usb-overdrive": [
+      {
+        "cask": "usb-overdrive",
+        "count": "124"
+      }
+    ],
+    "use-engine": [
+      {
+        "cask": "use-engine",
+        "count": "858"
+      }
+    ],
+    "utc-menu-clock": [
+      {
+        "cask": "utc-menu-clock",
+        "count": "104"
+      }
+    ],
+    "utiutility": [
+      {
+        "cask": "utiutility",
+        "count": "2"
+      }
+    ],
+    "utools": [
+      {
+        "cask": "utools",
+        "count": "99"
+      }
+    ],
+    "utorrent": [
+      {
+        "cask": "utorrent",
+        "count": "3"
+      }
+    ],
+    "utox": [
+      {
+        "cask": "utox",
+        "count": "47"
+      }
+    ],
+    "uu-booster": [
+      {
+        "cask": "uu-booster",
+        "count": "45"
+      }
+    ],
+    "uxprotect": [
+      {
+        "cask": "uxprotect",
+        "count": "7"
+      }
+    ],
+    "v2rayu": [
+      {
+        "cask": "v2rayu",
+        "count": "3,281"
+      }
+    ],
+    "v2rayx": [
+      {
+        "cask": "v2rayx",
+        "count": "1,497"
+      }
+    ],
+    "vagrant": [
+      {
+        "cask": "vagrant",
+        "count": "21,135"
+      }
+    ],
+    "vagrant-1.8.7": [
+      {
+        "cask": "vagrant-1.8.7",
+        "count": "1"
+      }
+    ],
+    "vagrant-manager": [
+      {
+        "cask": "vagrant-manager",
+        "count": "3,354"
+      }
+    ],
+    "vagrant-vmware-utility": [
+      {
+        "cask": "vagrant-vmware-utility",
+        "count": "308"
+      }
+    ],
+    "valentina-studio": [
+      {
+        "cask": "valentina-studio",
+        "count": "199"
+      }
+    ],
+    "valhallafreqecho": [
+      {
+        "cask": "valhallafreqecho",
+        "count": "4"
+      }
+    ],
+    "validator-sac": [
+      {
+        "cask": "validator-sac",
+        "count": "1"
+      }
+    ],
+    "valley": [
+      {
+        "cask": "valley",
+        "count": "22"
+      }
+    ],
+    "vanilla": [
+      {
+        "cask": "vanilla",
+        "count": "602"
+      }
+    ],
+    "vapor": [
+      {
+        "cask": "vapor",
+        "count": "72"
+      }
+    ],
+    "vassal": [
+      {
+        "cask": "vassal",
+        "count": "82"
+      }
+    ],
+    "vault@1.3.0": [
+      {
+        "cask": "vault@1.3.0",
+        "count": "1"
+      }
+    ],
+    "vbox-6-0-16": [
+      {
+        "cask": "vbox-6-0-16",
+        "count": "2"
+      }
+    ],
+    "vcv-rack": [
+      {
+        "cask": "vcv-rack",
+        "count": "105"
+      }
+    ],
+    "vectr": [
+      {
+        "cask": "vectr",
+        "count": "243"
+      }
+    ],
+    "vellum": [
+      {
+        "cask": "vellum",
+        "count": "5"
+      }
+    ],
+    "veonim": [
+      {
+        "cask": "veonim",
+        "count": "35"
+      }
+    ],
+    "veracrypt": [
+      {
+        "cask": "veracrypt",
+        "count": "947"
+      }
+    ],
+    "versions": [
+      {
+        "cask": "versions",
+        "count": "63"
+      }
+    ],
+    "vesta": [
+      {
+        "cask": "vesta",
+        "count": "52"
+      }
+    ],
+    "veusz": [
+      {
+        "cask": "veusz",
+        "count": "47"
+      }
+    ],
+    "viber": [
+      {
+        "cask": "viber",
+        "count": "922"
+      }
+    ],
+    "vidcutter": [
+      {
+        "cask": "vidcutter",
+        "count": "43"
+      }
+    ],
+    "videobox": [
+      {
+        "cask": "videobox",
+        "count": "3"
+      }
+    ],
+    "videostream": [
+      {
+        "cask": "videostream",
+        "count": "75"
+      }
+    ],
+    "vidrio": [
+      {
+        "cask": "vidrio",
+        "count": "16"
+      }
+    ],
+    "vidyo": [
+      {
+        "cask": "vidyo",
+        "count": "25"
+      }
+    ],
+    "vienna": [
+      {
+        "cask": "vienna",
+        "count": "297"
+      }
+    ],
+    "vimac": [
+      {
+        "cask": "vimac",
+        "count": "7"
+      }
+    ],
+    "vimediamanager": [
+      {
+        "cask": "vimediamanager",
+        "count": "10"
+      }
+    ],
+    "vimr": [
+      {
+        "cask": "vimr",
+        "count": "815"
+      }
+    ],
+    "vin047-abgx360": [
+      {
+        "cask": "vin047-abgx360",
+        "count": "28"
+      }
+    ],
+    "vip-access": [
+      {
+        "cask": "vip-access",
+        "count": "13"
+      }
+    ],
+    "virtual-ii": [
+      {
+        "cask": "virtual-ii",
+        "count": "15"
+      }
+    ],
+    "virtualbox": [
+      {
+        "cask": "virtualbox",
+        "count": "32,987"
+      }
+    ],
+    "virtualbox-5.2": [
+      {
+        "cask": "virtualbox-5.2",
+        "count": "8"
+      }
+    ],
+    "virtualbox-beta": [
+      {
+        "cask": "virtualbox-beta",
+        "count": "84"
+      }
+    ],
+    "virtualbox-extension-pack": [
+      {
+        "cask": "virtualbox-extension-pack",
+        "count": "5,379"
+      }
+    ],
+    "virtualbox-extension-pack-beta": [
+      {
+        "cask": "virtualbox-extension-pack-beta",
+        "count": "29"
+      }
+    ],
+    "virtualbox-extension-pack@6.0": [
+      {
+        "cask": "virtualbox-extension-pack@6.0",
+        "count": "3"
+      }
+    ],
+    "virtualbox-menulet": [
+      {
+        "cask": "virtualbox-menulet",
+        "count": "12"
+      }
+    ],
+    "virtualbox@6.0": [
+      {
+        "cask": "virtualbox@6.0",
+        "count": "4"
+      }
+    ],
+    "virtualc64": [
+      {
+        "cask": "virtualc64",
+        "count": "42"
+      }
+    ],
+    "virtualgl": [
+      {
+        "cask": "virtualgl",
+        "count": "17"
+      }
+    ],
+    "virtualhere": [
+      {
+        "cask": "virtualhere",
+        "count": "18"
+      }
+    ],
+    "virtualhereserver": [
+      {
+        "cask": "virtualhereserver",
+        "count": "15"
+      }
+    ],
+    "virtualhostx": [
+      {
+        "cask": "virtualhostx",
+        "count": "12"
+      }
+    ],
+    "virustotaluploader": [
+      {
+        "cask": "virustotaluploader",
+        "count": "31"
+      }
+    ],
+    "viscosity": [
+      {
+        "cask": "viscosity",
+        "count": "1,064"
+      }
+    ],
+    "visit": [
+      {
+        "cask": "visit",
+        "count": "32"
+      }
+    ],
+    "visual": [
+      {
+        "cask": "visual",
+        "count": "33"
+      }
+    ],
+    "visual-paradigm": [
+      {
+        "cask": "visual-paradigm",
+        "count": "63"
+      }
+    ],
+    "visual-paradigm-ce": [
+      {
+        "cask": "visual-paradigm-ce",
+        "count": "141"
+      }
+    ],
+    "visual-paradigm-project-viewer": [
+      {
+        "cask": "visual-paradigm-project-viewer",
+        "count": "2"
+      }
+    ],
+    "visual-studio": [
+      {
+        "cask": "visual-studio",
+        "count": "1,792"
+      }
+    ],
+    "visual-studio-code": [
+      {
+        "cask": "visual-studio-code",
+        "count": "48,365"
+      }
+    ],
+    "visual-studio-code-insiders": [
+      {
+        "cask": "visual-studio-code-insiders",
+        "count": "1,447"
+      }
+    ],
+    "visualboyadvance-m": [
+      {
+        "cask": "visualboyadvance-m",
+        "count": "46"
+      }
+    ],
+    "visualvm": [
+      {
+        "cask": "visualvm",
+        "count": "1,435"
+      }
+    ],
+    "vitalsource-bookshelf": [
+      {
+        "cask": "vitalsource-bookshelf",
+        "count": "43"
+      }
+    ],
+    "vitamin-r": [
+      {
+        "cask": "vitamin-r",
+        "count": "27"
+      }
+    ],
+    "vivaldi": [
+      {
+        "cask": "vivaldi",
+        "count": "2,215"
+      }
+    ],
+    "vivaldi-snapshot": [
+      {
+        "cask": "vivaldi-snapshot",
+        "count": "39"
+      }
+    ],
+    "vivi": [
+      {
+        "cask": "vivi",
+        "count": "2"
+      }
+    ],
+    "vk-messenger": [
+      {
+        "cask": "vk-messenger",
+        "count": "29"
+      }
+    ],
+    "vlc": [
+      {
+        "cask": "vlc",
+        "count": "22,689"
+      }
+    ],
+    "vlc-custom": [
+      {
+        "cask": "vlc-custom",
+        "count": "1"
+      }
+    ],
+    "vlc-nightly": [
+      {
+        "cask": "vlc-nightly",
+        "count": "124"
+      }
+    ],
+    "vlc-protocol": [
+      {
+        "cask": "vlc-protocol",
+        "count": "6"
+      }
+    ],
+    "vlc-webplugin": [
+      {
+        "cask": "vlc-webplugin",
+        "count": "159"
+      }
+    ],
+    "vlcstreamer": [
+      {
+        "cask": "vlcstreamer",
+        "count": "79"
+      }
+    ],
+    "vmpk": [
+      {
+        "cask": "vmpk",
+        "count": "11"
+      }
+    ],
+    "vmware-fusion": [
+      {
+        "cask": "vmware-fusion",
+        "count": "2,561"
+      }
+    ],
+    "vmware-fusion-tech-preview": [
+      {
+        "cask": "vmware-fusion-tech-preview",
+        "count": "17"
+      }
+    ],
+    "vmware-fusion10": [
+      {
+        "cask": "vmware-fusion10",
+        "count": "59"
+      }
+    ],
+    "vmware-fusion7": [
+      {
+        "cask": "vmware-fusion7",
+        "count": "5"
+      }
+    ],
+    "vmware-fusion8": [
+      {
+        "cask": "vmware-fusion8",
+        "count": "17"
+      }
+    ],
+    "vmware-horizon-client": [
+      {
+        "cask": "vmware-horizon-client",
+        "count": "575"
+      }
+    ],
+    "vmware-remote-console": [
+      {
+        "cask": "vmware-remote-console",
+        "count": "1"
+      }
+    ],
+    "vnc-server": [
+      {
+        "cask": "vnc-server",
+        "count": "287"
+      }
+    ],
+    "vnc-viewer": [
+      {
+        "cask": "vnc-viewer",
+        "count": "2,529"
+      }
+    ],
+    "vnote": [
+      {
+        "cask": "vnote",
+        "count": "378"
+      }
+    ],
+    "voicemac": [
+      {
+        "cask": "voicemac",
+        "count": "8"
+      }
+    ],
+    "voikkospellservice": [
+      {
+        "cask": "voikkospellservice",
+        "count": "5"
+      }
+    ],
+    "volkswagen-discovercare": [
+      {
+        "cask": "volkswagen-discovercare",
+        "count": "3"
+      }
+    ],
+    "volt": [
+      {
+        "cask": "volt",
+        "count": "24"
+      }
+    ],
+    "voodoopad": [
+      {
+        "cask": "voodoopad",
+        "count": "15"
+      }
+    ],
+    "vookiimageviewer-macos": [
+      {
+        "cask": "vookiimageviewer-macos",
+        "count": "1"
+      }
+    ],
+    "vorta": [
+      {
+        "cask": "vorta",
+        "count": "154"
+      }
+    ],
+    "vox": [
+      {
+        "cask": "vox",
+        "count": "379"
+      }
+    ],
+    "vox-preferences-pane": [
+      {
+        "cask": "vox-preferences-pane",
+        "count": "33"
+      }
+    ],
+    "vox2": [
+      {
+        "cask": "vox2",
+        "count": "8"
+      }
+    ],
+    "voxql": [
+      {
+        "cask": "voxql",
+        "count": "11"
+      }
+    ],
+    "vpn-enabler": [
+      {
+        "cask": "vpn-enabler",
+        "count": "15"
+      }
+    ],
+    "vrep": [
+      {
+        "cask": "vrep",
+        "count": "13"
+      }
+    ],
+    "vscodium": [
+      {
+        "cask": "vscodium",
+        "count": "3,640"
+      }
+    ],
+    "vsee": [
+      {
+        "cask": "vsee",
+        "count": "21"
+      }
+    ],
+    "vu": [
+      {
+        "cask": "vu",
+        "count": "5"
+      }
+    ],
+    "vuescan": [
+      {
+        "cask": "vuescan",
+        "count": "149"
+      }
+    ],
+    "vuescan-x32": [
+      {
+        "cask": "vuescan-x32",
+        "count": "7"
+      }
+    ],
+    "vulkan-sdk": [
+      {
+        "cask": "vulkan-sdk",
+        "count": "630"
+      }
+    ],
+    "vuze": [
+      {
+        "cask": "vuze",
+        "count": "121"
+      }
+    ],
+    "vv": [
+      {
+        "cask": "vv",
+        "count": "55"
+      }
+    ],
+    "vyprvpn": [
+      {
+        "cask": "vyprvpn",
+        "count": "59"
+      }
+    ],
+    "vysor": [
+      {
+        "cask": "vysor",
+        "count": "213"
+      }
+    ],
+    "wacom-inkspace": [
+      {
+        "cask": "wacom-inkspace",
+        "count": "38"
+      }
+    ],
+    "wacom-pentablet@5.3.7-6": [
+      {
+        "cask": "wacom-pentablet@5.3.7-6",
+        "count": "1"
+      }
+    ],
+    "wacom-tablet": [
+      {
+        "cask": "wacom-tablet",
+        "count": "275"
+      }
+    ],
+    "wacom-tablet-patched@5.3.7-6": [
+      {
+        "cask": "wacom-tablet-patched@5.3.7-6",
+        "count": "3"
+      }
+    ],
+    "wadoku": [
+      {
+        "cask": "wadoku",
+        "count": "1"
+      }
+    ],
+    "wail": [
+      {
+        "cask": "wail",
+        "count": "3"
+      }
+    ],
+    "wakeonlan": [
+      {
+        "cask": "wakeonlan",
+        "count": "82"
+      }
+    ],
+    "wallpaper-wizard": [
+      {
+        "cask": "wallpaper-wizard",
+        "count": "39"
+      }
+    ],
+    "waltr": [
+      {
+        "cask": "waltr",
+        "count": "35"
+      }
+    ],
+    "wanna": [
+      {
+        "cask": "wanna",
+        "count": "2"
+      }
+    ],
+    "warsow": [
+      {
+        "cask": "warsow",
+        "count": "22"
+      }
+    ],
+    "wasabi-wallet": [
+      {
+        "cask": "wasabi-wallet",
+        "count": "38"
+      }
+    ],
+    "watchguard-mobile-vpn-with-ssl": [
+      {
+        "cask": "watchguard-mobile-vpn-with-ssl",
+        "count": "27"
+      }
+    ],
+    "waterfox": [
+      {
+        "cask": "waterfox",
+        "count": "199"
+      }
+    ],
+    "waterfox-current": [
+      {
+        "cask": "waterfox-current",
+        "count": "54"
+      }
+    ],
+    "watts": [
+      {
+        "cask": "watts",
+        "count": "1"
+      }
+    ],
+    "wavebox": [
+      {
+        "cask": "wavebox",
+        "count": "136"
+      }
+    ],
+    "waves-central": [
+      {
+        "cask": "waves-central",
+        "count": "26"
+      }
+    ],
+    "wavesurfer": [
+      {
+        "cask": "wavesurfer",
+        "count": "10"
+      }
+    ],
+    "wavtap": [
+      {
+        "cask": "wavtap",
+        "count": "4"
+      }
+    ],
+    "wch-ch34x-usb-serial-driver": [
+      {
+        "cask": "wch-ch34x-usb-serial-driver",
+        "count": "71"
+      }
+    ],
+    "wd-firmware-updater": [
+      {
+        "cask": "wd-firmware-updater",
+        "count": "5"
+      }
+    ],
+    "wd-security": [
+      {
+        "cask": "wd-security",
+        "count": "4"
+      }
+    ],
+    "web-sharing": [
+      {
+        "cask": "web-sharing",
+        "count": "12"
+      }
+    ],
+    "webarchiveextractor": [
+      {
+        "cask": "webarchiveextractor",
+        "count": "9"
+      }
+    ],
+    "webcamoid": [
+      {
+        "cask": "webcamoid",
+        "count": "407"
+      }
+    ],
+    "webcatalog": [
+      {
+        "cask": "webcatalog",
+        "count": "84"
+      }
+    ],
+    "webex-meetings": [
+      {
+        "cask": "webex-meetings",
+        "count": "1,306"
+      }
+    ],
+    "webex-meetings-installer": [
+      {
+        "cask": "webex-meetings-installer",
+        "count": "3"
+      }
+    ],
+    "webex-nbr-player": [
+      {
+        "cask": "webex-nbr-player",
+        "count": "17"
+      }
+    ],
+    "webex-teams": [
+      {
+        "cask": "webex-teams",
+        "count": "336"
+      }
+    ],
+    "webex-wrf-player": [
+      {
+        "cask": "webex-wrf-player",
+        "count": "14"
+      }
+    ],
+    "webpack-dashboard": [
+      {
+        "cask": "webpack-dashboard",
+        "count": "20"
+      }
+    ],
+    "webplotdigitizer": [
+      {
+        "cask": "webplotdigitizer",
+        "count": "15"
+      }
+    ],
+    "webponize": [
+      {
+        "cask": "webponize",
+        "count": "275"
+      }
+    ],
+    "webpquicklook": [
+      {
+        "cask": "webpquicklook",
+        "count": "3,519"
+      }
+    ],
+    "webrecorder-player": [
+      {
+        "cask": "webrecorder-player",
+        "count": "7"
+      }
+    ],
+    "website-watchman": [
+      {
+        "cask": "website-watchman",
+        "count": "6"
+      }
+    ],
+    "webstorm": [
+      {
+        "cask": "webstorm",
+        "count": "2,206"
+      }
+    ],
+    "webtorrent": [
+      {
+        "cask": "webtorrent",
+        "count": "454"
+      }
+    ],
+    "webviewscreensaver": [
+      {
+        "cask": "webviewscreensaver",
+        "count": "4"
+      }
+    ],
+    "wechat": [
+      {
+        "cask": "wechat",
+        "count": "2,168"
+      }
+    ],
+    "wechatwebdevtools": [
+      {
+        "cask": "wechatwebdevtools",
+        "count": "376"
+      }
+    ],
+    "wechatwork": [
+      {
+        "cask": "wechatwork",
+        "count": "592"
+      }
+    ],
+    "wechsel": [
+      {
+        "cask": "wechsel",
+        "count": "20"
+      }
+    ],
+    "weiyun": [
+      {
+        "cask": "weiyun",
+        "count": "76"
+      }
+    ],
+    "weka": [
+      {
+        "cask": "weka",
+        "count": "134"
+      }
+    ],
+    "welly": [
+      {
+        "cask": "welly",
+        "count": "211"
+      }
+    ],
+    "wercker": [
+      {
+        "cask": "wercker",
+        "count": "5"
+      }
+    ],
+    "wercker-cli": [
+      {
+        "cask": "wercker-cli",
+        "count": "7"
+      }
+    ],
+    "wewechat": [
+      {
+        "cask": "wewechat",
+        "count": "39"
+      }
+    ],
+    "wey": [
+      {
+        "cask": "wey",
+        "count": "3"
+      }
+    ],
+    "whale": [
+      {
+        "cask": "whale",
+        "count": "24"
+      }
+    ],
+    "whalebird": [
+      {
+        "cask": "whalebird",
+        "count": "47"
+      }
+    ],
+    "whatpulse": [
+      {
+        "cask": "whatpulse",
+        "count": "2"
+      }
+    ],
+    "whatroute": [
+      {
+        "cask": "whatroute",
+        "count": "34"
+      }
+    ],
+    "whatsapp": [
+      {
+        "cask": "whatsapp",
+        "count": "7,913"
+      }
+    ],
+    "whatsize": [
+      {
+        "cask": "whatsize",
+        "count": "20"
+      }
+    ],
+    "whatsyoursign": [
+      {
+        "cask": "whatsyoursign",
+        "count": "64"
+      }
+    ],
+    "whichspace": [
+      {
+        "cask": "whichspace",
+        "count": "38"
+      }
+    ],
+    "whither": [
+      {
+        "cask": "whither",
+        "count": "1"
+      }
+    ],
+    "whoozle-android-file-transfer": [
+      {
+        "cask": "whoozle-android-file-transfer",
+        "count": "149"
+      }
+    ],
+    "whoozle-android-file-transfer-nightly": [
+      {
+        "cask": "whoozle-android-file-transfer-nightly",
+        "count": "63"
+      }
+    ],
+    "wickrme": [
+      {
+        "cask": "wickrme",
+        "count": "189"
+      }
+    ],
+    "wickrpro": [
+      {
+        "cask": "wickrpro",
+        "count": "53"
+      }
+    ],
+    "widelands": [
+      {
+        "cask": "widelands",
+        "count": "32"
+      }
+    ],
+    "wifi-explorer": [
+      {
+        "cask": "wifi-explorer",
+        "count": "209"
+      }
+    ],
+    "wifispoof": [
+      {
+        "cask": "wifispoof",
+        "count": "58"
+      }
+    ],
+    "wiiuinjector-gui": [
+      {
+        "cask": "wiiuinjector-gui",
+        "count": "29"
+      }
+    ],
+    "window-switch": [
+      {
+        "cask": "window-switch",
+        "count": "18"
+      }
+    ],
+    "windows95": [
+      {
+        "cask": "windows95",
+        "count": "61"
+      }
+    ],
+    "winds": [
+      {
+        "cask": "winds",
+        "count": "35"
+      }
+    ],
+    "windscribe": [
+      {
+        "cask": "windscribe",
+        "count": "446"
+      }
+    ],
+    "wine-crossover": [
+      {
+        "cask": "wine-crossover",
+        "count": "76"
+      }
+    ],
+    "wine-devel": [
+      {
+        "cask": "wine-devel",
+        "count": "2,874"
+      }
+    ],
+    "wine-stable": [
+      {
+        "cask": "wine-stable",
+        "count": "27,896"
+      }
+    ],
+    "wine-staging": [
+      {
+        "cask": "wine-staging",
+        "count": "526"
+      }
+    ],
+    "wineskin-winery": [
+      {
+        "cask": "wineskin-winery",
+        "count": "704"
+      }
+    ],
+    "wingpersonal": [
+      {
+        "cask": "wingpersonal",
+        "count": "15"
+      }
+    ],
+    "wings3d": [
+      {
+        "cask": "wings3d",
+        "count": "29"
+      }
+    ],
+    "wintertime": [
+      {
+        "cask": "wintertime",
+        "count": "12"
+      }
+    ],
+    "winzip": [
+      {
+        "cask": "winzip",
+        "count": "163"
+      }
+    ],
+    "wire": [
+      {
+        "cask": "wire",
+        "count": "165"
+      }
+    ],
+    "wireframe-sketcher": [
+      {
+        "cask": "wireframe-sketcher",
+        "count": "8"
+      }
+    ],
+    "wireshark": [
+      {
+        "cask": "wireshark",
+        "count": "9,996"
+      }
+    ],
+    "wireshark-chmodbpf": [
+      {
+        "cask": "wireshark-chmodbpf",
+        "count": "808"
+      }
+    ],
+    "wisealpha-development-environment-cask": [
+      {
+        "cask": "wisealpha-development-environment-cask",
+        "count": "1"
+      }
+    ],
+    "witch": [
+      {
+        "cask": "witch",
+        "count": "169"
+      }
+    ],
+    "withings-scale": [
+      {
+        "cask": "withings-scale",
+        "count": "1"
+      }
+    ],
+    "wiznote": [
+      {
+        "cask": "wiznote",
+        "count": "56"
+      }
+    ],
+    "wjoy": [
+      {
+        "cask": "wjoy",
+        "count": "8"
+      }
+    ],
+    "wkhtmltopdf": [
+      {
+        "cask": "wkhtmltopdf",
+        "count": "6,008"
+      }
+    ],
+    "wkhtmltopdf0125": [
+      {
+        "cask": "wkhtmltopdf0125",
+        "count": "8"
+      }
+    ],
+    "wko": [
+      {
+        "cask": "wko",
+        "count": "2"
+      }
+    ],
+    "wonderfultools-screensaver": [
+      {
+        "cask": "wonderfultools-screensaver",
+        "count": "12"
+      }
+    ],
+    "wondershare-filmora": [
+      {
+        "cask": "wondershare-filmora",
+        "count": "52"
+      }
+    ],
+    "wordpresscom": [
+      {
+        "cask": "wordpresscom",
+        "count": "94"
+      }
+    ],
+    "wordservice": [
+      {
+        "cask": "wordservice",
+        "count": "26"
+      }
+    ],
+    "workbench": [
+      {
+        "cask": "workbench",
+        "count": "81"
+      }
+    ],
+    "workflowy": [
+      {
+        "cask": "workflowy",
+        "count": "171"
+      }
+    ],
+    "workflowy-beta": [
+      {
+        "cask": "workflowy-beta",
+        "count": "1"
+      }
+    ],
+    "workplace-chat": [
+      {
+        "cask": "workplace-chat",
+        "count": "131"
+      }
+    ],
+    "wowmatrix": [
+      {
+        "cask": "wowmatrix",
+        "count": "11"
+      }
+    ],
+    "wpsoffice": [
+      {
+        "cask": "wpsoffice",
+        "count": "791"
+      }
+    ],
+    "wpsoffice-cn": [
+      {
+        "cask": "wpsoffice-cn",
+        "count": "2"
+      }
+    ],
+    "wraparound": [
+      {
+        "cask": "wraparound",
+        "count": "11"
+      }
+    ],
+    "wrike": [
+      {
+        "cask": "wrike",
+        "count": "53"
+      }
+    ],
+    "writefull": [
+      {
+        "cask": "writefull",
+        "count": "11"
+      }
+    ],
+    "writemapper": [
+      {
+        "cask": "writemapper",
+        "count": "3"
+      }
+    ],
+    "writer": [
+      {
+        "cask": "writer",
+        "count": "3"
+      }
+    ],
+    "wwdc": [
+      {
+        "cask": "wwdc",
+        "count": "152"
+      }
+    ],
+    "wwdcsrt": [
+      {
+        "cask": "wwdcsrt",
+        "count": "4"
+      }
+    ],
+    "wxcrafter": [
+      {
+        "cask": "wxcrafter",
+        "count": "10"
+      }
+    ],
+    "x-air-edit": [
+      {
+        "cask": "x-air-edit",
+        "count": "1"
+      }
+    ],
+    "x-mirage": [
+      {
+        "cask": "x-mirage",
+        "count": "17"
+      }
+    ],
+    "x-moto": [
+      {
+        "cask": "x-moto",
+        "count": "7"
+      }
+    ],
+    "x2goclient": [
+      {
+        "cask": "x2goclient",
+        "count": "568"
+      }
+    ],
+    "x48": [
+      {
+        "cask": "x48",
+        "count": "26"
+      }
+    ],
+    "xact": [
+      {
+        "cask": "xact",
+        "count": "69"
+      }
+    ],
+    "xamarin": [
+      {
+        "cask": "xamarin",
+        "count": "88"
+      }
+    ],
+    "xamarin-android": [
+      {
+        "cask": "xamarin-android",
+        "count": "113"
+      }
+    ],
+    "xamarin-ios": [
+      {
+        "cask": "xamarin-ios",
+        "count": "121"
+      }
+    ],
+    "xamarin-mac": [
+      {
+        "cask": "xamarin-mac",
+        "count": "67"
+      }
+    ],
+    "xamarin-profiler": [
+      {
+        "cask": "xamarin-profiler",
+        "count": "19"
+      }
+    ],
+    "xamarin-studio": [
+      {
+        "cask": "xamarin-studio",
+        "count": "61"
+      }
+    ],
+    "xamarin-workbooks": [
+      {
+        "cask": "xamarin-workbooks",
+        "count": "29"
+      }
+    ],
+    "xampp": [
+      {
+        "cask": "xampp",
+        "count": "580"
+      }
+    ],
+    "xampp-vm": [
+      {
+        "cask": "xampp-vm",
+        "count": "32"
+      }
+    ],
+    "xaos": [
+      {
+        "cask": "xaos",
+        "count": "25"
+      }
+    ],
+    "xattred": [
+      {
+        "cask": "xattred",
+        "count": "5"
+      }
+    ],
+    "xbench": [
+      {
+        "cask": "xbench",
+        "count": "29"
+      }
+    ],
+    "xbox360-controller-driver-unofficial": [
+      {
+        "cask": "xbox360-controller-driver-unofficial",
+        "count": "80"
+      }
+    ],
+    "xca": [
+      {
+        "cask": "xca",
+        "count": "282"
+      }
+    ],
+    "xcode@10.3": [
+      {
+        "cask": "xcode@10.3",
+        "count": "1"
+      }
+    ],
+    "xctu": [
+      {
+        "cask": "xctu",
+        "count": "3"
+      }
+    ],
+    "xdm": [
+      {
+        "cask": "xdm",
+        "count": "52"
+      }
+    ],
+    "xee": [
+      {
+        "cask": "xee",
+        "count": "150"
+      }
+    ],
+    "xerox-print-driver": [
+      {
+        "cask": "xerox-print-driver",
+        "count": "39"
+      }
+    ],
+    "xiami": [
+      {
+        "cask": "xiami",
+        "count": "89"
+      }
+    ],
+    "ximalaya": [
+      {
+        "cask": "ximalaya",
+        "count": "61"
+      }
+    ],
+    "xit": [
+      {
+        "cask": "xit",
+        "count": "10"
+      }
+    ],
+    "xld": [
+      {
+        "cask": "xld",
+        "count": "825"
+      }
+    ],
+    "xlink-kai": [
+      {
+        "cask": "xlink-kai",
+        "count": "2"
+      }
+    ],
+    "xlplayer": [
+      {
+        "cask": "xlplayer",
+        "count": "18"
+      }
+    ],
+    "xmind": [
+      {
+        "cask": "xmind",
+        "count": "823"
+      }
+    ],
+    "xmind-zen": [
+      {
+        "cask": "xmind-zen",
+        "count": "567"
+      }
+    ],
+    "xmplify": [
+      {
+        "cask": "xmplify",
+        "count": "14"
+      }
+    ],
+    "xmrouter": [
+      {
+        "cask": "xmrouter",
+        "count": "5"
+      }
+    ],
+    "xnconvert": [
+      {
+        "cask": "xnconvert",
+        "count": "202"
+      }
+    ],
+    "xnview-mp": [
+      {
+        "cask": "xnview-mp",
+        "count": "1"
+      }
+    ],
+    "xnviewmp": [
+      {
+        "cask": "xnviewmp",
+        "count": "285"
+      }
+    ],
+    "xoctave": [
+      {
+        "cask": "xoctave",
+        "count": "153"
+      }
+    ],
+    "xonotic": [
+      {
+        "cask": "xonotic",
+        "count": "74"
+      }
+    ],
+    "xpra": [
+      {
+        "cask": "xpra",
+        "count": "237"
+      }
+    ],
+    "xquartz": [
+      {
+        "cask": "xquartz",
+        "count": "50,944"
+      }
+    ],
+    "xrg": [
+      {
+        "cask": "xrg",
+        "count": "76"
+      }
+    ],
+    "xscope": [
+      {
+        "cask": "xscope",
+        "count": "168"
+      }
+    ],
+    "xscreensaver": [
+      {
+        "cask": "xscreensaver",
+        "count": "118"
+      }
+    ],
+    "xsymbolicate": [
+      {
+        "cask": "xsymbolicate",
+        "count": "1"
+      }
+    ],
+    "xtorrent": [
+      {
+        "cask": "xtorrent",
+        "count": "137"
+      }
+    ],
+    "xversion": [
+      {
+        "cask": "xversion",
+        "count": "1"
+      }
+    ],
+    "xylink": [
+      {
+        "cask": "xylink",
+        "count": "1"
+      }
+    ],
+    "yacreader": [
+      {
+        "cask": "yacreader",
+        "count": "610"
+      }
+    ],
+    "yahoo-keykey": [
+      {
+        "cask": "yahoo-keykey",
+        "count": "4"
+      }
+    ],
+    "yakyak": [
+      {
+        "cask": "yakyak",
+        "count": "194"
+      }
+    ],
+    "yam-display": [
+      {
+        "cask": "yam-display",
+        "count": "23"
+      }
+    ],
+    "yammer": [
+      {
+        "cask": "yammer",
+        "count": "70"
+      }
+    ],
+    "yandex": [
+      {
+        "cask": "yandex",
+        "count": "117"
+      }
+    ],
+    "yandex-cloud-cli": [
+      {
+        "cask": "yandex-cloud-cli",
+        "count": "23"
+      }
+    ],
+    "yandex-disk": [
+      {
+        "cask": "yandex-disk",
+        "count": "140"
+      }
+    ],
+    "yandexradio": [
+      {
+        "cask": "yandexradio",
+        "count": "23"
+      }
+    ],
+    "yate": [
+      {
+        "cask": "yate",
+        "count": "61"
+      }
+    ],
+    "yc-yandexcloud": [
+      {
+        "cask": "yc-yandexcloud",
+        "count": "5"
+      }
+    ],
+    "yed": [
+      {
+        "cask": "yed",
+        "count": "374"
+      }
+    ],
+    "yemuzip": [
+      {
+        "cask": "yemuzip",
+        "count": "8"
+      }
+    ],
+    "yep": [
+      {
+        "cask": "yep",
+        "count": "14"
+      }
+    ],
+    "yinxiangbiji": [
+      {
+        "cask": "yinxiangbiji",
+        "count": "274"
+      }
+    ],
+    "yo": [
+      {
+        "cask": "yo",
+        "count": "37"
+      }
+    ],
+    "yoda": [
+      {
+        "cask": "yoda",
+        "count": "9"
+      }
+    ],
+    "yojimbo": [
+      {
+        "cask": "yojimbo",
+        "count": "9"
+      }
+    ],
+    "youdaodict": [
+      {
+        "cask": "youdaodict",
+        "count": "223"
+      }
+    ],
+    "youdaonote": [
+      {
+        "cask": "youdaonote",
+        "count": "206"
+      }
+    ],
+    "youku": [
+      {
+        "cask": "youku",
+        "count": "297"
+      }
+    ],
+    "youll-never-take-me-alive": [
+      {
+        "cask": "youll-never-take-me-alive",
+        "count": "6"
+      }
+    ],
+    "yourkit-java-profiler": [
+      {
+        "cask": "yourkit-java-profiler",
+        "count": "126"
+      }
+    ],
+    "youtrack-workflow": [
+      {
+        "cask": "youtrack-workflow",
+        "count": "11"
+      }
+    ],
+    "youtube-to-mp3": [
+      {
+        "cask": "youtube-to-mp3",
+        "count": "216"
+      }
+    ],
+    "ysyy": [
+      {
+        "cask": "ysyy",
+        "count": "1"
+      }
+    ],
+    "yt-music": [
+      {
+        "cask": "yt-music",
+        "count": "398"
+      }
+    ],
+    "yu-writer": [
+      {
+        "cask": "yu-writer",
+        "count": "12"
+      }
+    ],
+    "yubico-authenticator": [
+      {
+        "cask": "yubico-authenticator",
+        "count": "256"
+      }
+    ],
+    "yubico-yubikey-manager": [
+      {
+        "cask": "yubico-yubikey-manager",
+        "count": "349"
+      }
+    ],
+    "yubico-yubikey-personalization-gui": [
+      {
+        "cask": "yubico-yubikey-personalization-gui",
+        "count": "150"
+      }
+    ],
+    "yubico-yubikey-piv-manager": [
+      {
+        "cask": "yubico-yubikey-piv-manager",
+        "count": "73"
+      }
+    ],
+    "yubioath-desktop-beta": [
+      {
+        "cask": "yubioath-desktop-beta",
+        "count": "11"
+      }
+    ],
+    "yy": [
+      {
+        "cask": "yy",
+        "count": "27"
+      }
+    ],
+    "yyets": [
+      {
+        "cask": "yyets",
+        "count": "75"
+      }
+    ],
+    "zalo": [
+      {
+        "cask": "zalo",
+        "count": "63"
+      }
+    ],
+    "zandronum": [
+      {
+        "cask": "zandronum",
+        "count": "14"
+      }
+    ],
+    "zappy": [
+      {
+        "cask": "zappy",
+        "count": "29"
+      }
+    ],
+    "zazu": [
+      {
+        "cask": "zazu",
+        "count": "42"
+      }
+    ],
+    "zdoom": [
+      {
+        "cask": "zdoom",
+        "count": "13"
+      }
+    ],
+    "zecwallet": [
+      {
+        "cask": "zecwallet",
+        "count": "7"
+      }
+    ],
+    "zeebe-modeler": [
+      {
+        "cask": "zeebe-modeler",
+        "count": "146"
+      }
+    ],
+    "zenbeats": [
+      {
+        "cask": "zenbeats",
+        "count": "5"
+      }
+    ],
+    "zenmap": [
+      {
+        "cask": "zenmap",
+        "count": "1,107"
+      }
+    ],
+    "zenmate-vpn": [
+      {
+        "cask": "zenmate-vpn",
+        "count": "13"
+      }
+    ],
+    "zeplin": [
+      {
+        "cask": "zeplin",
+        "count": "1,343"
+      }
+    ],
+    "zerobranestudio": [
+      {
+        "cask": "zerobranestudio",
+        "count": "63"
+      }
+    ],
+    "zeronet": [
+      {
+        "cask": "zeronet",
+        "count": "72"
+      }
+    ],
+    "zerotier-one": [
+      {
+        "cask": "zerotier-one",
+        "count": "510"
+      }
+    ],
+    "zesarux": [
+      {
+        "cask": "zesarux",
+        "count": "7"
+      }
+    ],
+    "zettelkasten": [
+      {
+        "cask": "zettelkasten",
+        "count": "44"
+      }
+    ],
+    "zettlr": [
+      {
+        "cask": "zettlr",
+        "count": "550"
+      }
+    ],
+    "zig": [
+      {
+        "cask": "zig",
+        "count": "5"
+      }
+    ],
+    "zim-app": [
+      {
+        "cask": "zim-app",
+        "count": "1"
+      }
+    ],
+    "zipcleaner": [
+      {
+        "cask": "zipcleaner",
+        "count": "11"
+      }
+    ],
+    "zoc": [
+      {
+        "cask": "zoc",
+        "count": "105"
+      }
+    ],
+    "zoho-docs": [
+      {
+        "cask": "zoho-docs",
+        "count": "7"
+      }
+    ],
+    "zoho-mail": [
+      {
+        "cask": "zoho-mail",
+        "count": "47"
+      }
+    ],
+    "zoho-workdrive": [
+      {
+        "cask": "zoho-workdrive",
+        "count": "4"
+      }
+    ],
+    "zoolz": [
+      {
+        "cask": "zoolz",
+        "count": "4"
+      }
+    ],
+    "zoom": [
+      {
+        "cask": "zoom",
+        "count": "7,823"
+      }
+    ],
+    "zoom-in": [
+      {
+        "cask": "zoom-in",
+        "count": "17"
+      }
+    ],
+    "zoom-meeting": [
+      {
+        "cask": "zoom-meeting",
+        "count": "1"
+      }
+    ],
+    "zoom-us": [
+      {
+        "cask": "zoom-us",
+        "count": "1"
+      }
+    ],
+    "zoomus": [
+      {
+        "cask": "zoomus",
+        "count": "15,970"
+      }
+    ],
+    "zoomus-outlook-plugin": [
+      {
+        "cask": "zoomus-outlook-plugin",
+        "count": "139"
+      }
+    ],
+    "zotero": [
+      {
+        "cask": "zotero",
+        "count": "1,317"
+      }
+    ],
+    "zsa-wally": [
+      {
+        "cask": "zsa-wally",
+        "count": "47"
+      }
+    ],
+    "zterm": [
+      {
+        "cask": "zterm",
+        "count": "101"
+      }
+    ],
+    "zulip": [
+      {
+        "cask": "zulip",
+        "count": "218"
+      }
+    ],
+    "zulu": [
+      {
+        "cask": "zulu",
+        "count": "285"
+      }
+    ],
+    "zulu-jdk11": [
+      {
+        "cask": "zulu-jdk11",
+        "count": "54"
+      }
+    ],
+    "zulu-jdk12": [
+      {
+        "cask": "zulu-jdk12",
+        "count": "2"
+      }
+    ],
+    "zulu-jdk13": [
+      {
+        "cask": "zulu-jdk13",
+        "count": "19"
+      }
+    ],
+    "zulu-jdk14": [
+      {
+        "cask": "zulu-jdk14",
+        "count": "17"
+      }
+    ],
+    "zulu-jdk15ea": [
+      {
+        "cask": "zulu-jdk15ea",
+        "count": "4"
+      }
+    ],
+    "zulu-jdk7": [
+      {
+        "cask": "zulu-jdk7",
+        "count": "10"
+      }
+    ],
+    "zulu-jdk8": [
+      {
+        "cask": "zulu-jdk8",
+        "count": "60"
+      }
+    ],
+    "zulu-mc": [
+      {
+        "cask": "zulu-mc",
+        "count": "8"
+      }
+    ],
+    "zulu-mission-control": [
+      {
+        "cask": "zulu-mission-control",
+        "count": "3"
+      }
+    ],
+    "zulu11": [
+      {
+        "cask": "zulu11",
+        "count": "600"
+      }
+    ],
+    "zulu13": [
+      {
+        "cask": "zulu13",
+        "count": "34"
+      }
+    ],
+    "zulu14": [
+      {
+        "cask": "zulu14",
+        "count": "1"
+      }
+    ],
+    "zulu7": [
+      {
+        "cask": "zulu7",
+        "count": "348"
+      }
+    ],
+    "zulu8": [
+      {
+        "cask": "zulu8",
+        "count": "1,089"
+      }
+    ],
+    "zulutest": [
+      {
+        "cask": "zuluTest",
+        "count": "2"
+      }
+    ],
+    "zwift": [
+      {
+        "cask": "zwift",
+        "count": "81"
+      }
+    ],
+    "zxfast": [
+      {
+        "cask": "zxfast",
+        "count": "1"
+      }
+    ],
+    "zxpinstaller": [
+      {
+        "cask": "zxpinstaller",
+        "count": "23"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
And allow them to be generated by not setting `HOMEBREW_NO_ANALYTICS` globally.