### PR TITLE
Only cancel in-progress scheduled generation in pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: scheduled-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   generate-cask:


### PR DESCRIPTION
See https://github.com/Homebrew/formulae.brew.sh/issues/2000#issuecomment-3246601507

We don't want to cancel in-progress generation jobs for concurrency reasons. Instead, let the previous job finish and simply add the new job to a queue. This will reduce the frequency of generation failures if the generation job happens to take a long time.

Although it's worth noting, this will make it harder to catch issues that result in API generation taking an unusually long time.
