### PR TITLE
Stop advertising Rosetta-only macOS versions as Intel

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,17 @@ taps:
     fullname: Homebrew/homebrew-cask
     remote: https://github.com/Homebrew/homebrew-cask
 
+# macOS versions that run on Intel hardware. Unprefixed cask platform tags
+# outside this list are Rosetta-only and should not be advertised.
+intel_macos_platforms:
+  - tahoe
+  - sequoia
+  - sonoma
+  - ventura
+  - monterey
+  - big_sur
+  - catalina
+
 analytics:
   intervals:
     - name: 30 days

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -106,12 +106,13 @@ permalink: :title
 </table>
 {%- endif %}
 
-{%- if c.variations.size > 0 and c.supported_platforms.size > 0 -%}
+{%- assign supported_platforms = c.supported_platforms | where_exp: "platform", "platform contains 'arm64_' or platform contains '_linux' or site.intel_macos_platforms contains platform" -%}
+{%- if c.variations.size > 0 and supported_platforms.size > 0 -%}
 
 {%- assign arm64_platform_count = 0 -%}
 {%- assign intel_platform_count = 0 -%}
 {%- assign linux_platform_count = 0 -%}
-{%- for platform in c.supported_platforms -%}
+{%- for platform in supported_platforms -%}
     {%- if platform contains "_linux" -%}
         {%- assign linux_platform_count = linux_platform_count | plus: 1 -%}
     {%- elsif platform contains "arm64_" -%}
@@ -126,7 +127,7 @@ permalink: :title
     {%- if arm64_platform_count > 0 %}
     <tbody>
     {%- assign subsequent = false -%}
-    {%- for platform in c.supported_platforms -%}
+    {%- for platform in supported_platforms -%}
         {%- if platform contains "arm64_" %}
             {%- if platform contains "_linux" -%}
                 {%- continue -%}
@@ -154,7 +155,7 @@ permalink: :title
     {%- if intel_platform_count > 0 %}
     <tbody>
     {%- assign subsequent = false -%}
-    {%- for platform in c.supported_platforms -%}
+    {%- for platform in supported_platforms -%}
         {%- unless platform contains "arm64_" %}
             {%- if platform contains "_linux" -%}
                 {%- continue -%}
@@ -182,7 +183,7 @@ permalink: :title
     {%- if linux_platform_count > 0 %}
     <tbody>
     {%- assign subsequent = false -%}
-    {%- for platform in c.supported_platforms -%}
+    {%- for platform in supported_platforms -%}
         {%- if platform contains "_linux" %}
         {%- assign variation = c.variations[platform] -%}
         <tr>

--- a/script/validate-build.rb
+++ b/script/validate-build.rb
@@ -2,10 +2,23 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "yaml"
 
 Dir.chdir Pathname(__dir__).parent
 
 error = false
+
+config = YAML.safe_load_file("_config.yml", permitted_classes: [Date, Symbol, Time], aliases: true)
+intel_macos_platforms = config["intel_macos_platforms"]
+valid_intel_macos_platforms = intel_macos_platforms.is_a?(Array) &&
+                              !intel_macos_platforms.empty? &&
+                              intel_macos_platforms.all?(String)
+unless valid_intel_macos_platforms
+  error = true
+  warn "_config.yml: intel_macos_platforms must be a non-empty list of platform names"
+  intel_macos_platforms = []
+end
+intel_macos_platform_labels = intel_macos_platforms.map { |platform| platform.tr("_", " ") }
 
 %w[
   _site/api/formula.json
@@ -25,6 +38,74 @@ Pathname("_site").find do |path|
 
   error = true
   warn "#{path}: bad file contents: '#{contents}'"
+end
+
+supported_platforms_table_regex = %r{
+  <p>Supported\ platforms:</p>\s*
+  <table\ class="full-width\ no-stack">(.*?)</table>
+}mx
+
+inspected_supported_platforms_tables = 0
+supported_platform_rowgroups = Hash.new(0)
+
+Pathname("_site/cask").glob("*.html").each do |path|
+  contents = path.read
+  table = contents[supported_platforms_table_regex, 1]
+  unless table
+    if contents.include?('scope="rowgroup"')
+      error = true
+      warn "#{path}: rowgroup markup exists but no supported platforms table matched"
+    end
+    next
+  end
+
+  inspected_supported_platforms_tables += 1
+  table.scan(%r{scope="rowgroup">([^<]*)</th>}).flatten.each do |label|
+    supported_platform_rowgroups[label] += 1
+  end
+
+  if table.scan("<tr>").empty?
+    error = true
+    warn "#{path}: supported platforms table has no rows"
+  end
+
+  table.scan(%r{<tbody>(.*?)</tbody>}m).flatten.each do |tbody|
+    row_count = tbody.scan("<tr>").count
+    rowspan = tbody[/<th rowspan="(\d+)" scope="rowgroup">/, 1]
+    if rowspan && rowspan.to_i != row_count
+      error = true
+      warn "#{path}: supported platforms rowspan #{rowspan} does not match #{row_count} rows"
+    end
+
+    next unless tbody.match?(%r{<th [^>]*>Intel</th>})
+
+    platform_labels = tbody.scan(%r{<td style="text-transform:capitalize;">\s*([^<]*?)\s*</td>}m)
+                           .flatten
+                           .map { |label| label.gsub("&nbsp;", " ").strip }
+    if platform_labels.count != row_count
+      error = true
+      warn "#{path}: could not inspect every Intel platform row"
+    end
+
+    platform_labels.each do |label|
+      next if intel_macos_platform_labels.include?(label)
+
+      error = true
+      warn "#{path}: #{label} is incorrectly advertised as an Intel platform"
+    end
+  end
+end
+
+if inspected_supported_platforms_tables.zero?
+  error = true
+  warn "_site/cask: no supported platforms table matched; the check is not running"
+end
+
+["Apple Silicon", "Intel", "Linux"].each do |rowgroup|
+  next unless supported_platform_rowgroups[rowgroup].zero?
+
+  error = true
+  warn "_site/cask: no page renders a #{rowgroup} rowgroup"
 end
 
 abort if error


### PR DESCRIPTION
Cask pages listed macOS 27 Golden Gate as an Intel platform, reported in https://github.com/orgs/Homebrew/discussions/7026.

Cask API data carries both `arm64_golden_gate` and an unprefixed `golden_gate`, the latter describing x86_64 installs through Rosetta. `cask.html` treated every unprefixed tag as an Intel platform, so pages advertised a macOS version that no Intel Mac runs, and general-purpose Rosetta support ends after macOS 27 anyway.

Filtering `golden_gate` by name would need editing again on every macOS release and would regress silently in between: the site rebuilds from freshly generated cask data every 15 minutes, so a new unprefixed tag reaches production without a commit. `_config.yml` instead lists the macOS versions that do run on Intel, and unprefixed tags outside it are dropped once, before the supported platforms table is counted and rendered, so future releases are hidden by default. Casks such as 1password now list Golden Gate only under Apple Silicon, and a cask whose only platform is Rosetta-only renders no table rather than an empty one. Apple Silicon, Linux and Intel through Tahoe are unchanged, and no generated API data is touched.

`script/validate-build.rb` only inspected JSON, so nothing checked the generated HTML. It now fails the build when the allowlist is missing or malformed, when no supported platforms table is inspected, when an architecture rowgroup stops being rendered, when rowgroup markup appears without the table selector matching, when a table is empty or a row cannot be inspected, when a `rowspan` disagrees with its row count, or when a platform outside the allowlist renders under Intel. Several of those exist so the check cannot pass vacuously after a later markup or configuration change.
