### PR TITLE
Naively remove ANSI color codes from caveats

### DIFF
--- a/script/generate.rb
+++ b/script/generate.rb
@@ -1,4 +1,12 @@
 #!/usr/bin/env brew ruby
+
+def sanitize_formula_text(data)
+  # Naively remove ANSI color codes, to avoid HTML validation errors
+  data["caveats"] = data["caveats"].gsub(/\e\[[0-9;]+m/i, "") if data["caveats"].present?
+
+  data
+end
+
 os = ARGV.first
 tap_name = ARGV.second
 tap = Tap.fetch(tap_name)
@@ -13,7 +21,10 @@ html_template = IO.read "_formula.html.in"
 
 tap.formula_names.each do |n|
   f = Formulary.factory(n)
-  IO.write("_data/formula/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_hash_with_variations)}\n")
+  IO.write(
+    "_data/formula/#{f.name.tr("+", "_")}.json",
+    "#{JSON.pretty_generate(sanitize_formula_text(f.to_hash_with_variations))}\n"
+  )
   IO.write("_data/bottle/#{f.name.tr("+", "_")}.json", "#{JSON.pretty_generate(f.to_recursive_bottle_hash)}\n")
   IO.write("api/formula/#{f.name}.json", json_template)
   IO.write("api/bottle/#{f.name}.json", bottle_template)


### PR DESCRIPTION
The `vapoursynth` formula currently uses ANSI color codes in the `caveats` text to make certain text bold (e.g., `\x1B[3m\x1B[1mvapoursynth.core.sub\x1B[0m`) and this leads to a `Forbidden code point U+001b` HTML validation error.

This PR addresses the issue by naively removing ANSI color codes from formula caveats text when generating formula data. This approach definitely isn't exhaustive (I'm open to better alternatives) but it works for the codes currently used in `vapoursynth`, at least.

Alternatively, we can simply remove the ANSI codes from the `vapoursynth` formula's `caveats` text and discourage further use. This is currently the only formula/cask doing this, so it doesn't appear to be a widespread issue.