### PR TITLE
Add install command and copy to clipboard

### DIFF
--- a/_includes/code_snippet.html
+++ b/_includes/code_snippet.html
@@ -1,0 +1,17 @@
+{% assign code = include.code %}
+<style>
+.copyButton {
+	background: transparent;
+    border: none;
+}
+</style>
+<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
+
+<code id="code">{{code}}</code>
+<button class="copyButton" data-clipboard-target="#code" aria-label="Copy to clipboard">
+    📋
+</button>
+
+<script>
+    new ClipboardJS('.copyButton');
+</script>

--- a/_includes/code_snippet.html
+++ b/_includes/code_snippet.html
@@ -3,6 +3,7 @@
     #copyButton {
         background: transparent;
         border: none;
+        visibility: hidden;
     }
 </style>
 
@@ -16,8 +17,9 @@
 </button>
 
 <script>
-    if(!navigator.clipboard) {
-        document.getElementById("copyButton").remove();
+    if (navigator.clipboard) {
+        document
+            .getElementById("copyButton")
+            .style.removeProperty("visibility");
     }
 </script>
-

--- a/_includes/code_snippet.html
+++ b/_includes/code_snippet.html
@@ -15,3 +15,9 @@
     📋
 </button>
 
+<script>
+    if(!navigator.clipboard) {
+        document.getElementById("copyButton").remove();
+    }
+</script>
+

--- a/_includes/code_snippet.html
+++ b/_includes/code_snippet.html
@@ -1,17 +1,20 @@
 {% assign code = include.code %}
 <style>
-.copyButton {
-	background: transparent;
-    border: none;
-}
+    .copyButton {
+        background: transparent;
+        border: none;
+    }
 </style>
-<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
 
-<code id="code">{{code}}</code>
-<button class="copyButton" data-clipboard-target="#code" aria-label="Copy to clipboard">
+<code>{{code}}</code>
+<button
+    id="copyButton"
+    aria-label="Copy to clipboard"
+>
     📋
 </button>
 
 <script>
-    new ClipboardJS('.copyButton');
+    document.querySelector("#copyButton")
+    .addEventListener("click", () => navigator.clipboard.writeText("{{code}}"));
 </script>

--- a/_includes/code_snippet.html
+++ b/_includes/code_snippet.html
@@ -10,11 +10,8 @@
 <button
     id="copyButton"
     aria-label="Copy to clipboard"
+    onclick="navigator.clipboard.writeText('{{code}}')"
 >
     📋
 </button>
 
-<script>
-    document.querySelector("#copyButton")
-    .addEventListener("click", () => navigator.clipboard.writeText("{{code}}"));
-</script>

--- a/_includes/code_snippet.html
+++ b/_includes/code_snippet.html
@@ -1,6 +1,6 @@
 {% assign code = include.code %}
 <style>
-    .copyButton {
+    #copyButton {
         background: transparent;
         border: none;
     }

--- a/_includes/install_command.html
+++ b/_includes/install_command.html
@@ -14,9 +14,11 @@ brew {{include.modifier}} install {{include.item}}
 </style>
 
 Install command:
-<pre class="inline">
-    <code>{{code}}</code>
-</pre>
+<div class="inline">
+    {% highlight bash %}
+    $ {{code}}
+    {% endhighlight %}
+</div>
 <button
     id="copyButton"
     aria-label="Copy to clipboard"

--- a/_includes/install_command.html
+++ b/_includes/install_command.html
@@ -1,49 +1,10 @@
-{%- capture code -%}
-brew {{include.modifier}} install {{include.item}}
-{%- endcapture -%}
-<style>
-    .inline {
-        display: inline-flex;
-        background: rgba(0, 0, 0, 0.3);
-        border-radius: 0.4em;
-        padding-right: 8px;
-    }
-
-    .inline .highlight {
-        margin: 0;
-    }
-    
-    .inline .highlight pre {
-        margin: 0;
-    }
-    
-    #copyButton {
-        background: transparent;
-        border: none;
-        border-left: 1px solid #aaa;
-    }
-</style>
+{%- capture code -%} 
+brew {{include.modifier}}install {{include.item}} 
+{%- endcapture -%} 
 
 Install command:
-<div class="inline">
-    {% highlight bash %}
-    $ {{- code -}}
-    {% endhighlight %}
-
-    <button
-        id="copyButton"
-        aria-label="Copy to clipboard"
-        style="visibility: hidden"
-        onclick="navigator.clipboard.writeText('{{code}}')"
-    >
-    📋
-    </button>
+<div class="copyable">
+    {% highlight bash %} $ {{ code }} {% endhighlight %}
 </div>
 
-<script>
-    if (navigator.clipboard) {
-        document
-            .getElementById("copyButton")
-            .style.removeProperty("visibility");
-    }
-</script>
+<script src="//brew.sh/assets/js/copy.js"></script>

--- a/_includes/install_command.html
+++ b/_includes/install_command.html
@@ -1,32 +1,44 @@
 {%- capture code -%}
 brew {{include.modifier}} install {{include.item}}
 {%- endcapture -%}
-
 <style>
     .inline {
         display: inline-flex;
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 0.4em;
+        padding-right: 8px;
     }
 
