### PR TITLE
workflows/scheduled: run every hour.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -4,8 +4,8 @@ on:
     paths:
       - .github/workflows/scheduled.yml
   schedule:
-    # Once every other hour
-    - cron:  '30 */2 * * *'
+    # Once every hour
+    - cron:  '0 * * * *'
 jobs:
   generate:
     if: startsWith( github.repository, 'Homebrew/' )


### PR DESCRIPTION
We used to run this on every push so seems fair enough to run it a little more often.