### PR TITLE
workflows/tests: set up Python for new analytics handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,17 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Tap Homebrew/formula-analytics
+        id: tap-formula-analytics
+        run: |
+          brew tap Homebrew/formula-analytics
+          echo "python-version-file=$(brew --repo Homebrew/formula-analytics)/.python-version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        with:
+          python-version-file: ${{ steps.tap-formula-analytics.outputs.python-version-file }}
+
       - name: Create directories
         run: mkdir -p _data/analytics api/analytics
 


### PR DESCRIPTION
Python will become a dependency in https://github.com/Homebrew/homebrew-formula-analytics/pull/458.

CI in this PR here will fail until the other PR is merged, and once that other PR is merged then scheduled CI in this repo will start failing until this PR is merged.