### PR TITLE
Avoid per-row assign of formula/cask data hash in analytics layout

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -86,8 +86,7 @@ layout: base
                 <code>{{ item.test_bot_test | escape }}</code>
         {%- when "cask-install" -%}
             {%- assign data_token = item.cask | remove: "@" | remove: "." | replace: "+", "_" -%}
-            {%- assign cdata = site.data.cask[data_token] -%}
-            {%- if cdata and cdata.token == item.cask -%}
+            {%- if site.data.cask[data_token].token == item.cask -%}
                 <a href="{{ site.baseurl }}/cask/{{ item.cask | uri_escape }}"><code>{{ item.cask | escape }}</code></a>
             {%- else -%}
                 <code>{{ item.cask | escape }}</code>
@@ -95,8 +94,7 @@ layout: base
         {%- else -%}
             {%- assign fname = item.formula | split: " " | first -%}
             {%- assign data_fname = fname | remove: "@" | remove: "." | replace: "+", "_" -%}
-            {%- assign fdata = site.data.formula[data_fname] -%}
-            {%- if fdata and fdata.name == fname -%}
+            {%- if site.data.formula[data_fname].name == fname -%}
                 <a href="{{ site.baseurl }}/formula/{{ fname | uri_escape }}"><code>{{ item.formula | escape }}</code></a>
             {%- else -%}
                 <code>{{ item.formula | escape }}</code>


### PR DESCRIPTION
Liquid 4's `assign` calls `assign_score_of`, which recursively walks the assigned value to update resource-limit counters. Assigning a full formula/cask JSON hash (bottles, variations, checksums) once per analytics table row costs a few hundred method calls each, across ~270k rows on the install / install-on-request / build-error / cask-install pages.

Looking up `.name` / `.token` directly in the `if` avoids the assign. Rendered output is byte-identical; a nil lookup compares false so the missing-data guard is preserved.

`jekyll build --profile` with full CI data: `_layouts/analytics.html` ~26s → ~21s. The remaining time is Liquid iterating ~470k rows with a `case` per row.

Same root cause as the timeout fix in #2254.