### PR TITLE
import & display full deprecate/disable reasons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,26 @@ analytics:
       - name: Build Errors
         path: build-error
 
+# sync with Library/Homebrew/deprecate_disable.rb
+reasons:
+  formula:
+    does_not_build:      "does not build"
+    no_license:          "has no license"
+    repo_archived:       "has an archived upstream repository"
+    repo_removed:        "has a removed upstream repository"
+    unmaintained:        "is not maintained upstream"
+    unsupported:         "is not supported upstream"
+    deprecated_upstream: "is deprecated upstream"
+    versioned_formula:   "is a versioned formula"
+    checksum_mismatch:   "was built with an initially released source file that had a different checksum than the current one"
+  cask:
+    discontinued:             "is discontinued upstream"
+    moved_to_mas:             "is now exclusively distributed on the Mac App Store"
+    no_longer_available:      "is no longer available upstream"
+    no_longer_meets_criteria: "no longer meets the criteria for acceptable casks"
+    unmaintained:             "is not maintained upstream"
+    unsigned:                 "is unsigned or does not meet signature requirements"
+
 logo: /assets/img/homebrew.svg
 
 forkme_nwo: Homebrew/formulae.brew.sh

--- a/_includes/cask.html
+++ b/_includes/cask.html
@@ -6,7 +6,11 @@
     {%- assign include_cdata = site.data.cask[include_data_token] -%}
 {%- endunless -%}
 {%- if include_cdata -%}
-            <a href="{{ site.baseurl }}/cask/{{ include_cdata.token | uri_escape }}">{{ include_cdata.token | escape }}</a></td>
+            <a href="{{ site.baseurl }}/cask/{{ include_cdata.token | uri_escape }}"
+            {%- if include_cdata.disabled %} class="disabled" title="This cask has been disabled"
+            {%- elsif include_cdata.deprecated %} class="deprecated" title="This cask has been deprecated"
+            {%- endif -%}
+            >{{ include_cdata.token | escape }}</a></td>
         <td>{{ include_cdata.version | truncate: 20 | escape }}</td>
         <td>{{ include_cdata.desc | escape }}</td>
         <td>{{ include_cdata.name.first | escape }}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -6,8 +6,8 @@ permalink: :title
 {%- assign data_token = token | remove: "@" | remove: "." | replace: "+", "_" -%}
 {%- assign c = site.data.cask[data_token] -%}
 <h2
-    {%- if c.disabled %} class="disabled" title="This cask has been disabled since {{ c.disable_date | escape }} because it {{ c.disable_reason | escape }}"
-    {%- elsif c.deprecated %} class="deprecated" title="This cask has been deprecated since {{ c.deprecation_date | escape }} because it {{ c.deprecation_reason | escape }}"
+    {%- if c.disabled %} class="disabled" title="This cask has been disabled since {{ c.disable_date | escape }} because it {{ site.reasons.cask[c.disable_reason] | default: c.disable_reason | escape }}"
+    {%- elsif c.deprecated %} class="deprecated" title="This cask has been deprecated since {{ c.deprecation_date | escape }} because it {{ site.reasons.cask[c.deprecation_reason] | default: c.deprecation_reason | escape }}"
     {%- endif -%}
     >
     {{ c.token | escape }}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -6,8 +6,8 @@ permalink: :title
 {%- assign data_fname = fname | remove: "@" | remove: "." | replace: "+", "_" -%}
 {%- assign f = site.data.formula[data_fname] -%}
 <h2
-    {%- if f.disabled %} class="disabled" title="This formula has been disabled since {{ f.disable_date | escape }} because it {{ f.disable_reason | escape }}"
-    {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated since {{ f.deprecation_date | escape }} because it {{ f.deprecation_reason | escape }}"
+    {%- if f.disabled %} class="disabled" title="This formula has been disabled since {{ f.disable_date | escape }} because it {{ site.reasons.formula[f.disable_reason] | default: f.disable_reason | escape }}"
+    {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated since {{ f.deprecation_date | escape }} because it {{ site.reasons.formula[f.deprecation_reason] | default: f.deprecation_reason | escape }}"
     {%- endif -%}
     >
     {{ f.name | escape }}


### PR DESCRIPTION
This adds deprecated/disabled badges lists of casks, and copies over the deprecate/disable reasons from [`deprecate_disable.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/deprecate_disable.rb) and inserts either the full text [corresponding with the reason symbol](https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae#deprecate-and-disable-reasons) into the hovertext or the text from the formula/cask itself if customized.