### PR TITLE
Allow manual runs of the `scheduled.yml` workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     # Once every hour
     - cron: "0 * * * *"
+  workflow_dispatch:
 
 concurrency:
   group: scheduled


### PR DESCRIPTION
We should be able to manually trigger a re-deploy of the site. For example, if we're making an API change in Homebrew/brew, we may want to have two-step system where we merge an API changed, wait for it to be deployed to the site, and then update the formula/cask loader to handle it. Instead of needing to wait an hour for the update to happen, we should be able to trigger one immediately and not have to wait.
