### PR TITLE
rework setup of formula includes

### DIFF
--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -1,9 +1,13 @@
 
         <td>
 {%- assign include_cdata = site.data.cask[include.data_token] -%}
-{%- if include_cdata != nil -%}
-            <a href="{{ site.baseurl }}/cask/{{ include.token | uri_escape }}">{{ include.token | escape }}</a></td>
-        <td>{{ include_cdata.version | truncate: 25 | escape }}</td>
+{%- unless include_cdata -%}
+    {%- assign include_data_token = site.data.cask_canonical[include.token] | remove: "@" | remove: "." | replace: "+", "_" -%}
+    {%- assign include_cdata = site.data.cask[include_data_token] -%}
+{%- endunless -%}
+{%- if include_cdata -%}
+            <a href="{{ site.baseurl }}/cask/{{ include_cdata.token | uri_escape }}">{{ include_cdata.token | escape }}</a></td>
+        <td>{{ include_cdata.version | truncate: 20 | escape }}</td>
         <td>{{ include_cdata.desc | escape }}</td>
         <td>{{ include_cdata.name.first | escape }}
 {%- else -%}

--- a/_includes/formula.html
+++ b/_includes/formula.html
@@ -1,8 +1,21 @@
 
-        <td><a href="{{ site.baseurl }}/formula/{{ include.formula.name | uri_escape }}"
-            {%- if include.formula.disabled %} class="disabled" title="This formula has been disabled"
-            {%- elsif include.formula.deprecated %} class="deprecated" title="This formula has been deprecated"
+        <td>
+{%- assign include_fdata = site.data.formula[include.data_fname] -%}
+{%- unless include_fdata -%}
+    {%- assign include_data_fname = site.data.formula_canonical[include.fname] | remove: "@" | remove: "." | replace: "+", "_" -%}
+    {%- assign include_fdata = site.data.formula[include_data_fname] -%}
+{%- endunless -%}
+{%- if include_fdata -%}
+            <a href="{{ site.baseurl }}/formula/{{ include_fdata.name | uri_escape }}"
+            {%- if include_fdata.disabled %} class="disabled" title="This formula has been disabled"
+            {%- elsif include_fdata.deprecated %} class="deprecated" title="This formula has been deprecated"
             {%- endif -%}
-            >{{ include.formula.name | escape }}</a></td>
-        <td>{{ include.formula.versions.stable | escape }}</td>
-        <td>{{ include.formula.desc | escape }}</td>
+            >{{ include_fdata.name | escape }}</a></td>
+        <td>{{ include_fdata.versions.stable | truncate: 20 | escape }}</td>
+        <td>{{ include_fdata.desc | escape }}
+{%- else -%}
+            {{ include.fname | escape }}</td>
+        <td></td>
+        <td>
+{%- endif -%}
+        </td>

--- a/_includes/formulae.html
+++ b/_includes/formulae.html
@@ -1,15 +1,10 @@
-{%- if include.formulae.size > 0 %}
+{%- if include.fnames.size > 0 %}
 <p>{{ include.description }}:</p>
 <table>
-    {%- for full_name in include.formulae -%}
+    {%- for include_fname in include.fnames -%}
     <tr>
