### PR TITLE
Rakefile: temporarily disable Linux analytics.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -139,7 +139,10 @@ task cask_and_analytics: %i[cask analytics]
 desc "Dump Linux formulae and analytics data"
 task :linux_formula_and_analytics do
   Rake::Task["formulae"].tap(&:reenable).invoke("linux")
-  Rake::Task["analytics"].tap(&:reenable).invoke("linux")
+  # TODO: re-enable when
+  # https://github.com/Homebrew/formulae.brew.sh/runs/1903832906?check_suite_focus=true#step:9:69
+  # is fixed
+  # Rake::Task["analytics"].tap(&:reenable).invoke("linux")
 end
 
 desc "Dump all formulae (macOS and Linux)"


### PR DESCRIPTION
It's currently broken and blocking all updates:
https://github.com/Homebrew/formulae.brew.sh/runs/1903832906?check_suite_focus=true#step:9:69

CC https://github.com/Homebrew/formulae.brew.sh/pull/150 @issyl0 @sjackman who I think have access to the Linuxbrew analytics permissions. Ideally we'd get these transferred over to the Homebrew organisation so they can share credentials. We have a `From https://console.developers.google.com/apis/credentials?project=homebrew-analytics` note in 1Password for the Homebrew key but nothing similar for the Linuxbrew one.