### PR TITLE
tests.yml: set up uv for formula-analytics

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,15 +155,8 @@ jobs:
           bundler-cache: true
           portable-ruby: true
 
-      - name: Get Python version file
-        id: get-python-version
-        run: |
-          echo "python-version-file=$(brew --repo)/Library/Homebrew/formula-analytics/.python-version" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version-file: ${{ steps.get-python-version.outputs.python-version-file }}
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Create directories
         run: mkdir -p _data/analytics api/analytics

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,8 +155,21 @@ jobs:
           bundler-cache: true
           portable-ruby: true
 
+      - name: Get formula analytics paths
+        id: formula-analytics
+        run: |
+          echo "directory=$(brew --repo)/Library/Homebrew/formula-analytics" >> "$GITHUB_OUTPUT"
+          echo "uv-cache-directory=${HOME}/.cache/uv" >> "$GITHUB_OUTPUT"
+
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          working-directory: ${{ steps.formula-analytics.outputs.directory }}
+          cache-local-path: ${{ steps.formula-analytics.outputs.uv-cache-directory }}
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+            .python-version
 
       - name: Create directories
         run: mkdir -p _data/analytics api/analytics


### PR DESCRIPTION
Needs https://github.com/Homebrew/brew/pull/23379

- `brew formula-analytics` now provisions Python and its virtualenv with `uv` from a `uv.lock`, so set up `uv` with the official action and drop `actions/setup-python` before `brew generate-analytics-api` runs.