### PR TITLE
Use `brew generate-analytics-api` and cleanup `Rakefile`

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,10 +30,11 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Reset homebrew/cask tap
+        run: brew update-reset $(brew --repository homebrew/cask)
+
       - name: Update data for homebrew/cask
-        run: |
-          brew update-reset $(brew --repository homebrew/cask)
-          /usr/bin/rake cask
+        run: bundle exec rake casks
         env:
           HOMEBREW_DEVELOPER: 1
 
@@ -60,8 +61,11 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Reset homebrew/core tap
+        run: brew update-reset $(brew --repository homebrew/core)
+
       - name: Update data for homebrew/core
-        run: /usr/bin/rake formulae
+        run: bundle exec rake formulae
         env:
           HOMEBREW_DEVELOPER: 1
 
@@ -99,7 +103,7 @@ jobs:
         run: echo "$ANALYTICS_JSON_KEY" > ~/.homebrew_analytics.json
 
       - name: Update analytics data
-        run: rake all_analytics
+        run: bundle exec rake analytics
 
       - name: Archive data
         run: tar czvf data-analytics.tar.gz _data/analytics _data/analytics-linux api/analytics api/analytics-linux
@@ -130,7 +134,7 @@ jobs:
           ruby-version: "2.6"
 
       - name: Update data for api samples
-        run: rake api_samples
+        run: bundle exec rake api_samples
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,6 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - name: Generate site
-        run: bundle exec rake formulae cask
+        run: bundle exec rake formulae casks
+        env:
+          HOMEBREW_DEVELOPER: 1

--- a/Rakefile
+++ b/Rakefile
@@ -4,27 +4,7 @@ require "rake"
 require "rake/clean"
 require "yaml"
 
-def jekyll_config(*props)
-  @config ||= YAML.load_file('_config.yml')
-  props.empty? ? @config : @config.dig(*props)
-end
-
-MAX_RETRIES = 3
-
-def sh_retry(command)
-  @retries ||= 0
-  sh(command)
-rescue RuntimeError
-  if @retries < MAX_RETRIES
-    sleep 2**(@retries + 3)
-    @retries += 1
-    retry
-  end
-
-  raise
-end
-
-task default: :formula_and_analytics
+task default: :generate
 
 desc "Dump macOS formulae data"
 task :formulae do
@@ -33,7 +13,7 @@ end
 CLOBBER.include FileList[%w[_data/formula api/formula formula _data/formula_canonical.json]]
 
 desc "Dump cask data"
-task :cask do
+task :casks do
   sh "brew", "generate-cask-api"
 end
 CLOBBER.include FileList[%w[_data/cask api/cask api/cask-source cask]]
@@ -53,8 +33,6 @@ def setup_formula_analytics_cmd
   unless `brew tap`.include?("homebrew/formula-analytics")
     sh "brew", "tap", "Homebrew/formula-analytics"
   end
-
-  sh "brew", "formula-analytics", "--setup"
 end
 
 def setup_analytics
@@ -62,80 +40,11 @@ def setup_analytics
   setup_formula_analytics_cmd
 end
 
