### PR TITLE
Fix cask GitHub links

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -20,7 +20,7 @@ permalink: :title
 <p class="homepage"><a href="{{ c.homepage }}">{{ c.homepage }}</a></p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ f.tap_git_head }}/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ c.tap_git_head }}/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 


### PR DESCRIPTION
It's `c.tap_git_head` and not `f.tap_git_head`.