### PR TITLE
ci: Only regenerate Linux analytics data every hour

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -81,15 +81,15 @@ jobs:
             git commit -m "docs: update API samples" _includes/api-samples
           fi
 
-      - name: Update data for Homebrew/linuxbrew-core
+      - name: Update analytics data for Homebrew/linuxbrew-core
         if: matrix.os == 'ubuntu-latest'
         run: |
-          rake linux_formula_and_analytics
+          rake linux_analytics
 
           git reset origin/master
-          git add _data/analytics-linux _data/formula-linux{,_canonical.json} _data/bottle-linux api/formula-linux api/bottle-linux formula-linux
-          if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux _data/formula-linux{,_canonical.json} _data/bottle-linux api/formula-linux api/bottle-linux formula-linux; then
-            git commit -m "formula-linux: updates from Homebrew/linuxbrew-core" _data/analytics-linux _data/formula-linux{,_canonical.json} _data/bottle-linux api/formula-linux api/bottle-linux formula-linux
+          git add _data/analytics-linux
+          if ! git diff --no-patch --exit-code HEAD -- _data/analytics-linux; then
+            git commit -m "analytics-linux: Updates from Linuxbrew's GA" _data/analytics-linux
           fi
 
       - name: Push commits

--- a/Rakefile
+++ b/Rakefile
@@ -142,9 +142,8 @@ task formula_and_analytics: %i[formulae analytics]
 desc "Dump macOS casks and analytics data"
 task cask_and_analytics: %i[cask analytics]
 
-desc "Dump Linux formulae and analytics data"
-task :linux_formula_and_analytics do
-  Rake::Task["formulae"].tap(&:reenable).invoke("linux")
+desc "Dump Linux analytics data"
+task :linux_analytics do
   Rake::Task["analytics"].tap(&:reenable).invoke("linux")
 end
 


### PR DESCRIPTION
- This stops collecting formulae data for Linux, but keeps the analytics processing, as they're still in a separate account.
- Regenerating Linux formulae data is a waste of compute now that the Homebrew/linuxbrew-core repo is archived so nothing will change.
- It was quite amusing to see 4d7f1f1c4f7e130e5f9999178f0972a521206dc2 chronicling our macOS Monterey bottling effort, though. :-)
- Part of #566.