+    .inline .highlight {
+        margin: 0;
+    }
+    
+    .inline .highlight pre {
+        margin: 0;
+    }
+    
     #copyButton {
         background: transparent;
         border: none;
+        border-left: 1px solid #aaa;
     }
 </style>
 
 Install command:
 <div class="inline">
     {% highlight bash %}
-    $ {{code}}
+    $ {{- code -}}
     {% endhighlight %}
-</div>
-<button
-    id="copyButton"
-    aria-label="Copy to clipboard"
-    style="visibility: hidden"
-    onclick="navigator.clipboard.writeText('{{code}}')"
->
+
+    <button
+        id="copyButton"
+        aria-label="Copy to clipboard"
+        style="visibility: hidden"
+        onclick="navigator.clipboard.writeText('{{code}}')"
+    >
     📋
-</button>
+    </button>
+</div>
 
 <script>
     if (navigator.clipboard) {

--- a/_includes/install_command.html
+++ b/_includes/install_command.html
@@ -1,4 +1,7 @@
-{% assign code = include.code %}
+{%- capture code -%}
+brew {{include.modifier}} install {{include.item}}
+{%- endcapture -%}
+
 <style>
     #copyButton {
         background: transparent;

--- a/_includes/install_command.html
+++ b/_includes/install_command.html
@@ -6,5 +6,3 @@ Install command:
 <div class="copyable">
     {% highlight bash %} $ {{ code }} {% endhighlight %}
 </div>
-
-<script src="//brew.sh/assets/js/copy.js"></script>

--- a/_includes/install_command.html
+++ b/_includes/install_command.html
@@ -3,17 +3,24 @@ brew {{include.modifier}} install {{include.item}}
 {%- endcapture -%}
 
 <style>
+    .inline {
+        display: inline-flex;
+    }
+
     #copyButton {
         background: transparent;
         border: none;
-        visibility: hidden;
     }
 </style>
 
-<code>{{code}}</code>
+Install command:
+<pre class="inline">
+    <code>{{code}}</code>
+</pre>
 <button
     id="copyButton"
     aria-label="Copy to clipboard"
+    style="visibility: hidden"
     onclick="navigator.clipboard.writeText('{{code}}')"
 >
     📋

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -7,7 +7,7 @@ permalink: :title
 {%- assign c = site.data.cask[token] -%}
 <h2>{{ token }}</h2>
 
-{% include install_command.html item=token modifier='cask' %}
+{% include install_command.html item=token modifier='cask ' %}
 
 <p>Name{%- if c.name.size > 1 -%}s{%- endif -%}:
 {%- for name in c.name %}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -7,11 +7,7 @@ permalink: :title
 {%- assign c = site.data.cask[token] -%}
 <h2>{{ token }}</h2>
 
-{%- capture code -%}
-brew cask install {{ token }}
-{%- endcapture -%}
-
-{% include code_snippet.html code=code language='bash' %}
+{% include install_command.html item=token modifier='cask' %}
 
 <p>Name{%- if c.name.size > 1 -%}s{%- endif -%}:
 {%- for name in c.name %}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -6,6 +6,13 @@ permalink: :title
 {%- assign formula_path = "formula" -%}
 {%- assign c = site.data.cask[token] -%}
 <h2>{{ token }}</h2>
+
+{%- capture code -%}
+brew install cask {{ token }}
+{%- endcapture -%}
+
+{% include code_snippet.html code=code language='bash' %}
+
 <p>Name{%- if c.name.size > 1 -%}s{%- endif -%}:
 {%- for name in c.name %}
     <strong>{{ name }}</strong>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -8,7 +8,7 @@ permalink: :title
 <h2>{{ token }}</h2>
 
 {%- capture code -%}
-brew install cask {{ token }}
+brew cask install {{ token }}
 {%- endcapture -%}
 
 {% include code_snippet.html code=code language='bash' %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -12,11 +12,7 @@ permalink: :title
     {%- endif -%}
     >{{ f.name }}</h2>
 
-{%- capture code -%}
-brew install {{ f.name }}
-{%- endcapture -%}
-
-{% include code_snippet.html code=code language='bash' %}
+{% include install_command.html item=f.name %}
 
 {%- if f.aliases.size > 0 %}
 <p>Also known as: <strong>{{ f.aliases | join: "</strong>, <strong>" }}</strong></p>

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -11,6 +11,13 @@ permalink: :title
     {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated"
     {%- endif -%}
     >{{ f.name }}</h2>
+
+{%- capture code -%}
+brew install {{ f.name }}
+{%- endcapture -%}
+
+{% include code_snippet.html code=code language='bash' %}
+
 {%- if f.aliases.size > 0 %}
 <p>Also known as: <strong>{{ f.aliases | join: "</strong>, <strong>" }}</strong></p>
 {%- endif -%}


### PR DESCRIPTION
Adds install command user can directly copy and paste.

Fixes #329 
![image](https://user-images.githubusercontent.com/10703445/93807126-d09cf600-fc67-11ea-9613-17669969780f.png)

Points to finalise
- [x] Placement of element
- [x] Icon to use

