### PR TITLE
Escape formula name in templates

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -40,9 +40,9 @@ layout: base
         {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
         {%- assign formula = site.data.formula[data_name] -%}
         {%- if full_name == formula.name -%}
-            <a href="{{ site.baseurl }}/formula/{{ full_name }}"><code>{{ item.formula }}</code></a>
+            <a href="{{ site.baseurl }}/formula/{{ full_name }}"><code>{{ item.formula | escape }}</code></a>
         {%- else -%}
-            <code>{{ item.formula }}</code>
+            <code>{{ item.formula | escape }}</code>
         {%- endif -%}
     {%- endif -%}
         </td>

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -204,7 +204,7 @@ permalink: :title
     </tr>
     {%- for fa in site.data.analytics.install.homebrew-core[interval].formulae[full_name] -%}
     <tr>
-        <td><code>{{ fa.formula }}</code></td>
+        <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
     {%- else -%}
@@ -219,7 +219,7 @@ permalink: :title
     </tr>
     {%- for fa in site.data.analytics.install-on-request.homebrew-core[interval].formulae[full_name] -%}
     <tr>
-        <td><code>{{ fa.formula }}</code></td>
+        <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
     {%- else -%}
@@ -235,7 +235,7 @@ permalink: :title
     </tr>
         {%- for fa in site.data.analytics.build-error.homebrew-core[interval].formulae[full_name] -%}
     <tr>
-        <td><code>{{ fa.formula }}</code></td>
+        <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
         {%- else -%}
@@ -258,7 +258,7 @@ permalink: :title
     </tr>
     {%- for fa in site.data.analytics-linux.install.homebrew-core[interval].formulae[full_name] -%}
     <tr>
-        <td><code>{{ fa.formula }}</code></td>
+        <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
     {%- else -%}
@@ -273,7 +273,7 @@ permalink: :title
     </tr>
     {%- for fa in site.data.analytics-linux.install-on-request.homebrew-core[interval].formulae[full_name] -%}
     <tr>
-        <td><code>{{ fa.formula }}</code></td>
+        <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
     {%- else -%}
@@ -289,7 +289,7 @@ permalink: :title
     </tr>
         {%- for fa in site.data.analytics-linux.build-error.homebrew-core[interval].formulae[full_name] -%}
     <tr>
-        <td><code>{{ fa.formula }}</code></td>
+        <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
         {%- else -%}


### PR DESCRIPTION
A few items in the analytics contain the text for an `Options` object, like `adns #<Options:0x0000000102592c90>`. When used in related HTML templates, we end up with `<code>adns #<Options:0x0000000102592c90></code>`, which produces various validation errors because the `Options` text is being treated as an element:

> Element "options:0x0000000102592c90" not allowed as child of element "code" in this context.

> End tag "code" violates nesting rules.

This PR resolves the errors by escaping the formula name in templates, so the related HTML is `<code>adns #&lt;Options:0x0000000102592c90&gt;</code>` instead.

There may be a better way to address this when generating the related JSON data (e.g., `_data/analytics/build-error/365d.json`) but escaping this in the HTML templates may be a good idea regardless.