### PR TITLE
Don't open multiple build failure issues upon workflow cancellation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -246,7 +246,7 @@ jobs:
           title: formulae.brew.sh deployment failed!
           body: The most recent [formulae.brew.sh deployment failed](${{ env.RUN_URL }}).
           labels: deploy failure
-          update-existing: ${{ contains(needs.*.result, 'failure') }}
+          update-existing: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
           close-existing: ${{ needs.deploy.result == 'success' }}
           close-from-author: github-actions[bot]
           close-comment: The most recent [formulae.brew.sh deployment succeeded](${{ env.RUN_URL }}). Closing issue.


### PR DESCRIPTION
If the scheduled generation workflow fails, it opens an issue. If there are more failures, it adds additional comments to the same issue.

However, if a job is cancelled (either manually or if superseded by a new instance), a new issue is opened instead of commenting on the existing issue.

This is because the `Homebrew/actions/create-or-update-issue` action sets `update-existing` if there is a failed job. If the jobs are cancelled and there is no failure, then `update-existing` is false, meaning a new issue is opened.

Instead, set `update-existing` to true if any job has failed, was cancelled, or was skipped. That way, we will only get one issue at a time.

This was done and tested in rubydoc.brew.sh:
- https://github.com/Homebrew/rubydoc.brew.sh/pull/779
- https://github.com/Homebrew/rubydoc.brew.sh/issues/780