### PR TITLE
workflows/scheduled: allow more concurrency.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: scheduled
+  group: scheduled-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We can have more than one job per repo just don't want more than one per ref.