-        {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-        {%- assign formula = site.data.formula[data_name] -%}
-        {%- unless formula -%}
-            {%- assign data_name = site.data.formula_canonical[full_name] | remove: "@" | remove: "." | replace: "+", "_" -%}
-            {%- assign formula = site.data.formula[data_name] -%}
-        {%- endunless -%}
-        {%- include formula.html formula=formula -%}
+        {%- assign include_data_fname = include_fname | remove: "@" | remove: "." | replace: "+", "_" -%}
+        {%- include formula.html data_fname=include_data_fname fname=include_fname -%}
     </tr>
     {%- endfor -%}
 </table>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -35,7 +35,7 @@ permalink: :title
 
 {%- if c.depends_on.size > 0 -%}
     {%- include casks.html tokens=c.depends_on.cask description="Depends on casks" -%}
-    {%- include formulae.html formulae=c.depends_on.formula description="Depends on" -%}
+    {%- include formulae.html fnames=c.depends_on.formula description="Depends on" -%}
     {%- assign requirements = "" -%}
     {%- if c.depends_on.macos -%}
         {%- capture requirements -%}
@@ -63,9 +63,7 @@ permalink: :title
 
 {%- if c.conflicts_with.size > 0 -%}
     {%- include casks.html tokens=c.conflicts_with.cask description="Conflicts with casks" -%}
-
-    {%- assign conflicts_with_formula = c.conflicts_with.formula | where_exp: "f", "site.data.formula[f]" -%}
-    {%- include formulae.html formulae=conflicts_with_formula description="Conflicts with" -%}
+    {%- include formulae.html fnames=c.conflicts_with.formula description="Conflicts with" -%}
 {%- endif -%}
 
 {%- if c.caveats -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -2,9 +2,9 @@
 layout: default
 permalink: :title
 ---
-{%- assign full_name = page.title -%}
-{%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-{%- assign f = site.data.formula[data_name] -%}
+{%- assign fname = page.title -%}
+{%- assign data_fname = fname | remove: "@" | remove: "." | replace: "+", "_" -%}
+{%- assign f = site.data.formula[data_fname] -%}
 <h2
     {%- if f.disabled %} class="disabled" title="This formula has been disabled since {{ f.disable_date | escape }} because it {{ f.disable_reason | escape }}"
     {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated since {{ f.deprecation_date | escape }} because it {{ f.deprecation_reason | escape }}"
@@ -115,7 +115,7 @@ permalink: :title
 {%- endif %}
 </table>
 
-{%- include formulae.html formulae=f.versioned_formulae description="Other versions" -%}
+{%- include formulae.html fnames=f.versioned_formulae description="Other versions" -%}
 
 {%- if f.revision > 0 %}
 <p>Revision: <strong>{{ f.revision }}</strong></p>
@@ -137,10 +137,10 @@ permalink: :title
 </table>
 {%- endif -%}
 
-{%- include formulae.html formulae=f.dependencies description="Depends on" -%}
-{%- include formulae.html formulae=f.recommended_dependencies description="Depends on recommended" -%}
-{%- include formulae.html formulae=f.optional_dependencies description="Depends on optionally" -%}
-{%- include formulae.html formulae=f.build_dependencies description="Depends on when building from source" -%}
+{%- include formulae.html fnames=f.dependencies description="Depends on" -%}
+{%- include formulae.html fnames=f.recommended_dependencies description="Depends on recommended" -%}
+{%- include formulae.html fnames=f.optional_dependencies description="Depends on optionally" -%}
+{%- include formulae.html fnames=f.build_dependencies description="Depends on when building from source" -%}
 
 {%- if f.requirements.size > 0 %}
 <p>Requires:
@@ -152,8 +152,6 @@ permalink: :title
                     {{ r.version | escape }}
                 {%- when "macos" or "maximum_macos" -%}
                     macOS
-                {%- when "osxfuse" -%}
-                    FUSE
                 {%- else -%}
                     {{ r.name | capitalize | escape }}
             {%- endcase -%}
@@ -187,8 +185,8 @@ permalink: :title
 
 {%- if f.conflicts_with.size > 0 %}
 <p>Conflicts with:
-    {%- for c in f.conflicts_with %}
-        <strong><a href="{{ site.baseurl }}/formula/{{ c | uri_escape }}">{{ c | escape }}</a></strong>
+    {%- for conflict in f.conflicts_with %}
+        <strong><a href="{{ site.baseurl }}/formula/{{ conflict | uri_escape }}">{{ conflict | escape }}</a></strong>
         {%- unless forloop.last -%}, {% endunless -%}
     {%- endfor %}
 </p>
@@ -216,14 +214,14 @@ permalink: :title
     <tr>
         <th colspan="2">{{ category.name }} ({{ interval.name }})</th>
     </tr>
-    {%- for fa in site.data.analytics[category.path].homebrew-core[interval.path].formulae[full_name] -%}
+    {%- for fa in site.data.analytics[category.path].homebrew-core[interval.path].formulae[fname] -%}
     <tr>
         <td><code>{{ fa.formula | escape }}</code></td>
         <td class="number-data">{{ fa.count }}</td>
     </tr>
     {%- else -%}
     <tr>
-        <td><code>{{ full_name | escape }}</code></td>
+        <td><code>{{ fname | escape }}</code></td>
         <td class="number-data">0</td>
     </tr>
     {%- endfor -%}

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -1,11 +1,11 @@
 ---
 ---
-{%- assign full_name = page.name | remove: ".json" -%}
-{%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-{%- assign formula = site.data.formula[data_name] -%}
+{%- assign fname = page.name | remove: ".json" -%}
+{%- assign data_fname = fname | remove: "@" | remove: "." | replace: "+", "_" -%}
+{%- assign fdata = site.data.formula[data_fname] -%}
 {
 
-{%- for key_value in formula -%}
+{%- for key_value in fdata -%}
   {{ key_value[0] | jsonify }}:{{ key_value[1] | jsonify }},
 {%- endfor -%}
 
@@ -14,16 +14,14 @@
   "{{ category.path | replace: "-", "_" }}":{
   {%- for interval in site.analytics.intervals -%}
     "{{ interval.path }}":{
-    {%- if site.data.analytics[category.path].homebrew-core[interval.path].formulae[full_name].size > 0 -%}
-      {%- for fa in site.data.analytics[category.path].homebrew-core[interval.path].formulae[full_name] -%}
-        {{ fa.formula | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
-        {%- unless forloop.last -%}
-        ,
-        {%- endunless -%}
-      {%- endfor -%}
+    {%- for fa in site.data.analytics[category.path].homebrew-core[interval.path].formulae[fname] -%}
+      {{ fa.formula | jsonify }}:{{ fa.count | remove: "," | plus: 0 }}
+      {%- unless forloop.last -%}
+      ,
+      {%- endunless -%}
     {%- else -%}
-      {{ full_name | jsonify }}:0
-    {%- endif -%}
+      {{ fname | jsonify }}:0
+    {%- endfor -%}
     }
     {%- if category.path == "build-error" -%}
       {%- break -%}

--- a/formula_index.html
+++ b/formula_index.html
@@ -10,10 +10,11 @@ redirect_from: /formula-linux/
 
 <table>
     {%- assign sorted_formulae = site.data.formula | sort -%}
-    {%- for f in sorted_formulae -%}
+    {%- for formula in sorted_formulae -%}
     <tr>
-        {%- assign formula = f[1] -%}
-        {%- include formula.html formula=formula -%}
+        {%- assign data_fname = formula[0] -%}
+        {%- assign fname = formula[1].name -%}
+        {%- include formula.html data_fname=data_fname fname=fname -%}
     </tr>
     {%- endfor -%}
 </table>


### PR DESCRIPTION
These changes mirror those from #1153 for how formulae are handled, and also:
- changes `_layouts/cask.html` so that references to non-core casks in conflicts_with aren't skipped
- adds to `_includes/cask.html` the handling of references to old names of casks (depends on Homebrew/brew#17225)
- drops the number of characters to display of versions to 20
- removes a FUSE requirement reference