### PR TITLE
Add more analytics pages for command options and test bot events

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -28,6 +28,10 @@ layout: base
             Version
     {%- when "brew-command-run" -%}
             Command
+    {%- when "brew-command-run-options" -%}
+            Command
+    {%- when "brew-test-bot-test" -%}
+            Command
     {%- when "cask-install" -%}
             Cask
     {%- else -%}
@@ -51,6 +55,10 @@ layout: base
             <code>{{ item.prefix | escape }}</code>
     {%- elsif page.category == "brew-command-run" -%}
             <code>{{ item.command_run | escape }}</code>
+    {%- elsif page.category == "brew-command-run-options" -%}
+            <code>{{ item.command_run_options | escape }}</code>
+    {%- elsif page.category == "brew-test-bot-test" -%}
+            <code>{{ item.test_bot_test | escape }}</code>
     {%- elsif page.category == "homebrew-versions" -%}
             <code>{{ item.version | escape }}</code>
     {%- elsif page.category == "cask-install" -%}

--- a/analytics/brew-command-run-options/30d/index.html
+++ b/analytics/brew-command-run-options/30d/index.html
@@ -1,0 +1,8 @@
+---
+title: Homebrew Analytics Commands and Options (30 days)
+layout: analytics
+days: 30d
+category: brew-command-run-options
+category_pretty: Homebrew Commands and Options
+redirect_from: /analytics/brew-command-run-options/
+---

--- a/analytics/brew-command-run-options/365d/index.html
+++ b/analytics/brew-command-run-options/365d/index.html
@@ -1,0 +1,7 @@
+---
+title: Homebrew Analytics Commands and Options (365 days)
+layout: analytics
+days: 365d
+category: brew-command-run-options
+category_pretty: Homebrew Commands and Options
+---

--- a/analytics/brew-command-run-options/90d/index.html
+++ b/analytics/brew-command-run-options/90d/index.html
@@ -1,0 +1,7 @@
+---
+title: Homebrew Analytics Commands and Options (90 days)
+layout: analytics
+days: 90d
+category: brew-command-run-options
+category_pretty: Homebrew Commands and Options
+---

--- a/analytics/brew-test-bot-test/30d/index.html
+++ b/analytics/brew-test-bot-test/30d/index.html
@@ -1,0 +1,8 @@
+---
+title: Homebrew Analytics Core Test Bot Events (30 days)
+layout: analytics
+days: 30d
+category: brew-test-bot-test
+category_pretty: Homebrew Core Test Bot Events
+redirect_from: /analytics/brew-command-run/
+---

--- a/analytics/brew-test-bot-test/365d/index.html
+++ b/analytics/brew-test-bot-test/365d/index.html
@@ -1,0 +1,7 @@
+---
+title: Homebrew Analytics Core Test Bot Events (365 days)
+layout: analytics
+days: 365d
+category: brew-test-bot-test
+category_pretty: Homebrew Core Test Bot Events
+---

--- a/analytics/brew-test-bot-test/90d/index.html
+++ b/analytics/brew-test-bot-test/90d/index.html
@@ -1,0 +1,7 @@
+---
+title: Homebrew Analytics Core Test Bot Events (90 days)
+layout: analytics
+days: 90d
+category: brew-test-bot-test
+category_pretty: Homebrew Core Test Bot Events
+---

--- a/analytics/index.md
+++ b/analytics/index.md
@@ -66,6 +66,18 @@ redirect_from: /analytics-linux/
         <td><a href="{{ site.baseurl }}/analytics/brew-command-run/365d/">365 days</a></td>
     </tr>
     <tr>
+        <td>Homebrew Command and Options Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/brew-command-run-options/30d/">30 days</a></td>
+        <td><a href="{{ site.baseurl }}/analytics/brew-command-run-options/90d/">90 days</a></td>
+        <td><a href="{{ site.baseurl }}/analytics/brew-command-run-options/365d/">365 days</a></td>
+    </tr>
+    <tr>
+        <td>Homebrew Core Test Bot Events</td>
+        <td><a href="{{ site.baseurl }}/analytics/brew-test-bot-test/30d/">30 days</a></td>
+        <td><a href="{{ site.baseurl }}/analytics/brew-test-bot-test/90d/">90 days</a></td>
+        <td><a href="{{ site.baseurl }}/analytics/brew-test-bot-test/365d/">365 days</a></td>
+    </tr>
+    <tr>
         <td><code>/api/analytics/install/homebrew-core/${DAYS}.json</code> (JSON API)</td>
         <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/30d.json">30 days</a></td>
         <td><a href="{{ site.baseurl }}/api/analytics/install/homebrew-core/90d.json">90 days</a></td>


### PR DESCRIPTION
As-of https://github.com/Homebrew/homebrew-formula-analytics/pull/465 we now generate data for these events so let's add pages for them too.