### PR TITLE
workflows/tests: clean runner before formula API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,8 @@ jobs:
           core: true
           cask: false
 
+      - run: brew test-bot --only-cleanup-before
+
       - run: brew generate-formula-api
         env:
           HOMEBREW_DEVELOPER: 1


### PR DESCRIPTION
Not sure yet if this actually works as expected. Mainly opening to discuss best way to handle:
- https://formulae.brew.sh/formula/openssl@1.1#default

The issue seems to be due to GitHub runners having a copy of removed formula in core tap:
- https://github.com/actions/runner-images/blob/main/images/macos/scripts/build/install-openssl.sh

I added `git clean -ffdx` similar to what **actions/checkout** does - https://github.com/actions/checkout?tab=readme-ov-file#usage
```
    # Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching
    # Default: true
    clean: ''
```
