### PR TITLE
Start signing internal v3 json

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -74,7 +74,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-core.tar.gz _data/formula/ _data/formula_canonical.json api/formula/ api/formula_tap_migrations.json formula/
+        run: tar czvf data-core.tar.gz _data/formula/ _data/formula_canonical.json api/formula/ api/formula_tap_migrations.json formula/ api/internal/v3/homebrew-core.json
 
       - uses: actions/upload-artifact@v3
         with:

--- a/script/sign-json.rb
+++ b/script/sign-json.rb
@@ -17,6 +17,7 @@ PRIVATE_KEY = OpenSSL::PKey::RSA.new(ENV.fetch("JWS_SIGNING_KEY")).freeze
   ROOT/"_site/api/cask.json",
   ROOT/"_site/api/formula_tap_migrations.json",
   ROOT/"_site/api/cask_tap_migrations.json",
+  ROOT/"_site/api/internal/v3/homebrew-core.json",
 ].each do |path|
   data_string = path.read
 


### PR DESCRIPTION
Now that the PR on the main brew repo got merged in we're generating the internal v3 JSON but we're not storing or using it anywhere. This updates the scheduled generation task to not only store the resulting JSON but also sign it to allow us to use it as a reference when building the loader code.

- https://github.com/Homebrew/brew/pull/16541
- https://github.com/Homebrew/brew/issues/16410