### PR TITLE
tests: Use the maintained `ruby/setup-ruby` Action

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set up Ruby
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/setup-ruby@main
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.6"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@main
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.6"
 


### PR DESCRIPTION
- I saw this in the CI output:

```
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
```