### PR TITLE
Gemfile: use newer Jekyll.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,9 @@
 source "https://rubygems.org"
 
 gem "faraday-retry"
-gem "github-pages", group: :jekyll_plugins
+gem "jekyll"
+gem "jekyll-redirect-from"
+gem "jekyll-remote-theme"
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"
 gem "rake"


### PR DESCRIPTION
Jekyll 4 is compatible with the GitHub Pages deployed from GitHub Actions pipeline we're using and generates about 3x faster on my machine.