### PR TITLE
layout: use `bottles` CSS id for `Bottle` and `Supported platform` sections

### DIFF
--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -163,7 +163,7 @@ permalink: :title
 {%- endfor %}
 
 <p>Supported platforms:</p>
-<table class="full-width no-stack">
+<table class="full-width no-stack" id="bottles">
     {%- if arm64_platform_count > 0 %}
     <tbody>
     {%- assign subsequent = false -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -96,7 +96,9 @@ permalink: :title
             {%- assign intel_bottle_count = intel_bottle_count | plus: 1 -%}
         {%- endif -%}
     {%- endfor %}
-<table class="no-stack">
+<table class="no-stack" id="bottles">
+    {%- if arm64_bottle_count > 0 %}
+    <tbody>
     {%- assign subsequent = false -%}
     {%- for b in f.bottle.stable.files -%}
         {%- if b[0] contains "arm64_" %}
@@ -115,9 +117,10 @@ permalink: :title
         </tr>
         {%- endif -%}
     {%- endfor %}
-    {%- if arm64_bottle_count > 0 and intel_bottle_count > 0 %}
-    <tr><th colspan="3"></th></tr>
+    </tbody>
     {%- endif %}
+    {%- if intel_bottle_count > 0 %}
+    <tbody>
     {%- assign subsequent = false -%}
     {%- for b in f.bottle.stable.files -%}
         {%- unless b[0] contains "arm64_" %}
@@ -136,10 +139,10 @@ permalink: :title
         </tr>
         {%- endunless -%}
     {%- endfor -%}
-    {%- assign macos_bottle_count = arm64_bottle_count | plus: intel_bottle_count %}
-    {%- if macos_bottle_count > 0 and linux_bottle_count > 0 %}
-    <tr><th colspan="3"></th></tr>
+    </tbody>
     {%- endif %}
+    {%- if linux_bottle_count > 0 %}
+    <tbody>
     {%- assign subsequent = false -%}
     {%- for b in f.bottle.stable.files -%}
         {%- if b[0] contains "_linux" %}
@@ -155,6 +158,8 @@ permalink: :title
         </tr>
         {%- endif -%}
     {%- endfor -%}
+    </tbody>
+    {%- endif %}
 </table>
 {%- endif %}
 

--- a/script/validate-build.rb
+++ b/script/validate-build.rb
@@ -42,7 +42,7 @@ end
 
 supported_platforms_table_regex = %r{
   <p>Supported\ platforms:</p>\s*
-  <table\ class="full-width\ no-stack">(.*?)</table>
+  <table\ class="full-width\ no-stack"\ id="bottles">(.*?)</table>
 }mx
 
 inspected_supported_platforms_tables = 0


### PR DESCRIPTION
Add small border between `Supported platform` blocks, similar to how it works with formulae `Bottle` section.

Before:
<img width="689" height="605" alt="image" src="https://github.com/user-attachments/assets/82d61d56-73a3-4788-8fe1-854ade79937c" />

After:
<img width="692" height="605" alt="image" src="https://github.com/user-attachments/assets/5d4329c1-e524-461a-8ef4-a2e4e2967d2a" />

Closes https://github.com/orgs/Homebrew/discussions/7042