### PR TITLE
github/workflows: update taps.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -32,6 +32,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
         with:
           core: false
+          cask: true
           test-bot: false
 
       - name: Update data for homebrew/cask
@@ -63,6 +64,7 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
+          core: true
           cask: false
           test-bot: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,16 +19,16 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: false
+          test-bot: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.6"
-
-      - name: Install RubyGems
-        run: |
-          gem install bundler -v "~>1"
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Generate site
         run: /usr/bin/rake formulae casks


### PR DESCRIPTION
Ensure that setup-homebrew is run with the correct options for each tap.

While we're here, set these everywhere and use the bundler cache.

Fixes https://github.com/Homebrew/formulae.brew.sh/issues/921