### PR TITLE
ci: use ubuntu-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
   generate-analytics:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate analytics data
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out repository
@@ -139,7 +139,7 @@ jobs:
   generate-samples:
     if: startsWith( github.repository, 'Homebrew/' )
     name: Generate API samples
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out repository
@@ -172,7 +172,7 @@ jobs:
 
   build:
     needs: [generate-cask, generate-core, generate-analytics, generate-samples]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Set up Git repository


### PR DESCRIPTION
Align CI setup with what has been done in https://github.com/Homebrew/brew/pull/18704
Use ubuntu-latest when the ubuntu version does not matter.
ubuntu-latest is equivalent to 22.04 right now so this does not change anything