### PR TITLE
Use renamed `docker-desktop` cask for API samples

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -48,11 +48,11 @@ curl https://formulae.brew.sh/api/cask/${CASK}.json
 
 **Variables:**
 
-- `${CASK}`: the name of the cask, e.g. `docker`
+- `${CASK}`: the name of the cask, e.g. `docker-desktop`
 
 **[Response](https://formulae.brew.sh/api/cask/docker.json):**
 
-{% include api-samples/cask_docker.md %}
+{% include api-samples/cask_docker_desktop.md %}
 
 ## Analytics
 

--- a/script/generate-api-samples.rb
+++ b/script/generate-api-samples.rb
@@ -12,7 +12,7 @@ SAMPLES = {
   analytics_cask_install_homebrew_cask_30d: "analytics/cask-install/homebrew-cask/30d.json",
   analytics_install_30d:                    "analytics/install/30d.json",
   analytics_install_homebrew_core_30d:      "analytics/install/homebrew-core/30d.json",
-  cask_docker:                              "cask/docker.json",
+  cask_docker_desktop:                      "cask/docker-desktop.json",
   formula_wget:                             "formula/wget.json",
   formula:                                  "formula/wget.json",
 }.freeze


### PR DESCRIPTION
Fixes broken site generation after the `docker` cask was renamed to `docker-desktop`
