### PR TITLE
rework setup of cask includes

### DIFF
--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -1,11 +1,15 @@
 
         <td>
-{%- if site.data.cask[include.sort_key] != nil -%}
-            <a href="{{ site.baseurl }}/cask/{{ include.cask.token | uri_escape }}">{{ include.cask.token | escape }}</a>
+{%- assign include_cdata = site.data.cask[include.data_token] -%}
+{%- if include_cdata != nil -%}
+            <a href="{{ site.baseurl }}/cask/{{ include.token | uri_escape }}">{{ include.token | escape }}</a></td>
+        <td>{{ include_cdata.version | truncate: 25 | escape }}</td>
+        <td>{{ include_cdata.desc | escape }}</td>
+        <td>{{ include_cdata.name.first | escape }}
 {%- else -%}
-            {{ include.cask.token | escape }}
+            {{ include.token | escape }}</td>
+        <td></td>
+        <td></td>
+        <td>
 {%- endif -%}
         </td>
-        <td>{{ include.cask.version | truncate: 25 | escape }}</td>
-        <td>{{ include.cask.desc | escape }}</td>
-        <td>{{ include.cask.name.first | escape }}</td>

--- a/_includes/casks.html
+++ b/_includes/casks.html
@@ -1,10 +1,10 @@
-{%- if include.casks.size > 0 %}
+{%- if include.tokens.size > 0 %}
 <p>{{ include.description }}:</p>
 <table>
-    {%- for token in include.casks -%}
+    {%- for include_token in include.tokens -%}
     <tr>
-        {%- assign cask = site.data.cask[token] -%}
-        {%- include cask.html token=token cask=cask -%}
+        {%- assign include_data_token = include_token | remove: "@" | remove: "." | replace: "+", "_" -%}
+        {%- include cask.html data_token=include_data_token token=include_token -%}
     </tr>
     {%- endfor -%}
 </table>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -2,9 +2,9 @@
 layout: default
 permalink: :title
 ---
