### PR TITLE
recommended replacement: adjust to new API

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -23,10 +23,14 @@ permalink: :title
     {%- include attribute.html key="Disable date" value=c.disable_date -%}
 {%- endif -%}
 
-{%- if c.disable_replacement -%}
-    {%- include replacement.html item=c.disable_replacement r_type="cask" -%}
-{%- elsif c.deprecation_replacement -%}
-    {%- include replacement.html item=c.deprecation_replacement r_type="cask" -%}
+{%- if c.disable_replacement_formula -%}
+    {%- include replacement.html item=c.disable_replacement_formula r_type="formula" -%}
+{%- elsif c.disable_replacement_cask -%}
+    {%- include replacement.html item=c.disable_replacement_cask r_type="cask" -%}
+{%- elsif c.deprecation_replacement_formula -%}
+    {%- include replacement.html item=c.deprecation_replacement_formula r_type="formula" -%}
+{%- elsif c.deprecation_replacement_cask -%}
+    {%- include replacement.html item=c.deprecation_replacement_cask r_type="cask" -%}
 {%- endif -%}
 
 {%- include install_command.html item=c.token modifier=" --cask" %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -23,10 +23,14 @@ permalink: :title
     {%- include attribute.html key="Disable date" value=f.disable_date -%}
 {%- endif -%}
 
-{%- if f.disable_replacement -%}
-    {%- include replacement.html item=f.disable_replacement r_type="formula" -%}
-{%- elsif f.deprecation_replacement -%}
-    {%- include replacement.html item=f.deprecation_replacement r_type="formula" -%}
+{%- if f.disable_replacement_formula -%}
+    {%- include replacement.html item=f.disable_replacement_formula r_type="formula" -%}
+{%- elsif f.disable_replacement_cask -%}
+    {%- include replacement.html item=f.disable_replacement_cask r_type="cask" -%}
+{%- elsif f.deprecation_replacement_formula -%}
+    {%- include replacement.html item=f.deprecation_replacement_formula r_type="formula" -%}
+{%- elsif f.deprecation_replacement_cask -%}
+    {%- include replacement.html item=f.deprecation_replacement_cask r_type="cask" -%}
 {%- endif -%}
 
 {%- include install_command.html item=f.name %}


### PR DESCRIPTION
In new version of Homebrew there's no `disable_replacement` and `deprecation_replacement` but separate fields for casks and formulae