### PR TITLE
Add `executables.txt` from `Homebrew/command-not-found` to internal API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,6 +177,12 @@ jobs:
           tar xvf data-cask/data-cask.tar.gz
           tar xvf data-core/data-core.tar.gz
 
+      - name: Install oras for pulling from GitHub Packages
+        run: brew install oras
+
+      - name: Pull executables.txt from GitHub Packages
+        run: oras pull ghcr.io/homebrew/command-not-found/executables:latest --output api/internal
+
       - name: Generate API samples
         run: |
           GENERATE_SAMPLES="${{ github.ref_name == 'main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.event.pull_request.user.login != 'dependabot[bot]') }}"


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-command-not-found/issues/246

This PR pulls the latest `executables.txt` file to be served at `https://formulae.brew.sh/api/internal/executables.txt` for future use by `brew which-formula`.

Although as I'm opening this I'm wondering: is serving this from formulae.brew.sh better than having users download directly from GitHub?
