### PR TITLE
Fix formula/cask GitHub links

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -20,7 +20,7 @@ permalink: :title
 <p class="homepage"><a href="{{ c.homepage }}">{{ c.homepage }}</a></p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ f.tap_revision }}/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ f.tap_git_head }}/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -29,7 +29,7 @@ permalink: :title
 <p>Formula JSON API: <a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code></a></p>
 <p>Bottle JSON API: <a href="{{ site.baseurl }}/api/{{ bottle_path }}/{{ f.name }}.json"><code>/api/{{ bottle_path }}/{{ f.name }}.json</code></a></p>
 
-<p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/{{ f.tap_revision }}/Formula/{{ f.name }}.rb"><code>{{ f.name }}.rb</code></a> on GitHub</p>
+<p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/{{ f.tap_git_head }}/Formula/{{ f.name }}.rb"><code>{{ f.name }}.rb</code></a> on GitHub</p>
 
 <p>Bottle (binary package)
 {%- assign bottles = false -%}


### PR DESCRIPTION
It's `tap_git_head` and not `tap_revision`.

Fixes https://github.com/Homebrew/formulae.brew.sh/issues/716