-{%- assign full_name = page.title -%}
-{%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-{%- assign c = site.data.cask[data_name] -%}
+{%- assign token = page.title -%}
+{%- assign data_token = token | remove: "@" | remove: "." | replace: "+", "_" -%}
+{%- assign c = site.data.cask[data_token] -%}
 <h2
     {%- if c.disabled %} class="disabled" title="This cask has been disabled since {{ c.disable_date | escape }} because it {{ c.disable_reason | escape }}"
     {%- elsif c.deprecated %} class="deprecated" title="This cask has been deprecated since {{ c.deprecation_date | escape }} because it {{ c.deprecation_reason | escape }}"
@@ -34,7 +34,7 @@ permalink: :title
 <p>Current version: <a href="{{ c.url | escape }}" title="Download for {{ c.token | escape }}">{{ c.version | escape }}</a></p>
 
 {%- if c.depends_on.size > 0 -%}
-    {%- include casks.html casks=c.depends_on.cask description="Depends on casks" -%}
+    {%- include casks.html tokens=c.depends_on.cask description="Depends on casks" -%}
     {%- include formulae.html formulae=c.depends_on.formula description="Depends on" -%}
     {%- assign requirements = "" -%}
     {%- if c.depends_on.macos -%}
@@ -61,10 +61,12 @@ permalink: :title
     {%- endif -%}
 {%- endif -%}
 
-{%- include casks.html casks=c.conflicts_with.cask description="Conflicts with casks" -%}
+{%- if c.conflicts_with.size > 0 -%}
+    {%- include casks.html tokens=c.conflicts_with.cask description="Conflicts with casks" -%}
 
-{%- assign conflicts_with_formula = c.conflicts_with.formula | where_exp: "f", "site.data.formula[f]" -%}
-{%- include formulae.html formulae=conflicts_with_formula description="Conflicts with" -%}
+    {%- assign conflicts_with_formula = c.conflicts_with.formula | where_exp: "f", "site.data.formula[f]" -%}
+    {%- include formulae.html formulae=conflicts_with_formula description="Conflicts with" -%}
+{%- endif -%}
 
 {%- if c.caveats -%}
 {%- capture soft_indent %}
@@ -142,14 +144,14 @@ permalink: :title
     <tr>
         <th colspan="2">Installs ({{ interval.name }})</th>
     </tr>
-    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[full_name] -%}
+    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token] -%}
     <tr>
         <td><code>{{ fa.cask | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
     {%- else -%}
     <tr>
-        <td><code>{{ full_name | escape }}</code></td>
+        <td><code>{{ token | escape }}</code></td>
         <td class="number-data">0</td>
     </tr>
     {%- endfor -%}

--- a/_layouts/cask_json.json
+++ b/_layouts/cask_json.json
@@ -1,27 +1,25 @@
 ---
 ---
-{%- assign full_name = page.name | remove: ".json" -%}
-{%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-{%- assign cask = site.data.cask[data_name] -%}
+{%- assign token = page.name | remove: ".json" -%}
+{%- assign data_token = token | remove: "@" | remove: "." | replace: "+", "_" -%}
+{%- assign cdata = site.data.cask[data_token] -%}
 {
 
-{%- for key_value in cask -%}
+{%- for key_value in cdata -%}
   {{ key_value[0] | jsonify }}:{{ key_value[1] | jsonify }},
 {%- endfor -%}
 
 "analytics":{"install":{
 {%- for interval in site.analytics.intervals -%}
   "{{ interval.path }}":{
-  {%- if site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[full_name].size > 0 -%}
-    {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[full_name] -%}
-      {{ fa.cask | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
-      {%- unless forloop.last -%}
-      ,
-      {%- endunless -%}
-    {%- endfor -%}
+  {%- for fa in site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token] -%}
+    {{ fa.cask | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
+    {%- unless forloop.last -%}
+    ,
+    {%- endunless -%}
   {%- else -%}
-    {{ full_name | jsonify }}:0
-  {%- endif -%}
+    {{ token | jsonify }}:0
+  {%- endfor -%}
   }
   {%- unless forloop.last -%}
   ,

--- a/cask_index.html
+++ b/cask_index.html
@@ -9,11 +9,11 @@ permalink: /cask/
 
 <table>
     {%- assign sorted_casks = site.data.cask | sort -%}
-    {%- for c in sorted_casks -%}
+    {%- for cask in sorted_casks -%}
     <tr>
-        {%- assign sort_key = c[0] -%}
-        {%- assign cask = c[1] -%}
-        {%- include cask.html sort_key=sort_key cask=cask -%}
+        {%- assign data_token = cask[0] -%}
+        {%- assign token = cask[1].token -%}
+        {%- include cask.html data_token=data_token token=token -%}
     </tr>
     {%- endfor -%}
 </table>


### PR DESCRIPTION
This reworks how includes work for cask data (and fixes some missing conflicting cask links) by:

- rewording variables to distinguish between "token/tokens" (cask token strings), "data_token" (cask tokens adjusted to [match Jekyll's sanitization](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/readers/data_reader.rb#L70-L73)), "cask/casks" (full key+value info from site data), and "cdata" or "c" (cask value data whose properties can be fetched with dot notation),
	- variables in includes have "include_" prepended to avoid lurking bugs with (lack of) variable scope
- changing `includes/casks.html` to infer a data_token from each of its passed tokens and pass those to `includes/cask.html`,
- changing `includes/cask.html` to expect a data_token and a token, and do its own cask data retrieval if available. This is because it can be called by either:
  - `/cask_index.html`, which is looping through all the site's cask data, or
  - `includes/casks.html`, which can only provide a token which may or may not be for a cask whose data is in the site, e.g. for a cask page that lists cask dependencies or conflicts not in homebrew/cask.

This also replaces an if…for…else with a simpler [for…else](https://shopify.github.io/liquid/tags/iteration/#else) in `_layouts/cask_json.json`.