### PR TITLE
Migrate all analytics to InfluxDB

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -105,7 +105,7 @@ jobs:
           HOMEBREW_INFLUXDB_TOKEN: ${{ secrets.HOMEBREW_INFLUXDB_TOKEN }}
 
       - name: Archive data
-        run: tar czvf data-analytics.tar.gz _data/analytics _data/analytics-linux api/analytics api/analytics-linux
+        run: tar czvf data-analytics.tar.gz _data/analytics api/analytics
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ api/cask/
 api/cask-source/
 api/formula/
 api/analytics/
-api/analytics-linux/
 _includes/api-samples/
 cask/
 formula/

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ task :analytics do
 
   sh "brew", "generate-analytics-api"
 end
-CLOBBER.include FileList[%w[_data/analytics _data/analytics-linux api/analytics api/analytics-linux]]
+CLOBBER.include FileList[%w[_data/analytics api/analytics]]
 
 desc "Update API samples"
 task :api_samples do

--- a/_config.yml
+++ b/_config.yml
@@ -42,13 +42,6 @@ taps:
     remote: https://github.com/Homebrew/homebrew-cask
 
 analytics:
-  sources:
-    - name: All
-      path: analytics
-    - name: macOS
-      path: analytics
-    - name: Linux
-      path: analytics-linux
   intervals:
     - name: 30 days
       path: 30d

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -3,9 +3,13 @@ layout: base
 ---
 {%- assign analytics_path = page.dir | split: "/" -%}
 {%- assign analytics_path = analytics_path[1] -%}
+{%- assign analytics_data = site.data[analytics_path][page.category][page.days] -%}
 <h2>{{ page.category_pretty }} Events ({{ page.days | split: "d" | first }} days)</h2>
 
 <h3><a href="{{ site.baseurl }}/api/{{ analytics_path }}/{{ page.category }}/{{ page.days }}.json"><code>/api/{{ analytics_path }}/{{ page.category }}/{{ page.days }}.json</code> (JSON API)</a></h3>
+
+<h4>Start Date: {{ analytics_data.start_date }}</h4>
+<h4>Total Events: {{ analytics_data.total_count }}</h4>
 
 <table class="full-width">
     <tr>
@@ -23,7 +27,7 @@ layout: base
         <th>Events</th>
         <th>%</th>
     </tr>
