### PR TITLE
Revert JSON v3 logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json cask/ api/internal/v3/homebrew-cask.json
+        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json cask/
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
@@ -76,7 +76,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-core.tar.gz _data/formula/ _data/formula_canonical.json api/formula/ api/formula_tap_migrations.json formula/ api/internal/v3/homebrew-core.json
+        run: tar czvf data-core.tar.gz _data/formula/ _data/formula_canonical.json api/formula/ api/formula_tap_migrations.json formula/
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:

--- a/script/sign-json.rb
+++ b/script/sign-json.rb
@@ -17,8 +17,6 @@ PRIVATE_KEY = OpenSSL::PKey::RSA.new(ENV.fetch("JWS_SIGNING_KEY")).freeze
   ROOT/"_site/api/cask.json",
   ROOT/"_site/api/formula_tap_migrations.json",
   ROOT/"_site/api/cask_tap_migrations.json",
-  ROOT/"_site/api/internal/v3/homebrew-core.json",
-  ROOT/"_site/api/internal/v3/homebrew-cask.json",
 ].each do |path|
   data_string = path.read
 


### PR DESCRIPTION
This hasn't been used in a around 8 months since the approach didn't work as well as we initially hoped so we're removing it per https://github.com/Homebrew/brew/issues/19204#issuecomment-2636151650.

It should be safe to just remove this since it means that we're not archiving some generated files and not signing the files that are no longer being archived. In a follow-up PR, I'll remove the generation logic for the JSON files that no longer need to be updated from the main Brew repo.

This PR essentially reverts the following 2 commits:
- 439c237b18ff6e078e22d119b02f5ed73e59ec0b
- 8e4d93474ec9a711d9d6fb47c5255bc1519ab6ae

Related Links:
- New approach: https://github.com/Homebrew/brew/issues/19204
- Old approach: https://github.com/Homebrew/brew/issues/16410

CC: @Rylan12 since you might want to add some logic like this in the future to sign other JSON files.