### PR TITLE
Show additional formula/cask info

### DIFF
--- a/_includes/formula.html
+++ b/_includes/formula.html
@@ -1,4 +1,8 @@
 
-        <td><a href="{{ site.baseurl }}/{{ include.formula_path || default: "formula" }}/{{ include.formula.name }}">{{ include.formula.name }}</a></td>
+        <td><a href="{{ site.baseurl }}/{{ include.formula_path || default: "formula" }}/{{ include.formula.name }}"
+            {%- if include.formula.disabled %} class="disabled" title="This formula has been disabled"
+            {%- elsif include.formula.deprecated %} class="deprecated" title="This formula has been deprecated"
+            {%- endif -%}
+            >{{ include.formula.name }}</a></td>
         <td>{{ include.formula.versions.stable }}</td>
         <td>{{ include.formula.desc | xml_escape }}</td>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -12,6 +12,9 @@ permalink: :title
     {%- unless forloop.last -%}, {% endunless %}
 {%- endfor -%}
 </p>
+{%- if c.desc %}
+<p>{{ c.desc }}</p>
+{%- endif %}
 <p><a href="{{ c.homepage }}">{{ c.homepage }}</a></p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -16,8 +16,8 @@ permalink: :title
 <p>{{ f.desc | xml_escape }}</p>
 <p><a href="{{ f.homepage }}">{{ f.homepage }}</a></p>
 {%- if f.license.size > 0 %}
-<p>License: <strong>{{ f.license | join: "</strong>, <strong>" }}</strong></p>
-{%- endif -%}
+<p>License: <strong>{{ f.license | join: "</strong>, <strong>" | replace: "_", " " }}</strong></p>
+{%- endif %}
 
 <p><a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code> (JSON API)</a></p>
 {%- if formula_path == "formula-linux" %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -6,7 +6,11 @@ permalink: :title
 {%- assign formula_path = page.dir | remove: "/" -%}
 {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
 {%- assign f = site.data[formula_path][data_name] -%}
-<h2>{{ f.name }}</h2>
+<h2
+    {%- if f.disabled %} class="disabled" title="This formula has been disabled"
+    {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated"
+    {%- endif -%}
+    >{{ f.name }}</h2>
 {%- if f.aliases.size > 0 %}
 <p>Also known as: <strong>{{ f.aliases | join: "</strong>, <strong>" }}</strong></p>
 {%- endif -%}


### PR DESCRIPTION
- sets a "disabled" or "deprecated" class and hovertext for titles of such formulae (relies on changes to site theme in https://github.com/Homebrew/brew.sh/pull/516) in both the formula page title and formula listings
- displays cask descriptions if they exist
- replaces the underscore with a space for formulae specifying `license :public_domain`

As suggested in https://github.com/Homebrew/brew/pull/8166.