### PR TITLE
Use `-` instead of `HEAD` in GitHub URLs

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -20,7 +20,7 @@ permalink: :title
 <p class="homepage"><a href="{{ c.homepage }}">{{ c.homepage }}</a></p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/HEAD/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/-/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -29,7 +29,7 @@ permalink: :title
 <p>Formula JSON API: <a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code></a></p>
 <p>Bottle JSON API: <a href="{{ site.baseurl }}/api/{{ bottle_path }}/{{ f.name }}.json"><code>/api/{{ bottle_path }}/{{ f.name }}.json</code></a></p>
 
-<p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/HEAD/Formula/{{ f.name }}.rb"><code>{{ f.name }}.rb</code></a> on GitHub</p>
+<p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/-/Formula/{{ f.name }}.rb"><code>{{ f.name }}.rb</code></a> on GitHub</p>
 
 <p>Bottle (binary package)
 {%- assign bottles = false -%}


### PR DESCRIPTION
`HEAD` gives a slightly weird experience on GitHub as it:
- Shows the current commit hash in some places (like the branch picker)
- Doesn't show the current branch
- Will just switch to using `HEAD`'s commit hash when using relative links (like click the name of the parent path)
  - This means future links are connected to a specific commit unnecessarily instead of the branch

Using `-` instead avoids hardcoding the name of the default branch while making the behaviour nicer when actually on GitHub as it simply redirects to the default branch. This keeps the same behaviour as `HEAD` but avoids the disadvantages mentioned above.