### PR TITLE
docs/api: drop non-functioning `--all`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ redirect_from:
 
 ### List metadata for all {{ site.taps.core.name }} formulae or {{ site.taps.cask.name }} casks
 
-List the `brew info --json --all` output for all current {{ site.taps.core.fullname }} formulae or {{ site.taps.cask.fullname }} casks.
+List the `brew info --json` output for all current {{ site.taps.core.fullname }} formulae or {{ site.taps.cask.fullname }} casks.
 
 ```
 GET https://formulae.brew.sh/api/formula.json


### PR DESCRIPTION
`--all` is not a valid option for `brew info`