### PR TITLE
formula: render vulnerabilities from the API JSON

### DIFF
--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -263,7 +263,7 @@ permalink: :title
 </table>
 {%- endif -%}
 
-{%- if f.vulnerabilities.open.size > 0 %}
+{%- if f.vulnerabilities and f.vulnerabilities.open.size > 0 %}
 <p>Known vulnerabilities in the current version:</p>
 <table class="full-width">
     {%- for v in f.vulnerabilities.open -%}
@@ -280,7 +280,7 @@ permalink: :title
 <p><small>Data from <a href="https://github.com/Homebrew/advisory-database">Homebrew/advisory-database</a>. Run <code>brew vulns {{ f.name | escape }}</code> for a live check.</small></p>
 {%- endif -%}
 
-{%- if f.vulnerabilities.patched.size > 0 %}
+{%- if f.vulnerabilities and f.vulnerabilities.patched.size > 0 %}
 <p>Homebrew ships patches for:
     {%- for v in f.vulnerabilities.patched -%}
     {%- assign vid = v.upstream[0] | default: v.id %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -263,6 +263,33 @@ permalink: :title
 </table>
 {%- endif -%}
 
+{%- if f.vulnerabilities.open.size > 0 %}
+<p>Known vulnerabilities in the current version:</p>
+<table class="full-width">
+    {%- for v in f.vulnerabilities.open -%}
+    {%- assign vid = v.upstream[0] | default: v.id -%}
+    <tr>
+        <td>
+            <a rel="nofollow" href="https://osv.dev/vulnerability/{{ vid | uri_escape }}">{{ vid | escape }}</a>
+            {%- if v.severity %} ({{ v.severity | escape }}){%- endif -%}
+        </td>
+        <td>{{ v.summary | truncate: 100 | escape }}</td>
+    </tr>
+    {%- endfor %}
+</table>
+<p><small>Data from <a href="https://github.com/Homebrew/advisory-database">Homebrew/advisory-database</a>. Run <code>brew vulns {{ f.name | escape }}</code> for a live check.</small></p>
+{%- endif -%}
+
+{%- if f.vulnerabilities.patched.size > 0 %}
+<p>Homebrew ships patches for:
+    {%- for v in f.vulnerabilities.patched -%}
+    {%- assign vid = v.upstream[0] | default: v.id %}
+    <a rel="nofollow" href="https://osv.dev/vulnerability/{{ vid | uri_escape }}">{{ vid | escape }}</a>
+    {%- unless forloop.last -%}, {% endunless -%}
+    {%- endfor -%}.
+</p>
+{%- endif %}
+
 <p>Analytics:</p>
 <table>
 {%- for interval in site.analytics.intervals -%}


### PR DESCRIPTION
Shows a **Known vulnerabilities** table on the formula page when `_data/formula/<name>.json` carries `vulnerabilities.open`, and a **Homebrew ships patches for** line when `vulnerabilities.patched` is non-empty. Nothing is rendered for formulae without the field.

The field is populated by `brew generate-formula-api` from [Homebrew/advisory-database](https://github.com/Homebrew/advisory-database)'s `data/advisories.json` (Homebrew/brew#23341, Homebrew/advisory-database#30). Each entry links its first `upstream` id (or the `BREW-*` id when there is none) to `https://osv.dev/vulnerability/<id>` with severity and truncated summary.

Rendered output for a fixture with two open (one CVE-linked, one without) and one patched:

```html
<p>Known vulnerabilities in the current version:</p>
<table class="full-width"><tr>
    <td><a rel="nofollow" href="https://osv.dev/vulnerability/CVE-2024-1111">CVE-2024-1111</a> (high)</td>
    <td>Something bad</td>
</tr><tr>
    <td><a rel="nofollow" href="https://osv.dev/vulnerability/BREW-testvuln-CPANSA-X">BREW-testvuln-CPANSA-X</a></td>
    <td>No CVE</td>
</tr></table>
<p><small>Data from <a href="https://github.com/Homebrew/advisory-database">Homebrew/advisory-database</a>. Run <code>brew vulns testvuln</code> for a live check.</small></p>
<p>Homebrew ships patches for: <a rel="nofollow" href="https://osv.dev/vulnerability/CVE-2014-0001">CVE-2014-0001</a>.</p>
```

Safe to merge before Homebrew/brew#23341: the field is absent until that lands, so both blocks are skipped.