### PR TITLE
Support URL sharding

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -20,7 +20,7 @@ permalink: :title
 <p class="homepage"><a href="{{ c.homepage }}">{{ c.homepage }}</a></p>
 
 <p><a href="{{ site.baseurl }}/api/cask/{{ token }}.json"><code>/api/cask/{{ token }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ c.tap_git_head }}/Casks/{{ token }}.rb">Cask code</a> on GitHub</p>
+<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ c.tap_git_head }}/{{ c.ruby_source_path }}">Cask code</a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url }}">{{ c.version }}</a></p>
 

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -32,7 +32,7 @@ permalink: :title
 
 <p>Formula JSON API: <a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name }}.json"><code>/api/{{ formula_path }}/{{ f.name }}.json</code></a></p>
 
-<p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/{{ f.tap_git_head }}/Formula/{{ f.name }}.rb"><code>{{ f.name }}.rb</code></a> on GitHub</p>
+<p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/{{ f.tap_git_head }}/{{ f.ruby_source_path }}"><code>{{ f.name }}.rb</code></a> on GitHub</p>
 
 <p>Bottle (binary package)
 {%- assign bottles = false -%}


### PR DESCRIPTION
Instead of constructing the formula path manually, let's use `ruby_source_path` instead.

Fixes https://github.com/orgs/Homebrew/discussions/4704.
