### PR TITLE
list cask fonts on separate page

### DIFF
--- a/cask-font_index.html
+++ b/cask-font_index.html
@@ -1,9 +1,9 @@
 ---
 title: homebrew-cask
 layout: default
-permalink: /cask/
+permalink: /cask-font/
 ---
-<p>This is a listing of all casks available from the <a href="{{ site.taps.cask.remote }}">{{ site.taps.cask.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
+<p>This is a listing of all fonts available from the <a href="{{ site.taps.cask.remote }}">{{ site.taps.cask.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>
 
 <h2><a href="{{ site.baseurl }}/api/cask.json"><code>/api/cask.json</code> (JSON API)</a></h2>
 
@@ -11,13 +11,13 @@ permalink: /cask/
     {%- assign sorted_casks = site.data.cask | sort -%}
     {%- for cask in sorted_casks -%}
         {%- assign subfolder = cask[1].ruby_source_path | slice: 6, 4 -%}
-        {%- unless subfolder == "font" -%}
+        {%- if subfolder == "font" -%}
         <tr>
             {%- assign data_token = cask[0] -%}
             {%- assign token = cask[1].token -%}
             {%- include cask.html data_token=data_token token=token -%}
         </tr>
-        {%- endunless -%}
+        {%- endif -%}
     {%- endfor -%}
 </table>
 <footer id="border-no-bottom">Last updated: {{ "today" | date: "%F %R" }}</footer>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@ layout: default
 <p><a href="{{ site.baseurl }}/">Homebrew Formulae</a> is an online package browser for <a href="https://brew.sh">Homebrew</a> – the macOS (and Linux) package manager. For more information on how to install and use Homebrew see <a href="https://brew.sh">our homepage</a>.</p>
 
 <h2><a href="{{ site.baseurl }}/formula/">Browse all formulae</a></h2>
-<h2><a href="{{ site.baseurl }}/cask/">Browse all casks</a></h2>
+<h2><a href="{{ site.baseurl }}/cask/">Browse all casks</a> or <a href="{{ site.baseurl }}/cask-font/">cask fonts</a></h2>
 <h2><a href="{{ site.baseurl }}/analytics/">Analytics data</a></h2>
 <h2><a href="{{ site.baseurl }}/docs/api/">JSON API documentation</a></h2>


### PR DESCRIPTION
Lists any cask fonts on https://formulae.brew.sh/cask-font/. Each font's page is still under /cask/; this just keeps the listing page lengths manageable.