### PR TITLE
Add deprecated/disabled messages to cask pages

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -5,7 +5,16 @@ permalink: :title
 {%- assign token = page.title -%}
 {%- assign formula_path = "formula" -%}
 {%- assign c = site.data.cask[token] -%}
-<h2>{{ token }}</h2>
+<h2
+    {%- if c.disabled %} class="disabled" title="This cask has been disabled since {{ c.disable_date }} because it {{ c.disable_reason }}"
+    {%- elsif c.deprecated %} class="deprecated" title="This cask has been deprecated since {{ c.deprecation_date }} because it {{ c.deprecation_reason }}"
+    {%- endif -%}
+    >
+    {{ token }}
+    {%- if c.disabled %} (disabled)
+    {%- elsif c.deprecated %} (deprecated)
+    {%- endif -%}
+</h2>
 
 {%- include install_command.html item=token modifier=" --cask" %}
 <p class="names">Name{%- if c.name.size > 1 -%}s{%- endif -%}:


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/16292

Show a warning when casks are deprecated or disabled now.

---

Something interesting that I noticed (that affects both formulae and casks), the `title` attribute of the `h2` includes the deprecation reason, but it just uses the pre-set reason instead of converting it to the actual string.

For example, take `zdoom` (which will soon contain `deprecate! date: "2023-12-17", because: :discontinued`). Right now, the `title` attribute is set to:

```
This cask has been deprecated since 2023-12-17 because it discontinued
```

Instead of:

```
This cask has been deprecated since 2023-12-17 because it is discontinued upstream
```

Anyway, something for another PR
