### PR TITLE
workflows/scheduled: ignore Algolia failures even harder.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -230,15 +230,16 @@ jobs:
             gh issue comment "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$COMMENT_BODY")"
             gh issue close "$EXISTING_ISSUE" --repo "$REPO"
           fi
+
+  # This is run on a schedule by Algolia too so we don't care about failures.
   algolia_recrawl:
     needs: deploy
     name: Algolia Recrawl
-    # This is run on a schedule by Algolia too so we don't care about failures.
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Algolia crawler creation and recrawl
         uses: algolia/algoliasearch-crawler-github-actions@v1
+        continue-on-error: true
         id: crawler_push
         with:
           crawler-name: Homebrew Search (https://*brew.sh)
@@ -247,3 +248,5 @@ jobs:
           crawler-api-key: ${{ secrets.CRAWLER_API_KEY }}
           algolia-app-id: ${{ secrets.ALGOLIA_APP_ID }}
           algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
+      - name: Unconditional success step
+        run: true


### PR DESCRIPTION
These don't fail the build but still shows a red failure state.