### PR TITLE
Revert "Revert "Revert "Revert "workflows/scheduled: temporarily use previous analytics data""""

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -84,41 +84,44 @@ jobs:
   generate-analytics:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate analytics data
+    permissions:
+      actions: read
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - name: Check out repository
-        uses: actions/checkout@main
+      - name: Download previous data
+        uses: actions/github-script@v7
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              ...context.repo,
+              workflow_id: "scheduled.yml",
+              event: "schedule",
+              status: "success",
+            })
 
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          core: false
-          cask: false
-          test-bot: false
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              ...context.repo,
+              run_id: runs.data.workflow_runs[0].id,
+            })
+            const artifact = artifacts.data.artifacts.find((artifact) => {
+              return artifact.name == "data-analytics"
+            })
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+            const zip = await github.rest.actions.downloadArtifact({
+              ...context.repo,
+              artifact_id: artifact.id,
+              archive_format: "zip",
+            })
+            require("fs").writeFileSync("analytics.zip", Buffer.from(zip.data))
 
-      - name: Update analytics data
-        run: /usr/bin/rake analytics
-        env:
-          HOMEBREW_INFLUXDB_TOKEN: ${{ secrets.HOMEBREW_INFLUXDB_READ_TOKEN }}
-
-      - name: Archive data
-        run: tar czvf data-analytics.tar.gz _data/analytics api/analytics
+      - run: unzip analytics.zip
 
       - uses: actions/upload-artifact@v3
         with:
           name: data-analytics
           path: data-analytics.tar.gz
-          retention-days: 1
+          retention-days: 3
   generate-samples:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate API samples


### PR DESCRIPTION
I've spent too many hours on this and I ultimately think it's unfixable on our side. It's clear something very suddenly happened (like a server code deploy) for things to suddenly cease to function properly on larger datasets and may require reaching out to support. https://github.com/Homebrew/homebrew-formula-analytics/pull/433

So let's get this necromance this revert train before the previous data expires after 24 hours, and to restore API updates.