### PR TITLE
workflows/tests: use `create-or-update-issue` action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,33 +247,19 @@ jobs:
       ]
     if: ${{ always() && github.ref_name == 'master' }}
     env:
-      GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-      REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Find existing deploy failure issue
-        run: |
-          EXISTING_ISSUE=$(gh issue list --repo "$REPO" --author BrewTestBot --label 'deploy failure' | awk '{print $1}')
-          echo "EXISTING_ISSUE=$EXISTING_ISSUE" >> $GITHUB_ENV
-          echo "WORKFLOW_URL=https://github.com/Homebrew/formulae.brew.sh/actions/runs/$RUN_ID" >> $GITHUB_ENV
-        env:
-          RUN_ID: ${{ github.run_id }}
-      - name: Report deploy failure
-        if: ${{ contains(needs.*.result, 'failure') }}
-        run: |
-          ISSUE_TITLE="formulae.brew.sh deployment failed!"
-          ISSUE_BODY="The most recent [formulae.brew.sh deployment failed]($WORKFLOW_URL)."
-          if [ -n "$EXISTING_ISSUE" ]; then
-            gh issue edit "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$ISSUE_BODY")"
-          else
-            gh issue create --repo "$REPO" --title "$ISSUE_TITLE" --label "deploy failure" --body "$(echo -e "$ISSUE_BODY")"
-          fi
-      - name: Report deploy success
-        if: ${{ needs.deploy.result == 'success' }}
-        run: |
-          COMMENT_BODY="The most recent [formulae.brew.sh deployment succeeded]($WORKFLOW_URL). Closing issue."
-          if [ -n "$EXISTING_ISSUE" ]; then
-            gh issue comment "$EXISTING_ISSUE" --repo "$REPO" --body "$(echo -e "$COMMENT_BODY")"
-            gh issue close "$EXISTING_ISSUE" --repo "$REPO"
-          fi
+      - name: Open, update, or close deploy issue
+        uses: Homebrew/actions/create-or-update-issue@master
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          repository: ${{ github.repository }}
+          title: formulae.brew.sh deployment failed!
+          body: The most recent [formulae.brew.sh deployment failed](${{ env.RUN_URL }}).
+          labels: deploy failure
+          update-existing: ${{ contains(needs.*.result, 'failure') }}
+          close-existing: ${{ needs.deploy.result == 'success' }}
+          close-from-author: BrewTestBot
+          close-comment: The most recent [formulae.brew.sh deployment succeeded](${{ env.RUN_URL }}). Closing issue.


### PR DESCRIPTION
This was added in Homebrew/actions#588. It simplifies the workflow, and reduces the number of API calls.
