### PR TITLE
Update youtube-dl urls given DMCAd Github repo

### DIFF
--- a/_data/formula-linux/youtube-dl.json
+++ b/_data/formula-linux/youtube-dl.json
@@ -10,7 +10,7 @@
   ],
   "desc": "Download YouTube videos from the command-line",
   "license": "Unlicense",
-  "homepage": "https://ytdl-org.github.io/youtube-dl/",
+  "homepage": "https://yt-dl.org",
   "versions": {
     "stable": "2020.09.20",
     "head": "HEAD",
@@ -18,7 +18,7 @@
   },
   "urls": {
     "stable": {
-      "url": "https://github.com/ytdl-org/youtube-dl/releases/download/2020.09.20/youtube-dl-2020.09.20.tar.gz",
+      "url": "http://abf-downloads.openmandriva.org/ytdl/youtube-dl-2020.09.20.tar.gz",
       "tag": null,
       "revision": null
     }

--- a/_data/formula/youtube-dl.json
+++ b/_data/formula/youtube-dl.json
@@ -10,7 +10,7 @@
   ],
   "desc": "Download YouTube videos from the command-line",
   "license": "Unlicense",
-  "homepage": "https://ytdl-org.github.io/youtube-dl/",
+  "homepage": "https://yt-dl.org",
   "versions": {
     "stable": "2020.09.20",
     "head": "HEAD",
@@ -18,7 +18,7 @@
   },
   "urls": {
     "stable": {
-      "url": "https://github.com/ytdl-org/youtube-dl/releases/download/2020.09.20/youtube-dl-2020.09.20.tar.gz",
+      "url": "http://abf-downloads.openmandriva.org/ytdl/youtube-dl-2020.09.20.tar.gz",
       "tag": null,
       "revision": null
     }


### PR DESCRIPTION
As noted in their [main website](https://yt-dl.org) and [Hacker News](https://news.ycombinator.com/item?id=24872911), youtube-dl [dev repository](https://github.com/ytdl-org/youtube-dl/) is taken down due to [DMCA takedown notice by RIAA](https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md).

This pull request updates links so they point to the mirror they set up.