### PR TITLE
Add days to analytics page titles

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -8,7 +8,7 @@ layout: base
 {%- else -%}
     {%- assign formula_path = "formula" -%}
 {%- endif -%}
-<h2>{{ page.category_pretty }} Events ({{ page.days }})</h2>
+<h2>{{ page.category_pretty }} Events ({{ page.days | split: "d" | first }} days)</h2>
 
 <h3><a href="{{ site.baseurl }}/api/{{ analytics_path }}/{{ page.category }}/{{ page.days }}.json"><code>/api/{{ analytics_path }}/{{ page.category }}/{{ page.days }}.json</code> (JSON API)</a></h3>
 

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -8,7 +8,7 @@ layout: base
 {%- else -%}
     {%- assign formula_path = "formula" -%}
 {%- endif -%}
-<h2>{{ page.category_pretty }} Events</h2>
+<h2>{{ page.category_pretty }} Events ({{ page.days }})</h2>
 
 <h3><a href="{{ site.baseurl }}/api/{{ analytics_path }}/{{ page.category }}/{{ page.days }}.json"><code>/api/{{ analytics_path }}/{{ page.category }}/{{ page.days }}.json</code> (JSON API)</a></h3>
 

--- a/analytics-linux/build-error/30d/index.html
+++ b/analytics-linux/build-error/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Build Error Events
+title: Homebrew Analytics Formula Build Error Events (30 days)
 layout: analytics
 days: 30d
 category: build-error

--- a/analytics-linux/build-error/365d/index.html
+++ b/analytics-linux/build-error/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Build Error Events
+title: Homebrew Analytics Formula Build Error Events (365 days)
 layout: analytics
 days: 365d
 category: build-error

--- a/analytics-linux/build-error/90d/index.html
+++ b/analytics-linux/build-error/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Build Error Events
+title: Homebrew Analytics Formula Build Error Events (90 days)
 layout: analytics
 days: 90d
 category: build-error

--- a/analytics-linux/install-on-request/30d/index.html
+++ b/analytics-linux/install-on-request/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events (30 days)
 layout: analytics
 days: 30d
 category: install-on-request

--- a/analytics-linux/install-on-request/365d/index.html
+++ b/analytics-linux/install-on-request/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events (365 days)
 layout: analytics
 days: 365d
 category: install-on-request

--- a/analytics-linux/install-on-request/90d/index.html
+++ b/analytics-linux/install-on-request/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events (90 days)
 layout: analytics
 days: 90d
 category: install-on-request

--- a/analytics-linux/install/30d/index.html
+++ b/analytics-linux/install/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install Events
+title: Homebrew Analytics Formula Install Events (30 days)
 layout: analytics
 days: 30d
 category: install

--- a/analytics-linux/install/365d/index.html
+++ b/analytics-linux/install/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install Events
+title: Homebrew Analytics Formula Install Events (365 days)
 layout: analytics
 days: 365d
 category: install

--- a/analytics-linux/install/90d/index.html
+++ b/analytics-linux/install/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install Events
+title: Homebrew Analytics Formula Install Events (90 days)
 layout: analytics
 days: 90d
 category: install

--- a/analytics/build-error/30d/index.html
+++ b/analytics/build-error/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Build Error Events
+title: Homebrew Analytics Formula Build Error Events (30 days)
 layout: analytics
 days: 30d
 category: build-error

--- a/analytics/build-error/365d/index.html
+++ b/analytics/build-error/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Build Error Events
+title: Homebrew Analytics Formula Build Error Events (365 days)
 layout: analytics
 days: 365d
 category: build-error

--- a/analytics/build-error/90d/index.html
+++ b/analytics/build-error/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Build Error Events
+title: Homebrew Analytics Formula Build Error Events (90 days)
 layout: analytics
 days: 90d
 category: build-error

--- a/analytics/cask-install/30d/index.html
+++ b/analytics/cask-install/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Cask Install Events
+title: Homebrew Analytics Cask Install Events (30 days)
 layout: analytics
 days: 30d
 category: cask-install

--- a/analytics/cask-install/365d/index.html
+++ b/analytics/cask-install/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Cask Install Events
+title: Homebrew Analytics Cask Install Events (365 days)
 layout: analytics
 days: 365d
 category: cask-install

--- a/analytics/cask-install/90d/index.html
+++ b/analytics/cask-install/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Cask Install Events
+title: Homebrew Analytics Cask Install Events (90 days)
 layout: analytics
 days: 90d
 category: cask-install

--- a/analytics/install-on-request/30d/index.html
+++ b/analytics/install-on-request/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events (30 days)
 layout: analytics
 days: 30d
 category: install-on-request

--- a/analytics/install-on-request/365d/index.html
+++ b/analytics/install-on-request/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events (365 days)
 layout: analytics
 days: 365d
 category: install-on-request

--- a/analytics/install-on-request/90d/index.html
+++ b/analytics/install-on-request/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install On Request Events
+title: Homebrew Analytics Formula Install On Request Events (90 days)
 layout: analytics
 days: 90d
 category: install-on-request

--- a/analytics/install/30d/index.html
+++ b/analytics/install/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install Events
+title: Homebrew Analytics Formula Install Events (30 days)
 layout: analytics
 days: 30d
 category: install

--- a/analytics/install/365d/index.html
+++ b/analytics/install/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install Events
+title: Homebrew Analytics Formula Install Events (365 days)
 layout: analytics
 days: 365d
 category: install

--- a/analytics/install/90d/index.html
+++ b/analytics/install/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics Formula Install Events
+title: Homebrew Analytics Formula Install Events (90 days)
 layout: analytics
 days: 90d
 category: install

--- a/analytics/os-version/30d/index.html
+++ b/analytics/os-version/30d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics macOS Versions
+title: Homebrew Analytics macOS Versions (30 days)
 layout: analytics
 days: 30d
 category: os-version

--- a/analytics/os-version/365d/index.html
+++ b/analytics/os-version/365d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics macOS Versions
+title: Homebrew Analytics macOS Versions (365 days)
 layout: analytics
 days: 365d
 category: os-version

--- a/analytics/os-version/90d/index.html
+++ b/analytics/os-version/90d/index.html
@@ -1,5 +1,5 @@
 ---
-title: Homebrew Analytics macOS Versions
+title: Homebrew Analytics macOS Versions (90 days)
 layout: analytics
 days: 90d
 category: os-version


### PR DESCRIPTION
Change analytics page titles from "Formula Install Events" to "Formula Install Events (30 days)". This is to support https://github.com/algolia/docsearch-configs/pull/3945. That way, the days are identifiable from the title without needing to read farther (and look at the `h3` `/api` url)

Before:

<img width="1280" alt="Screen Shot 2021-04-12 at 12 48 42 PM" src="https://user-images.githubusercontent.com/32525609/114431393-73c64600-9b8d-11eb-9794-ce7cc1c8340a.png">

After:

<img width="1280" alt="Screen Shot 2021-04-12 at 12 48 36 PM" src="https://user-images.githubusercontent.com/32525609/114431417-79239080-9b8d-11eb-9598-6181b16b9b13.png">
