### PR TITLE
Idea: show recommended replacement

### DIFF
--- a/_includes/replacement.html
+++ b/_includes/replacement.html
@@ -1,0 +1,1 @@
+<p class="recommended-replacement">Recommended replacement: <strong><a href="{{ site.baseurl }}/{{ include.r_type }}/{{ include.item | uri_escape }}">{{ include.item | escape }}</a></strong></p>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -16,6 +16,12 @@ permalink: :title
     {%- endif -%}
 </h2>
 
+{%- if c.disable_replacement %}
+{%- include replacement.html item=c.disable_replacement r_type="cask" %}
+{%- elsif c.deprecation_replacement %}
+{%- include replacement.html item=c.deprecation_replacement r_type="cask" %}
+{%- endif %}
+
 {%- include install_command.html item=c.token modifier=" --cask" %}
 <p class="names">Name{%- if c.name.size > 1 -%}s{%- endif -%}:
 {%- for name in c.name %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -16,6 +16,12 @@ permalink: :title
     {%- endif -%}
 </h2>
 
+{%- if f.disable_replacement %}
+{%- include replacement.html item=f.disable_replacement r_type="formula" %}
+{%- elsif f.deprecation_replacement %}
+{%- include replacement.html item=f.deprecation_replacement r_type="formula" %}
+{%- endif %}
+
 {%- include install_command.html item=f.name %}
 {%- if f.aliases.size > 0 %}
 <p class="aliases">Also known as:


### PR DESCRIPTION
It would be nice to show what people can use instead of disabled/deprecated package.

Unfortunately I cannot test changes locally (`rake generate` throws `Error: No InfluxDB credentials found in HOMEBREW_INFLUXDB_TOKEN!`, `bundle install` needs different Ruby version: `Your Ruby version is 3.4.2, but your Gemfile specified 3.3.7`)

It would be nice to add styles to `<hr/>` tag