### PR TITLE
config: remove feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,6 @@ exclude:
   - vendor
 
 plugins:
-  - jekyll-feed
   - jekyll-redirect-from
   - jekyll-remote-theme
   - jekyll-seo-tag


### PR DESCRIPTION
As with Homebrew/brew#15501, this slightly speeds up generation and it's no longer needed as of Homebrew/brew.sh#957.