### PR TITLE
layouts: define more data in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,28 @@ taps:
     fullname: Homebrew/homebrew-cask
     remote: https://github.com/Homebrew/homebrew-cask
 
+analytics:
+  sources:
+    - name: macOS
+      path: analytics
+    - name: Linux
+      path: analytics-linux
+  intervals:
+    - name: 30 days
+      path: 30d
+    - name: 90 days
+      path: 90d
+    - name: 365 days
+      path: 365d
+  categories:
+    formulae:
+      - name: Installs
+        path: install
+      - name: Installs on Request
+        path: install-on-request
+      - name: Build Errors
+        path: build-error
+
 logo: https://brew.sh/assets/img/homebrew-256x256.png
 
 forkme_nwo: Homebrew/formulae.brew.sh

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -77,13 +77,11 @@ permalink: :title
 
 <p>Analytics:</p>
 <table>
-{%- assign intervals = "30d, 90d, 365d" | split: ", " -%}
-{%- for interval in intervals -%}
-    {%- assign interval_days = interval | replace: "d", " days" -%}
+{%- for interval in site.analytics.intervals -%}
     <tr>
-        <th colspan="2">Installs ({{ interval_days }})</th>
+        <th colspan="2">Installs ({{ interval.name }})</th>
     </tr>
-    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval].formulae[token] -%}
+    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token] -%}
     <tr>
         <td><code>{{ fa.cask }}</code></td>
         <td class="number-data">{{ fa.count }}</td>

--- a/_layouts/cask_json.json
+++ b/_layouts/cask_json.json
@@ -2,7 +2,6 @@
 ---
 {%- assign token = page.name | remove: ".json" -%}
 {%- assign cask = site.data.cask[token] -%}
