### PR TITLE
Simplify loading casks.

### DIFF
--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -12,7 +12,7 @@ json_template = IO.read "_api_cask.json.in"
 html_template = IO.read "_cask.html.in"
 
 tap.cask_files.each do |p|
-  c = Cask::CaskLoader::load(p)
+  c = Cask::CaskLoader.load(p)
   IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)
   IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -12,7 +12,7 @@ json_template = IO.read "_api_cask.json.in"
 html_template = IO.read "_cask.html.in"
 
 tap.cask_files.each do |p|
-  c = Cask::CaskLoader::FromPathLoader.new(p).load(config: Cask::Config.from_json("{}"))
+  c = Cask::CaskLoader::load(p)
   IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)
   IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))


### PR DESCRIPTION
Use `Cask::CaskLoader::load` instead of creating a `Cask::CaskLoader::FromPathLoader` instance manually.