### PR TITLE
workflows/scheduled: use new org token.

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Update analytics data
         run: /usr/bin/rake analytics
         env:
-          HOMEBREW_INFLUXDB_TOKEN: ${{ secrets.HOMEBREW_INFLUXDB_TOKEN }}
+          HOMEBREW_INFLUXDB_TOKEN: ${{ secrets.HOMEBREW_INFLUXDB_READ_TOKEN }}
 
       - name: Archive data
         run: tar czvf data-analytics.tar.gz _data/analytics api/analytics


### PR DESCRIPTION
This is the same token we're using elsewhere now.