### PR TITLE
Gemfile: use `.ruby-version`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+ruby file: ".ruby-version"
+
 gem "faraday-retry"
 gem "jekyll"
 gem "jekyll-redirect-from"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,5 +117,8 @@ DEPENDENCIES
   jekyll-sitemap
   rake
 
+RUBY VERSION
+   ruby 3.3.1p55
+
 BUNDLED WITH
-   2.4.10
+   2.5.9


### PR DESCRIPTION
This ensures it's used consistently by `bundle`.