### PR TITLE
Scroll wide analytics tables within the content column

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -24,7 +24,7 @@ layout: base
 {%- endif %}
 
 <div style="overflow-x: auto; margin: 1em 0;" tabindex="0" role="region"
-     aria-label="{{ page.category_pretty }} events">
+     aria-label="{{ page.category_pretty | escape }} events">
 <table class="full-width" style="margin: 0;">
     <tr>
         <th></th>

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -23,7 +23,9 @@ layout: base
 </p>
 {%- endif %}
 
-<table class="full-width">
+<div style="overflow-x: auto; margin: 1em 0;" tabindex="0" role="region"
+     aria-label="{{ page.category_pretty }} events">
+<table class="full-width" style="margin: 0;">
     <tr>
         <th></th>
         <th>
@@ -112,3 +114,4 @@ layout: base
     </tr>
 {%- endfor %}
 </table>
+</div>


### PR DESCRIPTION
The environment configuration analytics table has eight columns and is wider than the site's centred content column, so it overflowed the document and horizontal scrolling dragged the header, search box and headings off-centre with it. Wrapping it in an `overflow-x: auto` container keeps the scrolling local to the table.

The wrapper carries `tabindex="0"` and a labelled `role="region"` because WebKit does not make overflowing scrollers focusable, which would otherwise leave the rightmost columns unreachable by keyboard in Safari. The 1em spacing sits on the wrapper rather than the table since `overflow-x: auto` establishes a block formatting context and would otherwise trap the table's margins.
