### PR TITLE
Stop bundling cask source files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           HOMEBREW_DEVELOPER: 1
 
       - name: Archive data
-        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask-source/ api/cask_tap_migrations.json api/internal/cask.* cask/
+        run: tar czvf data-cask.tar.gz _data/cask/ api/cask/ api/cask_tap_migrations.json api/internal/cask.* cask/
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ _data/
 _includes/api-samples/
 api/*_tap_migrations.json
 api/analytics/
-api/cask-source/
 api/cask/
 api/formula/
 api/internal/


### PR DESCRIPTION
Depends on https://github.com/Homebrew/brew/pull/23615

- `brew generate-cask-api` no longer writes `api/cask-source/*.rb` because brew never downloads cask source files any more: language variations and structured install steps are in the JSON API.
- Drop the directory from the cask data tarball and `.gitignore` so the workflow does not fail on a missing path.