### PR TITLE
Add `versions` key to cask versions API

### DIFF
--- a/api/versions-casks.json
+++ b/api/versions-casks.json
@@ -3,7 +3,7 @@
 {
 {%- assign sorted_casks = site.data.cask | sort -%}
 {% for cask in sorted_casks %}
-  "{{ cask[1].token }}":{"version":"{{ cask[1].version }}"}
+  "{{ cask[1].token }}":{"version":"{{ cask[1].version }}","versions":{{ cask[1].versions | jsonify }}}
   {%- unless forloop.last -%}
   ,
   {%- endunless -%}


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/11915

This PR adds a `versions` key to `/api/versions-casks.json`. This corresponds directly to the `versions` key of `Cask::Cask#to_h`. It contains any os-specific versions (i.e. versions on certain OSes that don't match the default cask version).

An excerpt of the new JSON file:

```json
{
  ...
  "amd-power-gadget":{"version":"0.7","versions":{}},
  "amethyst":{"version":"0.15.4","versions":{"el_capitan":"0.10.1","yosemite":"0.10.1"}},
  ...
}
```
