### PR TITLE
Fix analytics data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
-gem "rake"
+gem "faraday-retry"
 gem "github-pages", group: :jekyll_plugins
+gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "date"
 require "json"
 require "rake"
@@ -7,7 +9,7 @@ require "yaml"
 task default: :generate
 
 desc "Generate the API files"
-task generate: %i[formulae casks analytics api_samples]
+task generate: [:formulae, :casks, :analytics, :api_samples]
 
 desc "Dump macOS formulae data"
 task :formulae do
@@ -33,9 +35,9 @@ end
 
 def setup_formula_analytics_cmd
   ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
-  unless `brew tap`.include?("homebrew/formula-analytics")
-    sh "brew", "tap", "Homebrew/formula-analytics"
-  end
+  return if `brew tap`.include?("homebrew/formula-analytics")
+
+  sh "brew", "tap", "Homebrew/formula-analytics"
 end
 
 def setup_analytics

--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,8 @@ taps:
 
 analytics:
   sources:
+    - name: All
+      path: analytics
     - name: macOS
       path: analytics
     - name: Linux

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -193,10 +193,23 @@ permalink: :title
 {%- endif -%}
 
 {%- for source in site.analytics.sources %}
-
-<p>Analytics ({{ source.name }}):</p>
+{%- if source.name == "All" -%}
+    <p>Analytics:</p>
+{%- else -%}
+    <p>Analytics ({{ source.name }}):</p>
+{%- endif -%}
 <table>
 {%- for interval in site.analytics.intervals -%}
+  {%- if source.name == "All" -%}
+    {%- if interval.name != "30 days" -%}
+      {%- continue -%}
+    {%- endif -%}
+  {%- else -%}
+    {%- if interval.name == "30 days" -%}
+      {%- continue -%}
+    {%- endif -%}
+  {%- endif -%}
+
   {%- for category in site.analytics.categories.formulae -%}
     {%- if forloop.parentloop.first == false and forloop.last -%}
         {%- break -%}

--- a/analytics-linux/build-error/30d/index.html
+++ b/analytics-linux/build-error/30d/index.html
@@ -1,8 +1,0 @@
----
-title: Homebrew Analytics Formula Build Error Events (30 days)
-layout: analytics
-days: 30d
-category: build-error
-category_pretty: Formula Build Error
-redirect_from: /analytics-linux/build-error/
----

--- a/analytics-linux/install-on-request/30d/index.html
+++ b/analytics-linux/install-on-request/30d/index.html
@@ -1,8 +1,0 @@
----
-title: Homebrew Analytics Formula Install On Request Events (30 days)
-layout: analytics
-days: 30d
-category: install-on-request
-category_pretty: Formula Install On Request
-redirect_from: /analytics-linux/install-on-request/
----

--- a/analytics-linux/install/30d/index.html
+++ b/analytics-linux/install/30d/index.html
@@ -1,8 +1,0 @@
----
-title: Homebrew Analytics Formula Install Events (30 days)
-layout: analytics
-days: 30d
-category: install
-category_pretty: Formula Install
-redirect_from: /analytics-linux/install/
----

--- a/analytics/build-error/30d/index.html
+++ b/analytics/build-error/30d/index.html
@@ -4,5 +4,8 @@ layout: analytics
 days: 30d
 category: build-error
 category_pretty: Formula Build Error
-redirect_from: /analytics/build-error/
+redirect_from:
+- /analytics/build-error/
+- /analytics-linux/build-error/
+- /analytics-linux/build-error/30d/
 ---

--- a/analytics/index.md
+++ b/analytics/index.md
@@ -4,62 +4,87 @@ redirect_from: /analytics-linux/
 ---
 # Analytics Data
 
