### PR TITLE
show all former formula names / cask tokens

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -33,6 +33,15 @@ permalink: :title
 
 <p>Current version: <a href="{{ c.url | escape }}" title="Download for {{ c.token | escape }}">{{ c.version | escape }}</a></p>
 
+{%- if c.old_tokens.size > 0 %}
+<p class="oldnames">Former tokens:
+    {%- for oldtoken in c.old_tokens %}
+        <strong>{{ oldtoken | escape }}</strong>
+        {%- unless forloop.last -%}, {% endunless -%}
+    {%- endfor %}
+</p>
+{%- endif %}
+
 {%- if c.depends_on.size > 0 -%}
     {%- include casks.html tokens=c.depends_on.cask description="Depends on casks" -%}
     {%- include formulae.html fnames=c.depends_on.formula description="Depends on" -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -25,8 +25,13 @@ permalink: :title
     {%- endfor %}
 </p>
 {%- endif -%}
-{%- if f.oldname %}
-<p class="oldname">Formerly known as: <strong>{{ f.oldname | escape }}</strong></p>
+{%- if f.oldnames.size > 0 %}
+<p class="oldnames">Formerly known as:
+    {%- for oldname in f.oldnames %}
+        <strong>{{ oldname | escape }}</strong>
+        {%- unless forloop.last -%}, {% endunless -%}
+    {%- endfor %}
+</p>
 {%- endif %}
 <p class="desc">{{ f.desc | escape }}</p>
 <p class="homepage"><a href="{{ f.homepage | escape }}">{{ f.homepage | escape }}</a></p>


### PR DESCRIPTION
Also fixes "odeprecated" being shown instead of old formula name.