### PR TITLE
formula/cask pages: show future EOL dates

### DIFF
--- a/_includes/attribute.html
+++ b/_includes/attribute.html
@@ -1,0 +1,2 @@
+
+<p>{{ include.key }}: <strong>{{ include.value | escape }}</strong></p>

--- a/_includes/replacement.html
+++ b/_includes/replacement.html
@@ -1,1 +1,2 @@
+
 <p class="recommended-replacement">Recommended replacement: <strong><a href="{{ site.baseurl }}/{{ include.r_type }}/{{ include.item | uri_escape }}">{{ include.item | escape }}</a></strong></p>

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -45,39 +45,41 @@ layout: base
     <tr>
         <td class="number-data">#{{ item.number }}</td>
         <td>
-    {%- if page.category == "os-version" -%}
-            <code>{{ item.os_version | escape }}</code>
-    {%- elsif page.category == "homebrew-devcmdrun-developer" -%}
-            <code>{{ item.devcmdrun_developer | escape }}</code>
-    {%- elsif page.category == "homebrew-os-arch-ci" -%}
-            <code>{{ item.os_arch_ci | escape }}</code>
-    {%- elsif page.category == "homebrew-prefixes" -%}
-            <code>{{ item.prefix | escape }}</code>
-    {%- elsif page.category == "brew-command-run" -%}
-            <code>{{ item.command_run | escape }}</code>
-    {%- elsif page.category == "brew-command-run-options" -%}
-            <code>{{ item.command_run_options | escape }}</code>
-    {%- elsif page.category == "brew-test-bot-test" -%}
-            <code>{{ item.test_bot_test | escape }}</code>
-    {%- elsif page.category == "homebrew-versions" -%}
-            <code>{{ item.version | escape }}</code>
-    {%- elsif page.category == "cask-install" -%}
-        {%- assign data_name = item.cask | remove: "@" | remove: "." | replace: "+", "_" -%}
-        {%- if site.data.cask[data_name] != nil -%}
-            <a href="{{ site.baseurl }}/cask/{{ item.cask | uri_escape }}"><code>{{ item.cask | escape }}</code></a>
+    {%- case page.category -%}
+        {%- when "os-version" -%}
+                <code>{{ item.os_version | escape }}</code>
+        {%- when "homebrew-devcmdrun-developer" -%}
+                <code>{{ item.devcmdrun_developer | escape }}</code>
+        {%- when "homebrew-os-arch-ci" -%}
+                <code>{{ item.os_arch_ci | escape }}</code>
+        {%- when "homebrew-prefixes" -%}
+                <code>{{ item.prefix | escape }}</code>
+        {%- when "homebrew-versions" -%}
+                <code>{{ item.version | escape }}</code>
+        {%- when "brew-command-run" -%}
+                <code>{{ item.command_run | escape }}</code>
+        {%- when "brew-command-run-options" -%}
+                <code>{{ item.command_run_options | escape }}</code>
+        {%- when "brew-test-bot-test" -%}
+                <code>{{ item.test_bot_test | escape }}</code>
+        {%- when "cask-install" -%}
+            {%- assign data_token = item.cask | remove: "@" | remove: "." | replace: "+", "_" -%}
+            {%- assign cdata = site.data.cask[data_token] -%}
+            {%- if cdata and cdata.token == item.cask -%}
+                <a href="{{ site.baseurl }}/cask/{{ item.cask | uri_escape }}"><code>{{ item.cask | escape }}</code></a>
+            {%- else -%}
+                <code>{{ item.cask | escape }}</code>
+            {%- endif -%}
         {%- else -%}
