### PR TITLE
Fix cask page rendering macOS requirements

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -69,8 +69,11 @@ permalink: :title
     {%- if c.depends_on.macos -%}
         {%- capture requirements -%}
             macOS {% for x in c.depends_on.macos -%}
-                {{ x.first | escape }} <strong>{{ c.depends_on.macos[x.first] | join: "</strong> / <strong>" }}</strong>
-                {%- unless forloop.last %} and {% endunless -%}
+                {%- assign versions = x.last | join: "" | strip -%}
+                {%- if versions.size > 0 -%}
+                    {{ x.first | escape }} <strong>{{ c.depends_on.macos[x.first] | join: "</strong> / <strong>" }}</strong>
+                    {%- unless forloop.last %} and {% endunless -%}
+                {%- endif -%}
             {%- endfor -%}
         {%- endcapture -%}
     {%- endif -%}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -68,13 +68,21 @@ permalink: :title
     {%- assign requirements = "" -%}
     {%- if c.depends_on.macos -%}
         {%- capture requirements -%}
-            macOS {% for x in c.depends_on.macos -%}
+            {%- assign macos_requirements = "" | split: "" -%}
+            {%- for x in c.depends_on.macos -%}
                 {%- assign versions = x.last | join: "" | strip -%}
                 {%- if versions.size > 0 -%}
-                    {{ x.first | escape }} <strong>{{ c.depends_on.macos[x.first] | join: "</strong> / <strong>" }}</strong>
-                    {%- unless forloop.last %} and {% endunless -%}
+                    {%- capture single_requirement -%}
+                        macOS {{ x.first | escape }} <strong>{{ x.last | join: "</strong> / <strong>" }}</strong>
+                    {%- endcapture -%}
+                    {%- assign macos_requirements = macos_requirements | push: single_requirement -%}
                 {%- endif -%}
             {%- endfor -%}
+            {%- if macos_requirements.size > 0 -%}
+                {{- macos_requirements | array_to_sentence_string -}}
+            {%- else -%}
+                macOS
+            {%- endif -%}
         {%- endcapture -%}
     {%- endif -%}
     {%- if c.depends_on.arch -%}


### PR DESCRIPTION
When a cask has macOS requirements without specific version numbers(with `depends_on :macos`), the page was rendering `Requirements: macOS >=` such as https://formulae.brew.sh/cask/zed. 
<img width="1090" height="960" alt="image" src="https://github.com/user-attachments/assets/a2a1b929-fc25-43ff-9391-9fa50198914a" />
This fix adds a check to only display the requirement if version information is present.
And, I think this is an issue with Brew, see https://github.com/Homebrew/brew/pull/22137.
```bash
$ curl -s https://formulae.brew.sh/api/cask/zed.json|jq .depends_on
{
  "macos": {
    ">=": [
      ""
    ]
  }
}
```