### PR TITLE
Generate template API samples for Dependabot updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,9 +177,17 @@ jobs:
           tar xvf data-cask/data-cask.tar.gz
           tar xvf data-core/data-core.tar.gz
 
+      - name: Check whether to generate the entire API
+        id: check
+        run: echo "generate-entire-api=${{ github.ref_name == 'master' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]') }}" >> "$GITHUB_OUTPUT"
+
       - name: Generate API samples
-        run: /usr/bin/rake api_samples
-        if: github.ref_name == 'master' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]')
+        run: |
+          if [ "${{ steps.check.outputs.generate-entire-api }}" = "true" ]; then
+            /usr/bin/rake "api_samples"
+          else
+            /usr/bin/rake "api_samples[template]"
+          fi
 
       - name: Build site
         run: bundle exec jekyll build
@@ -188,7 +196,7 @@ jobs:
         run: ./script/validate-build.rb
 
       - name: Sign API
-        if: github.ref_name == 'master' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: steps.check.outputs.generate-entire-api == 'true'
         env:
           JWS_SIGNING_KEY_ID: homebrew-1
           JWS_SIGNING_KEY: ${{ secrets.JWS_HOMEBREW_1 }}

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,9 @@ end
 CLOBBER.include FileList[%w[_data/analytics api/analytics]]
 
 desc "Update API samples"
-task :api_samples do
-  sh "ruby", "script/generate-api-samples.rb"
+task :api_samples, [:options] do |_, args|
+  generate_args = %w[ruby script/generate-api-samples.rb]
+  generate_args << "--template" if args.options == "template"
+  sh(*generate_args)
 end
 CLOBBER.include FileList[%w[_includes/api-samples]]


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/formulae.brew.sh/pull/1913

When the API samples aren't generated, we still need the templated versions for testing purposes
