### PR TITLE
Additional support for requirements

### DIFF
--- a/_includes/formulae.html
+++ b/_includes/formulae.html
@@ -6,6 +6,11 @@
     <tr>
         {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
         {%- assign formula = site.data[formula_path][data_name] -%}
+        {%- unless formula -%}
+            {%- assign canonical_map = formula_path | append: "_canonical" -%}
+            {%- assign data_name = site.data[canonical_map][full_name] | remove: "@" | remove: "." | replace: "+", "_" -%}
+            {%- assign formula = site.data[formula_path][data_name] -%}
+        {%- endunless -%}
         {%- include formula.html formula_path=formula_path formula=formula -%}
     </tr>
     {%- endfor -%}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -25,12 +25,9 @@ permalink: :title
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 
-{%- include casks.html casks=c.depends_on.cask description="Depends on casks" -%}
-
-{%- assign depends_on_formula = c.depends_on.formula | where_exp: "f", "site.data.formula[f]" -%}
-{%- include formulae.html formula_path=formula_path formulae=depends_on_formula description="Depends on" -%}
-
 {%- if c.depends_on.size > 0 -%}
+    {%- include casks.html casks=c.depends_on.cask description="Depends on casks" -%}
+    {%- include formulae.html formula_path=formula_path formulae=c.depends_on.formula description="Depends on" -%}
     {%- assign requirements = "" -%}
     {%- if c.depends_on.macos -%}
         {%- capture requirements -%}
@@ -55,7 +52,7 @@ permalink: :title
         {%- if requirements.size > 0 -%}
             {%- assign requirements = requirements | append: ", " -%}
         {%- endif -%}
-        {%- capture requirements -%}{{ requirements }}<strong><a href="{{ site.baseurl }}/cask/xquartz">x11</a></strong>{%- endcapture -%}
+        {%- capture requirements -%}{{ requirements }}<strong><a href="{{ site.baseurl }}/cask/xquartz">X11</a></strong>{%- endcapture -%}
     {%- endif -%}
     {%- if requirements.size > 0 %}
 <p>Requires: {{ requirements }}</p>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -40,6 +40,17 @@ permalink: :title
             {%- endfor -%}
         {%- endcapture -%}
     {%- endif -%}
+    {%- if c.depends_on.arch -%}
+        {%- if requirements.size > 0 -%}
+            {%- assign requirements = requirements | append: ", " -%}
+        {%- endif -%}
+        {%- capture requirements -%}
+            {{ requirements }}{% for a in c.depends_on.arch -%}
+                <strong>{{ a.type | capitalize }} {{ a.bits }}-bit</strong>
+                {%- unless forloop.last %} or {% endunless -%}
+            {%- endfor %} architecture
+        {%- endcapture -%}
+    {%- endif -%}
     {%- if c.depends_on.x11 -%}
         {%- if requirements.size > 0 -%}
             {%- assign requirements = requirements | append: ", " -%}

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -6,7 +6,7 @@ formula_dir = os == "mac" ? "formula" : "formula-linux"
 tap = Tap.fetch(tap_name)
 
 directories = ["_data/#{formula_dir}", "api/#{formula_dir}", "#{formula_dir}"]
-FileUtils.rm_rf directories
+FileUtils.rm_rf directories + ["_data/#{formula_dir}_canonical.json"]
 FileUtils.mkdir_p directories
 
 json_template = IO.read "_api_formula.json.in"
@@ -18,3 +18,4 @@ tap.formula_names.each do |n|
   IO.write("api/#{formula_dir}/#{f.name}.json", json_template)
   IO.write("#{formula_dir}/#{f.name}.html", html_template.gsub("title: $TITLE", "title: \"#{f.name}\""))
 end
+IO.write("_data/#{formula_dir}_canonical.json", "#{JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))}\n")


### PR DESCRIPTION
1. Add display of cask `arch:` requirements
    - https://formulae.brew.sh/cask/locklizard-safeguard-viewer
2. For casks or formulae that specify formula dependencies using an alias or former name, look up the canonical name first
    - https://formulae.brew.sh/cask/cellery
    - https://formulae.brew.sh/cask/ibm-cloud-cli
    - https://formulae.brew.sh/formula/dotnet
    - https://formulae.brew.sh/formula/ncspot