### PR TITLE
update cask token handling

### DIFF
--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -1,9 +1,9 @@
 
         <td>
-{%- if site.data.cask[include.token] != nil -%}
-            <a href="{{ site.baseurl }}/cask/{{ include.token | uri_escape }}">{{ include.token | escape }}</a>
+{%- if site.data.cask[include.sort_key] != nil -%}
+            <a href="{{ site.baseurl }}/cask/{{ include.cask.token | uri_escape }}">{{ include.cask.token | escape }}</a>
 {%- else -%}
-            {{ include.token | escape }}
+            {{ include.cask.token | escape }}
 {%- endif -%}
         </td>
         <td>{{ include.cask.version | truncate: 25 | escape }}</td>

--- a/cask_index.html
+++ b/cask_index.html
@@ -11,9 +11,9 @@ permalink: /cask/
     {%- assign sorted_casks = site.data.cask | sort -%}
     {%- for c in sorted_casks -%}
     <tr>
-        {%- assign token = c[0] -%}
+        {%- assign sort_key = c[0] -%}
         {%- assign cask = c[1] -%}
-        {%- include cask.html token=token cask=cask -%}
+        {%- include cask.html sort_key=sort_key cask=cask -%}
     </tr>
     {%- endfor -%}
 </table>


### PR DESCRIPTION
This changes the way we are handling the token. Currently, for casks including `@`, we see the following:
```html
<tr>
        <td><a href="/cask/brave-browserbeta">brave-browserbeta</a></td>
        <td>1.66.90.0</td>
        <td>Web browser focusing on privacy</td>
        <td>Brave Beta</td>
</tr>
``` 
instead of: 
```html
<tr>
        <td><a href="/cask/brave-browser@beta">brave-browser@beta</a></td>
        <td>1.66.90.0</td>
        <td>Web browser focusing on privacy</td>
        <td>Brave Beta</td>
</tr>
``` 