-def generate_analytics_files(os)
-  analytics_data_path = "_data/analytics"
-  analytics_api_path = "api/analytics"
-  core_tap_name = "homebrew-core"
-  formula_analytics_os_arg = nil
-
-  if os == "linux"
-    analytics_data_path = "_data/analytics-linux"
-    analytics_api_path = "api/analytics-linux"
-    formula_analytics_os_arg = "--linux"
-  end
-
-  categories = %w[
-    build-error install install-on-request
-    core-build-error core-install core-install-on-request
-  ]
-  categories += %w[cask-install core-cask-install os-version] if os == "mac"
-
-  categories.each do |category|
-    case category
-    when "core-build-error"
-      category = "all-core-formulae-json --build-error"
-      category_name = "build-error"
-      data_source = core_tap_name
-    when "core-install"
-      category = "all-core-formulae-json --install"
-      category_name = "install"
-      data_source = core_tap_name
-    when "core-install-on-request"
-      category = "all-core-formulae-json --install-on-request"
-      category_name = "install-on-request"
-      data_source = core_tap_name
-    when "core-cask-install"
-      category = "all-core-formulae-json --cask-install"
-      category_name = "cask-install"
-      data_source = "homebrew-cask"
-    else
-      category_name = category
-    end
-
-    FileUtils.mkdir_p "#{analytics_data_path}/#{category_name}/#{data_source}"
-    FileUtils.mkdir_p "#{analytics_api_path}/#{category_name}/#{data_source}"
-    %w[30 90 365].each do |days|
-      next if days != "30" && category_name == "build-error" && !data_source.nil?
-
-      # The `--json` and `--all-core-formulae-json` flags are mutually
-      # exclusive, but we need to explicitly set `--json` sometimes,
-      # so only set it if we've not already set
-      # `--all-core-formulae-json`.
-      category_flags = category.include?("all-core-formulae-json") ? category : "json --#{category}"
-
-      path_suffix = File.join(category_name, data_source || "", "#{days}d.json")
-      sh_retry "brew formula-analytics #{formula_analytics_os_arg} --days-ago=#{days} --#{category_flags} " \
-        "> #{analytics_data_path}/#{path_suffix}"
-      IO.write("#{analytics_api_path}/#{path_suffix}", <<~EOS
-        ---
-        layout: analytics_json
-        category: #{category_name}
-        #{data_source + ": true" if data_source}
-        ---
-        {{ content }}
-      EOS
-      )
-    end
-  end
-end
-
 desc "Dump analytics data"
-task :analytics, [:os] do |task, args|
-  args.with_defaults(:os => "mac")
-
+task :analytics do
   setup_analytics
 
-  generate_analytics_files(args[:os])
+  sh "brew", "generate-analytics-api"
 end
 CLOBBER.include FileList[%w[_data/analytics _data/analytics-linux api/analytics api/analytics-linux]]
 
@@ -145,21 +54,8 @@ task :api_samples do
 end
 CLOBBER.include FileList[%w[_includes/api-sample]]
 
-desc "Dump macOS formulae and analytics data"
-task formula_and_analytics: %i[formulae analytics]
-
-desc "Dump macOS casks and analytics data"
-task cask_and_analytics: %i[cask analytics]
-
-desc "Dump Linux analytics data"
-task :linux_analytics do
-  Rake::Task["analytics"].tap(&:reenable).invoke("linux")
-end
-
-desc "Dump all analytics (macOS and Linux)"
-task all_analytics: :analytics do
-  Rake::Task["analytics"].tap(&:reenable).invoke("linux")
-end
+desc "Generate the API files"
+task generate: %i[formulae casks analytics api_samples]
 
 desc "Build the site"
 task :build do


### PR DESCRIPTION
Use the new `brew generate-analytics-api` command that will be added in https://github.com/Homebrew/homebrew-formula-analytics/pull/374 (this can't be merged until that is merged)

Also, while we're here, let's clean up the `Rakefile` and GitHub actions workflow a bit:
- Rename the `cask` task to `casks` for consistency
- Remove the option to generate analytics for only macOS/Linux
- Remove the option to generate analytics _and_ either core or cask data in the same task (this just didn't seem necessary)
- Add a new `generate` task that generates the entire site (`formulae`, `casks`, `analytics` and `api_samples`)
- Make the `generate` task the default task
- Remove some unused methods
- Use `bundle exec rake` across the board to call `rake` in GitHub actions (before it was a mix of `bundle exec rake`, `rake` and `/usr/bin/rake`)
- Run `brew update-reset` as its own GitHub actions task before generating core and cask data.

The thinking here is that if someone wants to clone this repo and generate the site data, all they have to do is run `rake` and the default is to generate everything. We still have the ability to generate one at a time in GitHub actions, but I think these defaults make more sense.
