### PR TITLE
Add `/api/bottle/$FORMULA.json`

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -60,8 +60,8 @@ jobs:
 
           git reset origin/master
           git add _data/formula{,_canonical.json} api/formula formula
-          if ! git diff --no-patch --exit-code HEAD -- _data/analytics _data/formula{,_canonical.json} api/formula formula cask; then
-            git commit -m "formula: updates from homebrew/core" _data/analytics _data/formula{,_canonical.json} api/formula formula
+          if ! git diff --no-patch --exit-code HEAD -- _data/analytics _data/formula{,_canonical.json} _data/bottle api/formula api/bottle formula cask; then
+            git commit -m "formula: updates from homebrew/core" _data/analytics _data/formula{,_canonical.json} _data/bottle api/formula api/bottle formula cask
           fi
 
           git add _data/cask api/cask cask
@@ -76,8 +76,8 @@ jobs:
 
           git reset origin/master
           git add _data/analytics-linux _data/formula-linux{,_canonical.json} api/formula-linux formula-linux
-          if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux _data/formula-linux{,_canonical.json} api/formula-linux formula-linux; then
-            git commit -m "formula-linux: updates from Homebrew/linuxbrew-core" _data/analytics-linux _data/formula-linux{,_canonical.json} api/formula-linux formula-linux
+          if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux _data/formula-linux{,_canonical.json} _data/bottle-linux api/formula-linux api/bottle-linux formula-linux; then
+            git commit -m "formula-linux: updates from Homebrew/linuxbrew-core" _data/analytics-linux _data/formula-linux{,_canonical.json} _data/bottle-linux api/formula-linux api/bottle-linux formula-linux
           fi
 
       - name: Push commits

--- a/_api_bottle.json.in
+++ b/_api_bottle.json.in
@@ -1,0 +1,4 @@
+---
+layout: bottle_json
+---
+{{ content }}

--- a/_layouts/bottle_json.json
+++ b/_layouts/bottle_json.json
@@ -1,0 +1,8 @@
+---
+---
+{%- assign bottle_path = page.dir | split: "/" -%}
+{%- assign bottle_path = bottle_path[2] -%}
+{%- assign full_name = page.name | remove: ".json" -%}
+{%- assign name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
+{%- assign bottle = site.data[bottle_path][name] -%}
+{{ bottle | jsonify }}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -25,7 +25,10 @@ permalink: :title
 <p>License: <strong>{{ f.license | join: "</strong>, <strong>" | replace: "_", " " }}</strong></p>
 {%- endif %}
 
+{%- assign bottle_path = formula_path | replace: "formula", "bottle" -%}
 <p><a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code> (JSON API)</a></p>
+<p><a href="{{ site.baseurl }}/api/{{ bottle_path }}/{{ f.name }}.json"><code>/api/{{ bottle_path }}/{{ f.name }}.json</code> (Bottle JSON API)</a></p>
+
 {%- if formula_path == "formula-linux" %}
 <p><a target="_blank" href="{{ site.taps.linux.remote }}/blob/HEAD/Formula/{{ f.name }}.rb">Linux formula code</a> on GitHub</p>
 {%- else %}

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -3,19 +3,23 @@ os = ARGV.first
 tap_name = ARGV.second
 
 formula_dir = os == "mac" ? "formula" : "formula-linux"
+bottle_dir = os == "mac" ? "bottle" : "bottle-linux"
 tap = Tap.fetch(tap_name)
 
-directories = ["_data/#{formula_dir}", "api/#{formula_dir}", "#{formula_dir}"]
+directories = ["_data/#{formula_dir}", "_data/#{bottle_dir}", "api/#{formula_dir}", "api/#{bottle_dir}", "#{formula_dir}"]
 FileUtils.rm_rf directories + ["_data/#{formula_dir}_canonical.json"]
 FileUtils.mkdir_p directories
 
 json_template = IO.read "_api_formula.json.in"
+bottle_template = IO.read "_api_bottle.json.in"
 html_template = IO.read "_formula.html.in"
 
 tap.formula_names.each do |n|
   f = Formulary.factory(n)
   IO.write("_data/#{formula_dir}/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_hash)}\n")
+  IO.write("_data/#{bottle_dir}/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_recursive_bottle_hash)}\n")
   IO.write("api/#{formula_dir}/#{f.name}.json", json_template)
+  IO.write("api/#{bottle_dir}/#{f.name}.json", bottle_template)
   IO.write("#{formula_dir}/#{f.name}.html", html_template.gsub("title: $TITLE", "title: \"#{f.name}\""))
 end
 IO.write("_data/#{formula_dir}_canonical.json", "#{JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))}\n")


### PR DESCRIPTION
This PR adds the `/api/bottle` JSON API for formulae in homebrew/core. I've tested this locally on my mac but I haven't tested it out on a Linux machine.

This relies on https://github.com/Homebrew/brew/pull/11488 to be merged so it can use the new `Formula#to_recursive_bottle_hash` method to generate the bottle API files. This PR should not be merged until that brew PR has been merged.
