### PR TITLE
Rakefile: don't require building formulae/casks/analytics.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 vendor/
 .jekyll-metadata
 .homebrew_analytics.json
+.sass-cache/

--- a/Rakefile
+++ b/Rakefile
@@ -153,7 +153,7 @@ task all_analytics: :analytics do
 end
 
 desc "Build the site"
-task build: %i[all_formulae all_analytics cask] do
+task :build do
   require 'jekyll'
   Jekyll::Commands::Build.process({})
 end


### PR DESCRIPTION
These are already in Git so it makes it harder and more error-prone than necessary to do a build. Also, `rake serve` does not depend on `rake build` to make this incremental for the user (because it's so slow to build).

While we're here, fix the `.gitignore` too.