### PR TITLE
_config.yml: fix logo CSP violation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ defaults:
   - scope:
       path: ""
     values:
-      image: https://brew.sh/assets/img/homebrew-256x256.png
+      image: /assets/img/homebrew-256x256.png
       search_name: Homebrew Formulae
       search_site: formulae
 
@@ -58,7 +58,7 @@ analytics:
       - name: Build Errors
         path: build-error
 
-logo: https://brew.sh/assets/img/homebrew-256x256.png
+logo: /assets/img/homebrew-256x256.png
 
 forkme_nwo: Homebrew/formulae.brew.sh
 


### PR DESCRIPTION
All the assets get copied by `remote_theme` anyway so we can just reference the copied image.

Fixes #955.