### PR TITLE
Re-add cask-source API.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -34,7 +34,7 @@ jobs:
           /usr/bin/rake cask
 
       - name: Archive data
-        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ cask/
+        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ cask/
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ vendor/
 Gemfile.lock
 _data/
 api/cask/
+api/cask-source/
 api/formula/
 api/analytics/
 api/analytics-linux/

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ task :cask, [:tap] do |task, args|
   ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
   sh "brew", "ruby", "script/generate-cask.rb", args[:tap]
 end
-CLOBBER.include FileList[%w[_data/cask api/cask cask]]
+CLOBBER.include FileList[%w[_data/cask api/cask api/cask-source cask]]
 
 def generate_analytics?(os)
   return false if ENV["HOMEBREW_NO_ANALYTICS"]

--- a/script/generate-cask.rb
+++ b/script/generate-cask.rb
@@ -4,7 +4,7 @@ require "cask/cask"
 tap_name = ARGV.first
 tap = Tap.fetch(tap_name)
 
-directories = ["_data/cask", "api/cask", "cask"]
+directories = ["_data/cask", "api/cask", "api/cask-source", "cask"]
 FileUtils.rm_rf directories
 FileUtils.mkdir_p directories
 
@@ -17,5 +17,6 @@ tap.cask_files.each do |p|
   c = Cask::CaskLoader.load(p)
   IO.write("_data/cask/#{c.token}.json", "#{JSON.pretty_generate(c.to_hash_with_variations)}\n")
   IO.write("api/cask/#{c.token}.json", json_template)
+  IO.write("api/cask-source/#{c.token}.rb", p.read)
   IO.write("cask/#{c.token}.html", html_template.gsub("title: $TITLE", "title: \"#{c.token}\""))
 end


### PR DESCRIPTION
This is going to be more reliable than querying homebrew-cask directly.