### PR TITLE
workflows/scheduled: remove cask update-reset

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,6 +19,7 @@ jobs:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate homebrew/cask data, pages and API
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@main
@@ -29,9 +30,6 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Reset homebrew/cask tap
-        run: brew update-reset $(brew --repository homebrew/cask)
 
       - name: Update data for homebrew/cask
         run: /usr/bin/rake casks
@@ -50,6 +48,7 @@ jobs:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate homebrew/core data, pages and API
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@main
@@ -78,6 +77,7 @@ jobs:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate analytics data
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@main
@@ -116,6 +116,7 @@ jobs:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate API samples
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - name: Check out repository
         uses: actions/checkout@main
@@ -143,6 +144,7 @@ jobs:
   build:
     needs: [generate-cask, generate-core, generate-analytics, generate-samples]
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Set up Git repository
         uses: actions/checkout@main
@@ -192,6 +194,7 @@ jobs:
     outputs:
       deploy_url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
@@ -212,6 +215,7 @@ jobs:
       GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
       REPO: ${{ github.repository }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Find existing deploy failure issue
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: macos-latest
     steps:
       - name: Set up Git repository
         uses: actions/checkout@main


### PR DESCRIPTION
`brew update-reset` does not exit with a failure code if the fetch fails, so a stale JSON could be generated in those scenarios (see https://github.com/Homebrew/brew/issues/15616). Replace the logic with https://github.com/Homebrew/actions/pull/382.

Also add some timeout values in case it prevents https://github.com/Homebrew/formulae.brew.sh/actions/runs/5322147907. Maybe not but no harm trying.