### PR TITLE
Add cask sources API

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -69,9 +69,9 @@ jobs:
             git commit -m "formula: updates from homebrew/core" _data/analytics _data/formula{,_canonical.json} _data/bottle api/formula api/bottle formula cask
           fi
 
-          git add _data/cask api/cask cask
-          if ! git diff --no-patch --exit-code HEAD -- _data/cask api/cask cask; then
-            git commit -m "cask: updates from homebrew/cask" _data/cask api/cask cask
+          git add _data/cask api/cask api/cask-source cask
+          if ! git diff --no-patch --exit-code HEAD -- _data/cask api/cask api/cask-source cask; then
+            git commit -m "cask: updates from homebrew/cask" _data/cask api/cask api/cask-source cask
           fi
 
       - name: Update data for Homebrew/linuxbrew-core

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -4,7 +4,7 @@ require "cask/cask"
 tap_name = ARGV.first
 tap = Tap.fetch(tap_name)
 
-directories = ["_data/cask", "api/cask", "cask"]
+directories = ["_data/cask", "api/cask", "api/cask-source", "cask"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
 
@@ -15,5 +15,6 @@ tap.cask_files.each do |p|
   c = Cask::CaskLoader.load(p)
   IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)
+  IO.write("api/cask-source/#{c.token}.rb", p.read)
   IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))
 end


### PR DESCRIPTION
This PR adds a new `/api/cask-source/foo.rb` API for getting the text contents of a cask file.

This will eventually be used to allow casks to be installed without needing `homebrew/cask` to be tapped.
