### PR TITLE
_layouts/formula.html: improve `all` bottle handling

### DIFF
--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -40,8 +40,11 @@ permalink: :title
         {%- assign bottles = true -%}
     {%- else %} not available on this platform.
     {%- endif -%}
-{%- elsif f.bottle.stable %} installation support provided for macOS releases:
-    {%- assign bottles = true -%}
+{%- elsif f.bottle.stable %} installation support provided for macOS releases
+    {%- if f.bottle.stable.files.all -%}.
+    {%- else -%}
+        {%- assign bottles = true -%}:
+    {%- endif -%}
 {%- else %} not available on this platform.
 {%- endif -%}</p>
 


### PR DESCRIPTION
Currently, `all` bottles aren't handled properly:
![image](https://user-images.githubusercontent.com/33784207/115954697-006aef80-a510-11eb-96c3-7cb1a24a38cb.png)
(Taken from https://formulae.brew.sh/formula/ack#default).

This PR is an attempt to improve handling for `all` bottles.