### PR TITLE
Fix `deploy-issue` job not depending on internal API generation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,7 +295,7 @@ jobs:
 
   deploy-issue:
     name: Open/close deploy issues
-    needs: [generate-cask, generate-core, generate-analytics, build, deploy]
+    needs: [generate-cask, generate-core, generate-analytics, generate-internal, build, deploy]
     if: ${{ always() && github.ref_name == 'main' }}
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Follow up to <https://github.com/Homebrew/formulae.brew.sh/pull/2173>

I realized that I forgot to update the `deploy-issue` job to depend on the new `generate-internal` job, so the issues wouldn't be opened on failed internal API generation.
