### PR TITLE
Add generated_date to JSON & HTML pages

### DIFF
--- a/_layouts/cask_json.json
+++ b/_layouts/cask_json.json
@@ -43,4 +43,4 @@
 {%- else -%}
   {{ token | jsonify }}:0
 {%- endif -%}
-}}}}
+}}},"generated_date":"{{ "today" | date: "%F" }}"}

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -101,4 +101,4 @@
 {%- else -%}
   {{ full_name | jsonify }}:0
 {%- endif -%}
-}}}}
+}}},"generated_date":"{{ "today" | date: "%F" }}"}

--- a/cask_index.html
+++ b/cask_index.html
@@ -17,3 +17,4 @@ permalink: /cask/
     </tr>
     {%- endfor -%}
 </table>
+<footer id="border-no-bottom">Last updated: {{ "today" | date: "%F %R" }}</footer>

--- a/formula_index.html
+++ b/formula_index.html
@@ -16,3 +16,4 @@ permalink: /formula/
     </tr>
     {%- endfor -%}
 </table>
+<footer id="border-no-bottom">Last updated: {{ "today" | date: "%F %R" }}</footer>

--- a/formula_linux_index.html
+++ b/formula_linux_index.html
@@ -17,3 +17,4 @@ permalink: /formula-linux/
     </tr>
     {%- endfor -%}
 </table>
+<footer id="border-no-bottom">Last updated: {{ "today" | date: "%F %R" }}</footer>


### PR DESCRIPTION
Adds a [date](https://github.com/Homebrew/formulae.brew.sh/pull/277#issuecomment-623114612) to the bottom of formulae/casks lists ("Last updated at 2020-05-15 11:30") and JSON results (`generated_date: "2020-05-15"`).