### PR TITLE
rename GitHub branches to HEAD

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -20,7 +20,7 @@ permalink: :title
 <p><a href="{{ c.homepage }}">{{ c.homepage }}</a></p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/master/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/HEAD/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -27,9 +27,9 @@ permalink: :title
 
 <p><a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code> (JSON API)</a></p>
 {%- if formula_path == "formula-linux" %}
-<p><a target="_blank" href="{{ site.taps.linux.remote }}/blob/master/Formula/{{ f.name }}.rb">Linux formula code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.linux.remote }}/blob/HEAD/Formula/{{ f.name }}.rb">Linux formula code</a> on GitHub</p>
 {%- else %}
-<p><a target="_blank" href="{{ site.taps.core.remote }}/blob/master/Formula/{{ f.name }}.rb">Formula code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.core.remote }}/blob/HEAD/Formula/{{ f.name }}.rb">Formula code</a> on GitHub</p>
 {%- endif %}
 
 <p>Current versions:</p>


### PR DESCRIPTION
Makes it usable with branches that aren't called `master`