-            <code>{{ item.cask | escape }}</code>
-        {%- endif -%}
-    {%- else -%}
-        {%- assign full_name = item.formula | split: " " | first -%}
-        {%- assign data_name = full_name | remove: "@" | remove: "." | replace: "+", "_" -%}
-        {%- assign formula = site.data.formula[data_name] -%}
-        {%- if full_name == formula.name -%}
-            <a href="{{ site.baseurl }}/formula/{{ full_name | uri_escape }}"><code>{{ item.formula | escape }}</code></a>
-        {%- else -%}
-            <code>{{ item.formula | escape }}</code>
-        {%- endif -%}
-    {%- endif -%}
+            {%- assign fname = item.formula | split: " " | first -%}
+            {%- assign data_fname = fname | remove: "@" | remove: "." | replace: "+", "_" -%}
+            {%- assign fdata = site.data.formula[data_fname] -%}
+            {%- if fdata and fdata.name == fname -%}
+                <a href="{{ site.baseurl }}/formula/{{ fname | uri_escape }}"><code>{{ item.formula | escape }}</code></a>
+            {%- else -%}
+                <code>{{ item.formula | escape }}</code>
+            {%- endif -%}
+    {%- endcase -%}
         </td>
         <td class="number-data">{{ item.count }}</td>
         <td class="number-data">{{ item.percent }}%</td>

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -7,7 +7,7 @@ permalink: :title
 {%- assign c = site.data.cask[data_token] -%}
 <h2
     {%- if c.disabled %} class="disabled" title="This cask has been disabled since {{ c.disable_date | escape }} because it {{ site.reasons.cask[c.disable_reason] | default: c.disable_reason | escape }}"
-    {%- elsif c.deprecated %} class="deprecated" title="This cask has been deprecated since {{ c.deprecation_date | escape }} because it {{ site.reasons.cask[c.deprecation_reason] | default: c.deprecation_reason | escape }}"
+    {%- elsif c.deprecated %} class="deprecated" title="This cask has been deprecated{% if c.deprecation_date %} since {{ c.deprecation_date | escape }}{% endif %} because it {{ site.reasons.cask[c.deprecation_reason] | default: c.deprecation_reason | escape }}"
     {%- endif -%}
     >
     {{ c.token | escape }}
@@ -41,8 +41,9 @@ permalink: :title
 {%- endif %}
 <p class="homepage"><a href="{{ c.homepage | escape }}">{{ c.homepage | escape }}</a></p>
 
-<p><a href="{{ site.baseurl }}/api/cask/{{ c.token | uri_escape }}.json"><code>/api/cask/{{ c.token | escape }}.json</code> (JSON API)</a></p>
-<p><a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ c.tap_git_head | url_encode }}/{{ c.ruby_source_path | uri_escape }}">Cask code</a> on GitHub</p>
+<p>Cask JSON API: <a href="{{ site.baseurl }}/api/cask/{{ c.token | uri_escape }}.json"><code>/api/cask/{{ c.token | escape }}.json</code></a></p>
+
+<p>Cask code: <a target="_blank" href="{{ site.taps.cask.remote }}/blob/{{ c.tap_git_head | url_encode }}/{{ c.ruby_source_path | uri_escape }}"><code>{{ c.token | escape }}.rb</code></a> on GitHub</p>
 
 <p>Current version: <a href="{{ c.url | escape }}" title="Download for {{ c.token | escape }}">{{ c.version | escape }}</a></p>
 
@@ -57,7 +58,7 @@ permalink: :title
 
 {%- if c.depends_on.size > 0 -%}
     {%- include casks.html tokens=c.depends_on.cask description="Depends on casks" -%}
-    {%- include formulae.html fnames=c.depends_on.formula description="Depends on" -%}
+    {%- include formulae.html fnames=c.depends_on.formula description="Depends on formulae" -%}
     {%- assign requirements = "" -%}
     {%- if c.depends_on.macos -%}
         {%- capture requirements -%}
@@ -79,13 +80,13 @@ permalink: :title
         {%- endcapture -%}
     {%- endif -%}
     {%- if requirements.size > 0 %}
-<p>Requires: {{ requirements }}</p>
+<p>Current version requires: {{ requirements }}</p>
     {%- endif -%}
 {%- endif -%}
 
 {%- if c.conflicts_with.size > 0 -%}
     {%- include casks.html tokens=c.conflicts_with.cask description="Conflicts with casks" -%}
-    {%- include formulae.html fnames=c.conflicts_with.formula description="Conflicts with" -%}
+    {%- include formulae.html fnames=c.conflicts_with.formula description="Conflicts with formulae" -%}
 {%- endif -%}
 
 {%- if c.caveats -%}
@@ -112,7 +113,7 @@ permalink: :title
     {%- endif -%}
 {%- endfor %}
 
