### PR TITLE
drop usage of `formula_path`

### DIFF
--- a/_includes/formula.html
+++ b/_includes/formula.html
@@ -1,5 +1,5 @@
 
-        <td><a href="{{ site.baseurl }}/{{ include.formula_path || default: "formula" }}/{{ include.formula.name | uri_escape }}"
+        <td><a href="{{ site.baseurl }}/formula/{{ include.formula.name | uri_escape }}"
             {%- if include.formula.disabled %} class="disabled" title="This formula has been disabled"
             {%- elsif include.formula.deprecated %} class="deprecated" title="This formula has been deprecated"
             {%- endif -%}

--- a/_includes/formulae.html
+++ b/_includes/formulae.html
@@ -1,17 +1,15 @@
 {%- if include.formulae.size > 0 %}
 <p>{{ include.description }}:</p>
 <table>
-    {%- assign formula_path = include.formula_path -%}
     {%- for full_name in include.formulae -%}
     <tr>
         {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-        {%- assign formula = site.data[formula_path][data_name] -%}
+        {%- assign formula = site.data.formula[data_name] -%}
         {%- unless formula -%}
-            {%- assign canonical_map = formula_path | append: "_canonical" -%}
-            {%- assign data_name = site.data[canonical_map][full_name] | remove: "@" | remove: "." | replace: "+", "_" -%}
-            {%- assign formula = site.data[formula_path][data_name] -%}
+            {%- assign data_name = site.data.formula_canonical[full_name] | remove: "@" | remove: "." | replace: "+", "_" -%}
+            {%- assign formula = site.data.formula[data_name] -%}
         {%- endunless -%}
-        {%- include formula.html formula_path=formula_path formula=formula -%}
+        {%- include formula.html formula=formula -%}
     </tr>
     {%- endfor -%}
 </table>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -3,7 +3,6 @@ layout: default
 permalink: :title
 ---
 {%- assign full_name = page.title -%}
-{%- assign formula_path = "formula" -%}
 {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
 {%- assign c = site.data.cask[data_name] -%}
 <h2
@@ -36,7 +35,7 @@ permalink: :title
 
 {%- if c.depends_on.size > 0 -%}
     {%- include casks.html casks=c.depends_on.cask description="Depends on casks" -%}
-    {%- include formulae.html formula_path=formula_path formulae=c.depends_on.formula description="Depends on" -%}
+    {%- include formulae.html formulae=c.depends_on.formula description="Depends on" -%}
     {%- assign requirements = "" -%}
     {%- if c.depends_on.macos -%}
         {%- capture requirements -%}
@@ -65,7 +64,7 @@ permalink: :title
 {%- include casks.html casks=c.conflicts_with.cask description="Conflicts with casks" -%}
 
 {%- assign conflicts_with_formula = c.conflicts_with.formula | where_exp: "f", "site.data.formula[f]" -%}
-{%- include formulae.html formula_path=formula_path formulae=conflicts_with_formula description="Conflicts with" -%}
+{%- include formulae.html formulae=conflicts_with_formula description="Conflicts with" -%}
 
 {%- if c.caveats -%}
 {%- capture soft_indent %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -3,9 +3,8 @@ layout: default
 permalink: :title
 ---
 {%- assign full_name = page.title -%}
-{%- assign formula_path = "formula" -%}
 {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-{%- assign f = site.data[formula_path][data_name] -%}
+{%- assign f = site.data.formula[data_name] -%}
 <h2
     {%- if f.disabled %} class="disabled" title="This formula has been disabled since {{ f.disable_date | escape }} because it {{ f.disable_reason | escape }}"
     {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated since {{ f.deprecation_date | escape }} because it {{ f.deprecation_reason | escape }}"
@@ -40,7 +39,7 @@ permalink: :title
 </p>
 {%- endif %}
 
-<p>Formula JSON API: <a href="{{ site.baseurl }}/api/{{ formula_path }}/{{ f.name | uri_escape }}.json"><code>/api/{{ formula_path }}/{{ f.name | escape }}.json</code></a></p>
+<p>Formula JSON API: <a href="{{ site.baseurl }}/api/formula/{{ f.name | uri_escape }}.json"><code>/api/formula/{{ f.name | escape }}.json</code></a></p>
 
 <p>Formula code: <a target="_blank" href="{{ site.taps.core.remote }}/blob/{{ f.tap_git_head | url_encode }}/{{ f.ruby_source_path | uri_escape }}"><code>{{ f.name | escape }}.rb</code></a> on GitHub</p>
 
@@ -116,7 +115,7 @@ permalink: :title
 {%- endif %}
 </table>
 
-{%- include formulae.html formula_path=formula_path formulae=f.versioned_formulae description="Other versions" -%}
+{%- include formulae.html formulae=f.versioned_formulae description="Other versions" -%}
 
 {%- if f.revision > 0 %}
 <p>Revision: <strong>{{ f.revision }}</strong></p>
@@ -138,10 +137,10 @@ permalink: :title
 </table>
 {%- endif -%}
 
-{%- include formulae.html formula_path=formula_path formulae=f.dependencies description="Depends on" -%}
-{%- include formulae.html formula_path=formula_path formulae=f.recommended_dependencies description="Depends on recommended" -%}
-{%- include formulae.html formula_path=formula_path formulae=f.optional_dependencies description="Depends on optionally" -%}
-{%- include formulae.html formula_path=formula_path formulae=f.build_dependencies description="Depends on when building from source" -%}
+{%- include formulae.html formulae=f.dependencies description="Depends on" -%}
+{%- include formulae.html formulae=f.recommended_dependencies description="Depends on recommended" -%}
+{%- include formulae.html formulae=f.optional_dependencies description="Depends on optionally" -%}
+{%- include formulae.html formulae=f.build_dependencies description="Depends on when building from source" -%}
 
 {%- if f.requirements.size > 0 %}
 <p>Requires:
@@ -159,7 +158,7 @@ permalink: :title
                     {{ r.name | capitalize | escape }}
             {%- endcase -%}
         {%- endcapture -%}
-        {%- if r.cask and formula_path == "formula" -%}
+        {%- if r.cask -%}
             {%- unless r.cask contains "/" -%}
                 <a href="{{ site.baseurl }}/cask/{{ r.cask | uri_escape }}">{{ requirement }}</a>
             {%- else -%}
@@ -189,7 +188,7 @@ permalink: :title
 {%- if f.conflicts_with.size > 0 %}
 <p>Conflicts with:
     {%- for c in f.conflicts_with %}
-        <strong><a href="{{ site.baseurl }}/{{ formula_path }}/{{ c | uri_escape }}">{{ c | escape }}</a></strong>
+        <strong><a href="{{ site.baseurl }}/formula/{{ c | uri_escape }}">{{ c | escape }}</a></strong>
         {%- unless forloop.last -%}, {% endunless -%}
     {%- endfor %}
 </p>


### PR DESCRIPTION
The `formula-linux` path has been unused since the linuxbrew merge, so no need to keep this logic around.