### PR TITLE
CI: use github actions to release pages

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,12 +11,11 @@ concurrency:
   group: scheduled
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   generate:
     if: startsWith( github.repository, 'Homebrew/' )
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -95,10 +94,42 @@ jobs:
             git commit -m "analytics-linux: Updates from Linuxbrew's GA" _data/analytics-linux
           fi
 
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master
+
+      - name: Build site
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          rake linux_analytics
+  build:
+    needs: generate
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@master
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.6"
+
+      - name: Install RubyGems
+        run: |
+          gem install bundler -v "~>1"
+          bundle install --jobs 4 --retry 3
+
+      - name: Generate site
+        run: bundle exec rake formulae cask
+
       - name: Upload artifact
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions/upload-pages-artifact@v1
   deploy:
-    needs: generate
+    needs: build
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   generate:
@@ -95,5 +95,18 @@ jobs:
             git commit -m "analytics-linux: Updates from Linuxbrew's GA" _data/analytics-linux
           fi
 
-      - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+  deploy:
+    needs: generate
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -125,6 +125,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
   deploy:
     needs: build
+    if: ${{ github.ref_name == 'master' }}
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -96,11 +96,6 @@ jobs:
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
-
-      - name: Build site
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          rake linux_analytics
   build:
     needs: generate
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Use https://github.com/actions/upload-pages-artifact and https://github.com/actions/deploy-pages to deploy to GitHub pages every hour instead of the automagic option