### PR TITLE
Report site deploy failures by opening an issue

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -218,6 +218,40 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+  report-status:
+    name: Report deploy status
+    needs: [generate-cask, generate-core, generate-analytics, generate-samples, build, deploy]
+    if: ${{ always() && github.ref_name == 'master' }}
+    env:
+      GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+      REPO: ${{ github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect existing deploy failure issue
+        run: |
+          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --author BrewTestBot --label 'deploy failure' | awk '{print $1}')
+          echo "EXISTING_ISSUE=$EXISTING_ISSUE" >> $GITHUB_ENV
+          echo "WORKFLOW_URL=https://github.com/Homebrew/formulae.brew.sh/actions/runs/$RUN_ID" >> $GITHUB_ENV
+        env:
+          RUN_ID: ${{ github.run_id }}
+      - name: Report deploy failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: |
+          ISSUE_TITLE="Site deploy failed"
+          ISSUE_BODY="The most recent site deploy attempt failed.\n\n[Click here to view the most recent failed run]($WORKFLOW_URL)"
+          if [ -n "$EXISTING_ISSUE" ]; then
+            gh issue edit "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$ISSUE_BODY")"
+          else
+            gh issue create --repo "$REPO" --title "$ISSUE_TITLE" --label "deploy failure" --body "$(echo -e "$ISSUE_BODY")"
+          fi
+      - name: Report deploy success
+        if: ${{ needs.deploy.result == 'success' }}
+        run: |
+          COMMENT_BODY="The most recent site deploy attempt succeeded.\n\n[Click here to view the successful run]($WORKFLOW_URL)"
+          if [ -n "$EXISTING_ISSUE" ]; then
+            gh issue comment "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$COMMENT_BODY")"
+            gh issue close "$EXISTING_ISSUE" --repo "$REPO"
+          fi
   algolia_recrawl:
     needs: deploy
     name: Algolia Recrawl

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -218,8 +218,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-  report-status:
-    name: Report deploy status
+  deploy-issue:
+    name: Open/close deploy issues
     needs: [generate-cask, generate-core, generate-analytics, generate-samples, build, deploy]
     if: ${{ always() && github.ref_name == 'master' }}
     env:
@@ -227,7 +227,7 @@ jobs:
       REPO: ${{ github.repository }}
     runs-on: ubuntu-latest
     steps:
-      - name: Detect existing deploy failure issue
+      - name: Find existing deploy failure issue
         run: |
           EXISTING_ISSUE=$(gh issue list --repo "$REPO" --author BrewTestBot --label 'deploy failure' | awk '{print $1}')
           echo "EXISTING_ISSUE=$EXISTING_ISSUE" >> $GITHUB_ENV
@@ -237,8 +237,8 @@ jobs:
       - name: Report deploy failure
         if: ${{ contains(needs.*.result, 'failure') }}
         run: |
-          ISSUE_TITLE="Site deploy failed"
-          ISSUE_BODY="The most recent site deploy attempt failed.\n\n[Click here to view the most recent failed run]($WORKFLOW_URL)"
+          ISSUE_TITLE="formulae.brew.sh deployment failed!"
+          ISSUE_BODY="The most recent [formulae.brew.sh deployment failed]($WORKFLOW_URL)."
           if [ -n "$EXISTING_ISSUE" ]; then
             gh issue edit "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$ISSUE_BODY")"
           else
@@ -247,7 +247,7 @@ jobs:
       - name: Report deploy success
         if: ${{ needs.deploy.result == 'success' }}
         run: |
-          COMMENT_BODY="The most recent site deploy attempt succeeded.\n\n[Click here to view the successful run]($WORKFLOW_URL)"
+          COMMENT_BODY="The most recent [formulae.brew.sh deployment succeeded]($WORKFLOW_URL). Closing issue."
           if [ -n "$EXISTING_ISSUE" ]; then
             gh issue comment "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$COMMENT_BODY")"
             gh issue close "$EXISTING_ISSUE" --repo "$REPO"
@@ -255,6 +255,8 @@ jobs:
   algolia_recrawl:
     needs: deploy
     name: Algolia Recrawl
+    # This is run on a schedule by Algolia too so we don't care about failures.
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Algolia crawler creation and recrawl


### PR DESCRIPTION
This PR adds a new job to the scheduled site update workflow. This job runs at the end of the deploy portion of the workflow (i.e. at the same time as the Algolia recrawl). It runs no matter what the outcome of the previous jobs were, and exists to report instances where the scheduled site deploy fails. If the deploy (or any previous step) fails, @BrewTestBot will open a new issue in this repository with a link to the most recent failed run. Subsequent failed runs will cause the issue body to be updated to link to the newest failed run, and will not cause a new issue to be opened. If an issue is open and a run succeeds, @BrewTestBot will leave a comment linking to the first successful run and then close the issue.

I've set up an example issue [here](https://github.com/Rylan12/Deploy-Notification-Test/issues/6). That was generated using an almost identical (except for necessary changes) [workflow file](https://github.com/Rylan12/Deploy-Notification-Test/blob/main/.github/workflows/scheduled.yml).

The intention of this feature is to draw attention to scheduled deploy failures. When `HOMEBREW_INSTALL_FROM_API` is the default, a deploy failure means that users won't get any updated package information, so this is important to handle ASAP if it occurs. For now, this just opens an issue in this repo. However, if we think it's worth it, we could also have the issue be opened in Homebrew/brew or tag e.g. `@Homebrew/brew` or something like that.

Note: this currently runs before the Algolia re-crawl which means that Algolia failures won't trigger the notification. Should it ultimately include the Algolia job?