### PR TITLE
Fix advisory data cache misses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,9 +172,6 @@ jobs:
           path: api/advisories.json
           key: ${{ steps.advisory-database.outputs.key }}
 
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: brew test-bot --only-cleanup-before
-
       - name: Generate advisory API data
         if: steps.cache.outputs.cache-hit != 'true'
         # Fail closed: never republish stale advisory data.


### PR DESCRIPTION
Cleanup removes the hosted runner's Homebrew-installed zstd after cache restore, so restore and save calculate different cache versions: later runs miss the existing key and cannot replace its gzip variant.