### PR TITLE
Don't generate API samples for Dependabot updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,6 +179,7 @@ jobs:
 
       - name: Generate API samples
         run: /usr/bin/rake api_samples
+        if: github.ref_name == 'master' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]')
 
       - name: Build site
         run: bundle exec jekyll build


### PR DESCRIPTION
See https://github.com/Homebrew/formulae.brew.sh/pull/1911

We don't generate the analytics API data for dependabot PRs, so we can't generate the API samples either. This PR gates the API sample generation by the same condition used to generate the analytics API data and sign the API files.
