### PR TITLE
index: don't allow breaking the line between "cask" and "fonts"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ layout: default
 <p><a href="{{ site.baseurl }}/">Homebrew Formulae</a> is an online package browser for <a href="https://brew.sh">Homebrew</a> – the macOS (and Linux) package manager. For more information on how to install and use Homebrew see <a href="https://brew.sh">our homepage</a>.</p>
 
 <h2><a href="{{ site.baseurl }}/formula/">Browse all formulae</a></h2>
-<h2><a href="{{ site.baseurl }}/cask/">Browse all casks</a> or <a href="{{ site.baseurl }}/cask-font/">cask fonts</a></h2>
+<h2><a href="{{ site.baseurl }}/cask/">Browse all casks</a> or
+    <a href="{{ site.baseurl }}/cask-font/">cask&nbsp;fonts</a></h2>
 <h2><a href="{{ site.baseurl }}/analytics/">Analytics data</a></h2>
 <h2><a href="{{ site.baseurl }}/docs/api/">JSON API documentation</a></h2>


### PR DESCRIPTION
This breaks on my iPhone and it doesn't look that great.