### PR TITLE
Gemfile: pin jekyll-remote-theme for Ruby 4.x.x compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "base64"
 gem "faraday-retry"
 gem "jekyll"
 gem "jekyll-redirect-from"
-gem "jekyll-remote-theme"
+gem "jekyll-remote-theme", "0.4.3" # 0.5.0 is incompatible with Ruby 4.x.x
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ DEPENDENCIES
   html-proofer
   jekyll
   jekyll-redirect-from
-  jekyll-remote-theme
+  jekyll-remote-theme (= 0.4.3)
   jekyll-seo-tag
   jekyll-sitemap
   mdl

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,1 @@
+../Gemfile.lock


### PR DESCRIPTION
`jekyll-remote-theme` had a new release for the first time since 2021. Ruby 4.0 ships the openssl `4.0.0` gem as its default, but the 0.5.0 release caps the openssl dependency at `~> 3.0`. That excludes `4.x` and forces the old openssl `3.x` line, which fails to load on Ruby 4.0, so the gem currently can't be installed on Ruby 4.0 at all. Pinning until my [upstream PR](https://github.com/benbalter/jekyll-remote-theme/pull/133) is addressed.