### PR TITLE
Sign `api/internal` API files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json cask/
+        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json api/internal/cask.* cask/
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -76,7 +76,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-core.tar.gz _data/formula/ _data/formula_canonical.json api/formula/ api/formula_tap_migrations.json formula/
+        run: tar czvf data-core.tar.gz _data/formula/ _data/formula_canonical.json api/formula/ api/formula_tap_migrations.json api/internal/formula.* formula/
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/script/sign-json.rb
+++ b/script/sign-json.rb
@@ -17,6 +17,7 @@ PRIVATE_KEY = OpenSSL::PKey::RSA.new(ENV.fetch("JWS_SIGNING_KEY")).freeze
   ROOT/"_site/api/cask.json",
   ROOT/"_site/api/formula_tap_migrations.json",
   ROOT/"_site/api/cask_tap_migrations.json",
+  *(ROOT/"_site/api/internal").glob("*.json"),
 ].each do |path|
   data_string = path.read
 


### PR DESCRIPTION
See https://github.com/Homebrew/brew/pull/20038

Since these are meant to eventually replace the `{formula,cask}.jws.json` files, they should also be signed. Unless there's a reason not to, I figure we may as well set that up now.

This is marked as a draft until https://github.com/Homebrew/brew/pull/20038 is merged.
