### PR TITLE
Revert "Start signing JSON v3 cask file"

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -41,7 +41,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json cask/ api/internal/v3/homebrew-cask.json
+        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json cask/
 
       - uses: actions/upload-artifact@v4
         with:

--- a/script/sign-json.rb
+++ b/script/sign-json.rb
@@ -18,7 +18,6 @@ PRIVATE_KEY = OpenSSL::PKey::RSA.new(ENV.fetch("JWS_SIGNING_KEY")).freeze
   ROOT/"_site/api/formula_tap_migrations.json",
   ROOT/"_site/api/cask_tap_migrations.json",
   ROOT/"_site/api/internal/v3/homebrew-core.json",
-  ROOT/"_site/api/internal/v3/homebrew-cask.json",
 ].each do |path|
   data_string = path.read
 


### PR DESCRIPTION
Reverts Homebrew/formulae.brew.sh#1092

We have not been able to reach a consensus on how this new format should work so I'm reverting the changes.

See https://github.com/Homebrew/brew/pull/16896#issuecomment-2046456989