-<p>Variations:</p>
+<p>Versions:</p>
 <table class="full-width">
     {%- assign subsequent = false -%}
     {%- for variation in c.variations -%}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -16,11 +16,18 @@ permalink: :title
     {%- endif -%}
 </h2>
 
-{%- if c.disable_replacement %}
-{%- include replacement.html item=c.disable_replacement r_type="cask" %}
-{%- elsif c.deprecation_replacement %}
-{%- include replacement.html item=c.deprecation_replacement r_type="cask" %}
-{%- endif %}
+{%- if c.deprecated == false and c.deprecation_date -%}
+    {%- include attribute.html key="Deprecation date" value=c.deprecation_date -%}
+{%- endif -%}
+{%- if c.disabled == false and c.disable_date -%}
+    {%- include attribute.html key="Disable date" value=c.disable_date -%}
+{%- endif -%}
+
+{%- if c.disable_replacement -%}
+    {%- include replacement.html item=c.disable_replacement r_type="cask" -%}
+{%- elsif c.deprecation_replacement -%}
+    {%- include replacement.html item=c.deprecation_replacement r_type="cask" -%}
+{%- endif -%}
 
 {%- include install_command.html item=c.token modifier=" --cask" %}
 <p class="names">Name{%- if c.name.size > 1 -%}s{%- endif -%}:

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -16,11 +16,18 @@ permalink: :title
     {%- endif -%}
 </h2>
 
-{%- if f.disable_replacement %}
-{%- include replacement.html item=f.disable_replacement r_type="formula" %}
-{%- elsif f.deprecation_replacement %}
-{%- include replacement.html item=f.deprecation_replacement r_type="formula" %}
-{%- endif %}
+{%- if f.deprecated == false and f.deprecation_date -%}
+    {%- include attribute.html key="Deprecation date" value=f.deprecation_date -%}
+{%- endif -%}
+{%- if f.disabled == false and f.disable_date -%}
+    {%- include attribute.html key="Disable date" value=f.disable_date -%}
+{%- endif -%}
+
+{%- if f.disable_replacement -%}
+    {%- include replacement.html item=f.disable_replacement r_type="formula" -%}
+{%- elsif f.deprecation_replacement -%}
+    {%- include replacement.html item=f.deprecation_replacement r_type="formula" -%}
+{%- endif -%}
 
 {%- include install_command.html item=f.name %}
 {%- if f.aliases.size > 0 %}
@@ -162,8 +169,8 @@ permalink: :title
 
 {%- include formulae.html fnames=f.versioned_formulae description="Other versions" -%}
 
-{%- if f.revision > 0 %}
-<p>Revision: <strong>{{ f.revision }}</strong></p>
+{%- if f.revision > 0 -%}
+    {%- include attribute.html key="Revision" value=f.revision -%}
 {%- endif -%}
 
 {%- if f.keg_only %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -7,7 +7,7 @@ permalink: :title
 {%- assign f = site.data.formula[data_fname] -%}
 <h2
     {%- if f.disabled %} class="disabled" title="This formula has been disabled since {{ f.disable_date | escape }} because it {{ site.reasons.formula[f.disable_reason] | default: f.disable_reason | escape }}"
-    {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated since {{ f.deprecation_date | escape }} because it {{ site.reasons.formula[f.deprecation_reason] | default: f.deprecation_reason | escape }}"
+    {%- elsif f.deprecated %} class="deprecated" title="This formula has been deprecated{% if f.deprecation_date %} since {{ f.deprecation_date | escape }}{% endif %} because it {{ site.reasons.formula[f.deprecation_reason] | default: f.deprecation_reason | escape }}"
     {%- endif -%}
     >
     {{ f.name | escape }}
@@ -48,6 +48,7 @@ permalink: :title
 {%- endif %}
 <p class="desc">{{ f.desc | escape }}</p>
 <p class="homepage"><a href="{{ f.homepage | escape }}">{{ f.homepage | escape }}</a></p>
+
 {%- if f.license.size > 0 %}
 <p>License:
     {%- for license in f.license %}


### PR DESCRIPTION
Adds displaying of future EOL dates if known. Fixes #1776. Examples: https://formulae.brew.sh/cask/mumble@snapshot, https://formulae.brew.sh/formula/go-boring

Also threw in some layout fixes & improvements I had on hand.