### PR TITLE
formula.html: do not separate bottle groups without bottles

### DIFF
--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -101,7 +101,9 @@ permalink: :title
         </tr>
         {%- endif -%}
     {%- endfor %}
+    {%- if arm64_bottle_count > 0 and intel_bottle_count > 0 %}
     <tr><th colspan="3"></th></tr>
+    {%- endif %}
     {%- assign subsequent = false -%}
     {%- for b in f.bottle.stable.files -%}
         {%- unless b[0] contains "arm64_" %}
@@ -120,7 +122,10 @@ permalink: :title
         </tr>
         {%- endunless -%}
     {%- endfor -%}
+    {%- assign macos_bottle_count = arm64_bottle_count | plus: intel_bottle_count %}
+    {%- if macos_bottle_count > 0 and linux_bottle_count > 0 %}
     <tr><th colspan="3"></th></tr>
+    {%- endif %}
     {%- assign subsequent = false -%}
     {%- for b in f.bottle.stable.files -%}
         {%- if b[0] contains "_linux" %}


### PR DESCRIPTION
Right now `Bottle` section has separating `<tr>` tags regardless of existing bottles. Examples:

Only Linux bottles:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/1603679f-a1d3-4ef5-8186-f8f6580102f2" />

Only ARM macOS bottles:
<img width="495" alt="image" src="https://github.com/user-attachments/assets/949cd69f-b00f-4f3a-aa1e-0d2c6e1348f5" />

Only macOS (Intel + ARM) bottles:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/ab784731-6d8d-42f9-a195-838727f3292c" />

This PR fixes it (same pages in the respective order):
<img width="500" alt="image" src="https://github.com/user-attachments/assets/445fc7d9-ec9f-4814-a940-8d106ef6a3fc" />

<img width="501" alt="image" src="https://github.com/user-attachments/assets/76f8e2c6-aa36-4ffe-b7af-008d2b203a7e" />

<img width="488" alt="image" src="https://github.com/user-attachments/assets/72460c80-3b11-4801-a395-1baed79beac1" />
