### PR TITLE
_includes/cask: update cask table layout

### DIFF
--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -6,5 +6,5 @@
             {{ include.token }}
 {%- endif -%}
         </td>
-        <td>{{ include.cask.name.first }}</td>
         <td>{{ include.cask.version | truncate: 25 }}</td>
+        <td>{{ include.cask.desc | xml_escape }}</td>

--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -8,3 +8,4 @@
         </td>
         <td>{{ include.cask.version | truncate: 25 }}</td>
         <td>{{ include.cask.desc | xml_escape }}</td>
+        <td>{{ include.cask.name.first }}</td>


### PR DESCRIPTION
This PR updates the table layout on - https://formulae.brew.sh/cask/ To match the same layout as formulae - https://formulae.brew.sh/formula/

Related: https://github.com/Homebrew/brew/issues/16876