-{%- for item in site.data[analytics_path][page.category][page.days].items -%}
+{%- for item in analytics_data.items -%}
     <tr>
         <td class="number-data">#{{ item.number }}</td>
         <td>

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -10,7 +10,12 @@ permalink: :title
     {%- if f.disabled %} class="disabled" title="This formula has been disabled since {{ f.disable_date }} because it {{ f.disable_reason }}"
     {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated since {{ f.deprecation_date }} because it {{ f.deprecation_reason }}"
     {%- endif -%}
-    >{{ f.name }}</h2>
+    >
+    {{ f.name }}
+    {%- if f.disabled %} (disabled)
+    {%- elsif f.deprecated %} (deprecated)
+    {%- endif -%}
+</h2>
 
 {%- include install_command.html item=f.name %}
 {%- if f.aliases.size > 0 %}
@@ -192,24 +197,9 @@ permalink: :title
 </table>
 {%- endif -%}
 
-{%- for source in site.analytics.sources %}
-{%- if source.name == "All" -%}
-    <p>Analytics:</p>
-{%- else -%}
-    <p>Analytics ({{ source.name }}):</p>
-{%- endif -%}
+<p>Analytics:</p>
 <table>
 {%- for interval in site.analytics.intervals -%}
-  {%- if source.name == "All" -%}
-    {%- if interval.name != "30 days" -%}
-      {%- continue -%}
-    {%- endif -%}
-  {%- else -%}
-    {%- if interval.name == "30 days" -%}
-      {%- continue -%}
-    {%- endif -%}
-  {%- endif -%}
-
   {%- for category in site.analytics.categories.formulae -%}
     {%- if forloop.parentloop.first == false and forloop.last -%}
         {%- break -%}
@@ -231,4 +221,3 @@ permalink: :title
   {%- endfor -%}
 {%- endfor %}
 </table>
-{%- endfor %}

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -9,35 +9,33 @@
   {{ key_value[0] | jsonify }}:{{ key_value[1] | jsonify }},
 {%- endfor -%}
 
-{%- for source in site.analytics.sources -%}
-  "{{ source.path }}":{
-  {%- for category in site.analytics.categories.formulae -%}
-    "{{ category.path | replace: "-", "_" }}":{
-    {%- for interval in site.analytics.intervals -%}
-      "{{ interval.path }}":{
-      {%- if site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name].size > 0 -%}
-        {%- for fa in site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name] -%}
-          {{ fa.formula | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
-          {%- unless forloop.last -%}
-          ,
-          {%- endunless -%}
-        {%- endfor -%}
-      {%- else -%}
-        {{ full_name | jsonify }}:0
-      {%- endif -%}
-      }
-      {%- if category.path == "build-error" -%}
-        {%- break -%}
-      {%- endif -%}
-      {%- unless forloop.last -%}
-      ,
-      {%- endunless -%}
-    {%- endfor -%}
+"analytics":{
+{%- for category in site.analytics.categories.formulae -%}
+  "{{ category.path | replace: "-", "_" }}":{
+  {%- for interval in site.analytics.intervals -%}
+    "{{ interval.path }}":{
+    {%- if site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name].size > 0 -%}
+      {%- for fa in site.data[source.path][category.path].homebrew-core[interval.path].formulae[full_name] -%}
+        {{ fa.formula | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
+        {%- unless forloop.last -%}
+        ,
+        {%- endunless -%}
+      {%- endfor -%}
+    {%- else -%}
+      {{ full_name | jsonify }}:0
+    {%- endif -%}
     }
+    {%- if category.path == "build-error" -%}
+      {%- break -%}
+    {%- endif -%}
     {%- unless forloop.last -%}
     ,
     {%- endunless -%}
   {%- endfor -%}
-  },
+  }
+  {%- unless forloop.last -%}
+  ,
+  {%- endunless -%}
 {%- endfor -%}
+},
 "generated_date":"{{ "today" | date: "%F" }}"}

--- a/analytics-linux/build-error/365d/index.html
+++ b/analytics-linux/build-error/365d/index.html
@@ -1,7 +1,0 @@
----
-title: Homebrew Analytics Formula Build Error Events (365 days)
-layout: analytics
-days: 365d
-category: build-error
-category_pretty: Formula Build Error
----

--- a/analytics-linux/build-error/90d/index.html
+++ b/analytics-linux/build-error/90d/index.html
@@ -1,7 +1,0 @@
----
-title: Homebrew Analytics Formula Build Error Events (90 days)
-layout: analytics
-days: 90d
-category: build-error
-category_pretty: Formula Build Error
----

--- a/analytics-linux/install-on-request/365d/index.html
+++ b/analytics-linux/install-on-request/365d/index.html
@@ -1,7 +1,0 @@
----
-title: Homebrew Analytics Formula Install On Request Events (365 days)
-layout: analytics
-days: 365d
-category: install-on-request
-category_pretty: Formula Install On Request
----

--- a/analytics-linux/install-on-request/90d/index.html
+++ b/analytics-linux/install-on-request/90d/index.html
@@ -1,7 +1,0 @@
----
-title: Homebrew Analytics Formula Install On Request Events (90 days)
-layout: analytics
-days: 90d
-category: install-on-request
-category_pretty: Formula Install On Request
----

--- a/analytics-linux/install/365d/index.html
+++ b/analytics-linux/install/365d/index.html
@@ -1,7 +1,0 @@
----
-title: Homebrew Analytics Formula Install Events (365 days)
-layout: analytics
-days: 365d
-category: install
-category_pretty: Formula Install
----

--- a/analytics-linux/install/90d/index.html
+++ b/analytics-linux/install/90d/index.html
@@ -1,7 +1,0 @@
----
-title: Homebrew Analytics Formula Install Events (90 days)
-layout: analytics
-days: 90d
-category: install
-category_pretty: Formula Install
----

--- a/analytics/build-error/365d/index.html
+++ b/analytics/build-error/365d/index.html
@@ -4,4 +4,6 @@ layout: analytics
 days: 365d
 category: build-error
 category_pretty: Formula Build Error
+redirect_from:
+- /analytics-linux/build-error/365d/
 ---

--- a/analytics/build-error/90d/index.html
+++ b/analytics/build-error/90d/index.html
@@ -4,4 +4,6 @@ layout: analytics
 days: 90d
 category: build-error
 category_pretty: Formula Build Error
+redirect_from:
+- /analytics-linux/build-error/90d/
 ---

--- a/analytics/index.md
+++ b/analytics/index.md
@@ -8,112 +8,55 @@ redirect_from: /analytics-linux/
     <tr>
         <td>Formula Install Events</td>
         <td><a href="{{ site.baseurl }}/analytics/install/30d/">30 days</a></td>
-    </tr>
-    <tr>
-        <td>Formula Install On Request Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/install-on-request/30d/">30 days</a></td>
-    </tr>
-    <tr>
-        <td>Cask Install Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/cask-install/30d/">30 days</a></td>
-    </tr>
-    <tr>
-        <td>Formula Build Error Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/build-error/30d/">30 days</a></td>
-    </tr>
-    <tr>
-        <td>OS Versions for Events</td>
-        <td><a href="{{ site.baseurl }}/analytics/os-version/30d/">30 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/30d.json">30 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics/install-on-request/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/30d.json">30 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics/cask-install/homebrew-cask/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/30d.json">30 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics/build-error/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics/build-error/homebrew-core/30d.json">30 days</a></td>
-    </tr>
-</table>
-
-## macOS
-
-<table>
-    <tr>
-        <td>Formula Install Events</td>
         <td><a href="{{ site.baseurl }}/analytics/install/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Formula Install On Request Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/install-on-request/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install-on-request/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/install-on-request/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Cask Install Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/cask-install/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/cask-install/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/cask-install/365d/">365 days</a></td>
     </tr>
     <tr>
         <td>Formula Build Error Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/build-error/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/build-error/365d/">365 days</a></td>
     </tr>
     <tr>
-        <td>macOS Versions for Events</td>
+        <td>OS Versions for Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/os-version/30d/">30 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/os-version/90d/">90 days</a></td>
         <td><a href="{{ site.baseurl }}/analytics/os-version/365d/">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/365d.json">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics/install-on-request/homebrew-core/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install-on-request/homebrew-core/365d.json">365 days</a></td>
     </tr>
     <tr>
         <td><code>/api/analytics/cask-install/homebrew-cask/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/90d.json">90 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/cask-install/homebrew-cask/365d.json">365 days</a></td>
     </tr>
-</table>
-
-## Linux
-
-<table>
     <tr>
-        <td>Formula Install Events</td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/install/90d/">90 days</a></td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/install/365d/">365 days</a></td>
-    </tr>
-    <tr>
-        <td>Formula Install On Request Events</td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/install-on-request/90d/">90 days</a></td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/install-on-request/365d/">365 days</a></td>
-    </tr>
-    <tr>
-        <td>Formula Build Error Events</td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/build-error/90d/">90 days</a></td>
-        <td><a href="{{ site.baseurl }}/analytics-linux/build-error/365d/">365 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics-linux/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/install/homebrew-core/90d.json">90 days</a></td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/install/homebrew-core/365d.json">365 days</a></td>
-    </tr>
-    <tr>
-        <td><code>/api/analytics-linux/install-on-request/homebrew-core/${DAYS}.json</code> (JSON API)</td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/install-on-request/homebrew-core/90d.json">90 days</a></td>
-        <td><a href="{{ site.baseurl }}/api/analytics-linux/install-on-request/homebrew-core/365d.json">365 days</a></td>
+        <td><code>/api/analytics/build-error/homebrew-core/${DAYS}.json</code> (JSON API)</td>
+        <td><a href="{{ site.baseurl }}/api/analytics/build-error/homebrew-core/30d.json">30 days</a></td>
+        <td></td>
+        <td></td>
     </tr>
 </table>

--- a/analytics/install-on-request/365d/index.html
+++ b/analytics/install-on-request/365d/index.html
@@ -4,4 +4,6 @@ layout: analytics
 days: 365d
 category: install-on-request
 category_pretty: Formula Install On Request
+redirect_from:
+- /analytics-linux/install-on-request/365d/
 ---

--- a/analytics/install-on-request/90d/index.html
+++ b/analytics/install-on-request/90d/index.html
@@ -4,4 +4,6 @@ layout: analytics
 days: 90d
 category: install-on-request
 category_pretty: Formula Install On Request
+redirect_from:
+- /analytics-linux/install-on-request/90d/
 ---

--- a/analytics/install/365d/index.html
+++ b/analytics/install/365d/index.html
@@ -4,4 +4,6 @@ layout: analytics
 days: 365d
 category: install
 category_pretty: Formula Install
+redirect_from:
+- /analytics-linux/install/365d/
 ---

--- a/analytics/install/90d/index.html
+++ b/analytics/install/90d/index.html
@@ -4,4 +4,6 @@ layout: analytics
 days: 90d
 category: install
 category_pretty: Formula Install
+redirect_from:
+- /analytics-linux/install/90d/
 ---

--- a/analytics/os-version/365d/index.html
+++ b/analytics/os-version/365d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics macOS Versions (365 days)
+title: Homebrew Analytics OS Versions (365 days)
 layout: analytics
 days: 365d
 category: os-version
-category_pretty: macOS Versions for
+category_pretty: OS Versions for
 ---

--- a/analytics/os-version/90d/index.html
+++ b/analytics/os-version/90d/index.html
@@ -1,7 +1,7 @@
 ---
-title: Homebrew Analytics macOS Versions (90 days)
+title: Homebrew Analytics OS Versions (90 days)
 layout: analytics
 days: 90d
 category: os-version
-category_pretty: macOS Versions for
+category_pretty: OS Versions for
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,7 +62,6 @@ List all analytics events for a specified category over a number of days, ordere
 
 ```
 GET https://formulae.brew.sh/api/analytics/${CATEGORY}/${DAYS}.json
-GET https://formulae.brew.sh/api/analytics-linux/${CATEGORY}/${DAYS}.json
 ```
 
 #### Variables
@@ -90,7 +89,6 @@ List all the {{ site.taps.core.fullname }} formulae's analytics events for a spe
 
 ```
 GET https://formulae.brew.sh/api/analytics/${CATEGORY}/homebrew-core/${DAYS}.json
-GET https://formulae.brew.sh/api/analytics-linux/${CATEGORY}/homebrew-core/${DAYS}.json
 ```
 
 #### Variables


### PR DESCRIPTION
- separate analytics-linux is no longer generated
- display start date and total events on analytics pages
- redirect from analytics-linux pages
- update API documentation

While we're here
- display (disabled) or (deprecated) on formula pages

Fixes https://github.com/Homebrew/formulae.brew.sh/issues/856
Fixes https://github.com/Homebrew/brew/issues/15528
Fixes https://github.com/Homebrew/brew/issues/13211