-{%- assign intervals = "30d, 90d, 365d" | split: ", " -%}
 {
 
 {%- for key_value in cask -%}
@@ -10,10 +9,10 @@
 {%- endfor -%}
 
 "analytics":{"install":{
-{%- for interval in intervals -%}
-  "{{ interval }}":{
-  {%- if site.data.analytics.cask-install.homebrew-cask[interval].formulae[token].size > 0 -%}
-    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval].formulae[token] -%}
+{%- for interval in site.analytics.intervals -%}
+  "{{ interval.path }}":{
+  {%- if site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token].size > 0 -%}
+    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token] -%}
       {{ fa.cask | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
       {%- unless forloop.last -%}
       ,

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -190,112 +190,32 @@ permalink: :title
         <td>{{ f.caveats | xml_escape | replace: soft_indent, hard_indent | strip | newline_to_br }}</td>
     </tr>
 </table>
-{%- endif %}
+{%- endif -%}
 
-<p>Analytics (macOS):</p>
+{%- for source in site.analytics.sources %}
+
+<p>Analytics ({{ source.name }}):</p>
 <table>
-{%- assign intervals = "30d, 90d, 365d" | split: ", " -%}
-{%- for interval in intervals -%}
-    {%- assign interval_days = interval | replace: "d", " days" -%}
-    <tr>
-        <th colspan="2">Installs ({{ interval_days }})</th>
-    </tr>
-    {%- for fa in site.data.analytics.install.homebrew-core[interval].formulae[full_name] -%}
-    <tr>
-        <td><code>{{ fa.formula | escape }}</code></td>
-        <td class="number-data">{{ fa.count }}</td>
-    </tr>
-    {%- else -%}
-    <tr>
-        <td><code>{{ full_name }}</code></td>
-        <td class="number-data">0</td>
-    </tr>
-    {%- endfor -%}
-
-    <tr>
-        <th colspan="2">Installs on Request ({{ interval_days }})</th>
-    </tr>
-    {%- for fa in site.data.analytics.install-on-request.homebrew-core[interval].formulae[full_name] -%}
-    <tr>
-        <td><code>{{ fa.formula | escape }}</code></td>
-        <td class="number-data">{{ fa.count }}</td>
-    </tr>
-    {%- else -%}
-    <tr>
-        <td><code>{{ full_name }}</code></td>
-        <td class="number-data">0</td>
-    </tr>
-    {%- endfor -%}
-
-    {%- if forloop.first -%}
-    <tr>
-        <th colspan="2">Build Errors ({{ interval_days }})</th>
-    </tr>
-        {%- for fa in site.data.analytics.build-error.homebrew-core[interval].formulae[full_name] -%}
-    <tr>
-        <td><code>{{ fa.formula | escape }}</code></td>
-        <td class="number-data">{{ fa.count }}</td>
-    </tr>
-        {%- else -%}
-    <tr>
-        <td><code>{{ full_name }}</code></td>
-        <td class="number-data">0</td>
-    </tr>
-        {%- endfor -%}
+{%- for interval in site.analytics.intervals -%}
+  {%- for category in site.analytics.categories.formulae -%}
+    {%- if forloop.parentloop.first == false and forloop.last -%}
+        {%- break -%}
     {%- endif -%}
+    <tr>
+        <th colspan="2">{{ category.name }} ({{ interval.name }})</th>
+    </tr>
+    {%- for fa in site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name] -%}
+    <tr>
+        <td><code>{{ fa.formula | escape }}</code></td>
+        <td class="number-data">{{ fa.count }}</td>
+    </tr>
+    {%- else -%}
+    <tr>
+        <td><code>{{ full_name }}</code></td>
+        <td class="number-data">0</td>
+    </tr>
+    {%- endfor -%}
+  {%- endfor -%}
 {%- endfor %}
 </table>
-
-<p>Analytics (Linux):</p>
-<table>
-{%- assign intervals = "30d, 90d, 365d" | split: ", " -%}
-{%- for interval in intervals -%}
-    {%- assign interval_days = interval | replace: "d", " days" -%}
-    <tr>
-        <th colspan="2">Installs ({{ interval_days }})</th>
-    </tr>
-    {%- for fa in site.data.analytics-linux.install.homebrew-core[interval].formulae[full_name] -%}
-    <tr>
-        <td><code>{{ fa.formula | escape }}</code></td>
-        <td class="number-data">{{ fa.count }}</td>
-    </tr>
-    {%- else -%}
-    <tr>
-        <td><code>{{ full_name }}</code></td>
-        <td class="number-data">0</td>
-    </tr>
-    {%- endfor -%}
-
-    <tr>
-        <th colspan="2">Installs on Request ({{ interval_days }})</th>
-    </tr>
-    {%- for fa in site.data.analytics-linux.install-on-request.homebrew-core[interval].formulae[full_name] -%}
-    <tr>
-        <td><code>{{ fa.formula | escape }}</code></td>
-        <td class="number-data">{{ fa.count }}</td>
-    </tr>
-    {%- else -%}
-    <tr>
-        <td><code>{{ full_name }}</code></td>
-        <td class="number-data">0</td>
-    </tr>
-    {%- endfor -%}
-
-    {%- if forloop.first -%}
-    <tr>
-        <th colspan="2">Build Errors ({{ interval_days }})</th>
-    </tr>
-        {%- for fa in site.data.analytics-linux.build-error.homebrew-core[interval].formulae[full_name] -%}
-    <tr>
-        <td><code>{{ fa.formula | escape }}</code></td>
-        <td class="number-data">{{ fa.count }}</td>
-    </tr>
-        {%- else -%}
-    <tr>
-        <td><code>{{ full_name }}</code></td>
-        <td class="number-data">0</td>
-    </tr>
-        {%- endfor -%}
-    {%- endif -%}
 {%- endfor %}
-</table>

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -3,23 +3,20 @@
 {%- assign full_name = page.name | remove: ".json" -%}
 {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
 {%- assign formula = site.data.formula[data_name] -%}
-{%- assign sources = "analytics, analytics-linux" | split: ", " -%}
-{%- assign categories = "install, install-on-request, build-error" | split: ", " -%}
-{%- assign intervals = "30d, 90d, 365d" | split: ", " -%}
 {
 
 {%- for key_value in formula -%}
   {{ key_value[0] | jsonify }}:{{ key_value[1] | jsonify }},
 {%- endfor -%}
 
-{%- for source in sources -%}
-  "{{ source }}":{
-  {%- for category in categories -%}
-    "{{ category | replace: "-", "_" }}":{
-    {%- for interval in intervals -%}
-      "{{ interval }}":{
-      {%- if site.data[source][category].homebrew-core[interval].formulae[full_name].size > 0 -%}
-        {%- for fa in site.data[source][category].homebrew-core[interval].formulae[full_name] -%}
+{%- for source in site.analytics.sources -%}
+  "{{ source.path }}":{
+  {%- for category in site.analytics.categories.formulae -%}
+    "{{ category.path | replace: "-", "_" }}":{
+    {%- for interval in site.analytics.intervals -%}
+      "{{ interval.path }}":{
+      {%- if site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name].size > 0 -%}
+        {%- for fa in site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name] -%}
           {{ fa.formula | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
           {%- unless forloop.last -%}
           ,
@@ -29,7 +26,7 @@
         {{ full_name | jsonify }}:0
       {%- endif -%}
       }
-      {%- if category == "build-error" -%}
+      {%- if category.path == "build-error" -%}
         {%- break -%}
       {%- endif -%}
       {%- unless forloop.last -%}


### PR DESCRIPTION
Fetching loop items from the config file data reduces the number of temporary arrays that Liquid needs to create and seems to speed up generation slightly; `241.446 seconds` vs. `230.459 seconds` in my testing. 