### PR TITLE
Use `#to_hash_with_variations` to generate formula and cask JSON

### DIFF
--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -13,7 +13,7 @@ html_template = IO.read "_cask.html.in"
 
 tap.cask_files.each do |p|
   c = Cask::CaskLoader.load(p)
-  IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_h)}\n")
+  IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_hash_with_variations)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)
   IO.write("api/cask-source/#{c.token}.rb", p.read)
   IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))

--- a/script/generate.rb
+++ b/script/generate.rb
@@ -13,7 +13,7 @@ html_template = IO.read "_formula.html.in"
 
 tap.formula_names.each do |n|
   f = Formulary.factory(n)
-  IO.write("_data/formula/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_hash)}\n")
+  IO.write("_data/formula/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_hash_with_variations)}\n")
   IO.write("_data/bottle/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_recursive_bottle_hash)}\n")
   IO.write("api/formula/#{f.name}.json", json_template)
   IO.write("api/bottle/#{f.name}.json", bottle_template)


### PR DESCRIPTION
Now that we can create `variations` hashes for formulae and casks, let's include them here in the JSON API. For a little bit, the cask API did include the variations hash, but that was changed when we started only doing the `variations` calculations when `--variations` was passed to `brew info --json`. This PR re-adds this functionality and adds it for formulae.