+<table>
+    <tr>
+        <td>Formula Install Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/install/30d/">30 days</a></td>
+    </tr>
+    <tr>
+        <td>Formula Install On Request Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/install-on-request/30d/">30 days</a></td>
+    </tr>
+    <tr>
+        <td>Cask Install Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/cask-install/30d/">30 days</a></td>
+    </tr>
+    <tr>
+        <td>Formula Build Error Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/build-error/30d/">30 days</a></td>
+    </tr>
+    <tr>
+        <td>OS Versions for Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/os-version/30d/">30 days</a></td>
+    </tr>
+    <tr>
+        <td><code>/api/analytics/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/30d.json">30 days</a></td>
+    </tr>
+    <tr>
+        <td><code>/api/analytics/install-on-request/homebrew-core/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/30d.json">30 days</a></td>
+    </tr>
+    <tr>
+        <td><code>/api/analytics/cask-install/homebrew-cask/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/30d.json">30 days</a></td>
+    </tr>
+    <tr>
+        <td><code>/api/analytics/build-error/homebrew-core/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/build-error/homebrew-core/30d.json">30 days</a></td>
+    </tr>
+</table>
+
 ## macOS
 
 <table>
     <tr>
         <td>Formula Install Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/install/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Formula Install On Request Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/install-on-request/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install-on-request/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install-on-request/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Cask Install Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/cask-install/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/cask-install/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/cask-install/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Formula Build Error Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/build-error/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>macOS Versions for Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/os-version/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/os-version/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/os-version/365d/">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/365d.json">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics/install-on-request/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/365d.json">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics/cask-install/homebrew-cask/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/365d.json">365 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics/build-error/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/build-error/homebrew-core/30d.json">30 days</a></td>
-        <td></td>
-        <td></td>
     </tr>
 </table>
 
@@ -68,38 +93,27 @@ redirect_from: /analytics-linux/
 <table>
     <tr>
         <td>Formula Install Events</td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/install/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics-linux/install/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics-linux/install/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Formula Install On Request Events</td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/install-on-request/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics-linux/install-on-request/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics-linux/install-on-request/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Formula Build Error Events</td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/build-error/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics-linux/build-error/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics-linux/build-error/365d/">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics-linux/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/install/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics-linux/install/homebrew-core/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics-linux/install/homebrew-core/365d.json">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics-linux/install-on-request/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/install-on-request/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics-linux/install-on-request/homebrew-core/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics-linux/install-on-request/homebrew-core/365d.json">365 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics-linux/build-error/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/build-error/homebrew-core/30d.json">30 days</a></td>
-        <td></td>
-        <td></td>
     </tr>
 </table>

--- a/analytics/install-on-request/30d/index.html
+++ b/analytics/install-on-request/30d/index.html
@@ -4,5 +4,8 @@ layout: analytics
 days: 30d
 category: install-on-request
 category_pretty: Formula Install On Request
-redirect_from: /analytics/install-on-request/
+redirect_from:
+- /analytics/install-on-request/
+- /analytics-linux/install-on-request/
+- /analytics-linux/install-on-request/30d/
 ---

--- a/analytics/install/30d/index.html
+++ b/analytics/install/30d/index.html
@@ -4,5 +4,8 @@ layout: analytics
 days: 30d
 category: install
 category_pretty: Formula Install
-redirect_from: /analytics/install/
+redirect_from:
+- /analytics/install/
+- /analytics-linux/install/
+- /analytics-linux/install/30d/
 ---

--- a/analytics/os-version/30d/index.html
+++ b/analytics/os-version/30d/index.html
@@ -1,8 +1,8 @@
 ---
-title: Homebrew Analytics macOS Versions (30 days)
+title: Homebrew Analytics OS Versions (30 days)
 layout: analytics
 days: 30d
 category: os-version
-category_pretty: macOS Versions for
+category_pretty: OS Versions for
 redirect_from: /analytics/os-version/
 ---


### PR DESCRIPTION
- 30 day (InfluxDB) analytics data is shared on macOS and Linux
- Add `faraday-retry` gem so Jekyll stops complaining about it on startup
- Let `brew style --fix` do some reformatting