### PR TITLE
Fix cask loading

### DIFF
--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -12,7 +12,7 @@ json_template = IO.read "_api_cask.json.in"
 html_template = IO.read "_cask.html.in"
 
 tap.cask_files.each do |p|
-  c = Cask::CaskLoader::FromPathLoader.new(p).load
+  c = Cask::CaskLoader::FromPathLoader.new(p).load(config: Cask::Config.from_json("{}"))
   IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)
   IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))


### PR DESCRIPTION
Fixes CI error:

```
brew ruby script/generate-cask.rb Homebrew/cask
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:62:in `load': missing keyword: config (ArgumentError)
	from script/generate-cask.rb:15:in `block in <main>'
	from script/generate-cask.rb:14:in `each'
	from script/generate-cask.rb:14:in `<main>'
```

Closes https://github.com/Homebrew/brew/pull/8828.