### PR TITLE
Select analytics rows from any populated interval

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -215,8 +215,13 @@ permalink: :title
         <th class="number-data">{{ interval.name }}</th>
         {%- endfor -%}
     </tr>
-{%- assign first_interval = site.analytics.intervals | first -%}
-{%- assign variants = site.data.analytics.cask-install.homebrew-cask[first_interval.path].formulae[token] -%}
+{%- assign variants = nil -%}
+{%- for interval in site.analytics.intervals -%}
+    {%- assign interval_variants = site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token] -%}
+    {%- if interval_variants and interval_variants != empty -%}
+        {%- assign variants = interval_variants -%}
+    {%- endif -%}
+{%- endfor -%}
 {%- for variant in variants -%}
     <tr>
         <th>Installs

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -230,14 +230,14 @@ permalink: :title
         </th>
         {%- for interval in site.analytics.intervals -%}
             {%- assign match = site.data.analytics.cask-install.homebrew-cask[interval.path].formulae[token] | where: "cask", variant.cask | first -%}
-        <td class="number-data">{{ match.count | default: "0" }}</td>
+        <td class="number-data">{% if site.data.analytics.cask-install.homebrew-cask[interval.path].total_items %}{{ match.count | default: "0" }}{% endif %}</td>
         {%- endfor -%}
     </tr>
 {%- else -%}
     <tr>
         <th>Installs</th>
         {%- for interval in site.analytics.intervals -%}
-        <td class="number-data">0</td>
+        <td class="number-data">{% if site.data.analytics.cask-install.homebrew-cask[interval.path].total_items %}0{% endif %}</td>
         {%- endfor -%}
     </tr>
 {%- endfor %}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -298,9 +298,14 @@ permalink: :title
         <th class="number-data">{{ interval.name }}</th>
         {%- endfor -%}
     </tr>
-{%- assign first_interval = site.analytics.intervals | first -%}
 {%- for category in site.analytics.categories.formulae -%}
-    {%- assign variants = site.data.analytics[category.path].homebrew-core[first_interval.path].formulae[fname] -%}
+    {%- assign variants = nil -%}
+    {%- for interval in site.analytics.intervals -%}
+        {%- assign interval_variants = site.data.analytics[category.path].homebrew-core[interval.path].formulae[fname] -%}
+        {%- if interval_variants and interval_variants != empty -%}
+            {%- assign variants = interval_variants -%}
+        {%- endif -%}
+    {%- endfor -%}
     {%- for variant in variants -%}
     <tr>
         <th>{{ category.name }}


### PR DESCRIPTION
Cask and formula pages could show zero installs for every interval even though their JSON APIs had nonzero 90- and 365-day counts, reported in https://github.com/orgs/Homebrew/discussions/7007.

The analytics table rework in #2254 selected the displayed rows from the first configured interval, currently 30 days, and then looked each cell's count up in its own interval. A package with no 30-day row therefore fell through to the all-zero fallback, discarding the rows that longer intervals did have. `--HEAD` rows disappeared the same way whenever a formula had no 30-day `--HEAD` installs.

Selecting from the last interval instead would swap one hard-coded position for another and break build errors: `brew generate-analytics-api` writes only the 30-day file for tap-scoped build-error data, so `/api/analytics/build-error/homebrew-core/90d.json` and `365d.json` are 404 and every formula's Build Errors row would render `0`. This walks the intervals and keeps the last one that actually has rows for the package, which does not depend on interval order or on which intervals a given dataset happens to publish.

The second commit gives `cask.html` the `total_items` guard `formula.html` already had, so a cell with no dataset behind it renders blank rather than `0`. All three cask intervals are published today, so rendered output is unchanged; it matters when an interval is added to `_config.yml` before the generator publishes it, which is the situation the first commit now tolerates.
